### PR TITLE
Add dotenv support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Tesla credentials
+TESLA_EMAIL=your_email@example.com
+TESLA_PASSWORD=your_password
+# Alternatively use an access token
+TESLA_ACCESS_TOKEN=

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+.env
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# Tesla Dashboard
+
+This is a simple Flask application that displays real-time data from a Tesla vehicle using the [teslapy](https://github.com/tdorssers/TeslaPy) library.
+
+## Setup
+
+1. Install dependencies:
+    ```bash
+    pip install -r requirements.txt
+    ```
+    The application uses `python-dotenv` to load variables from a `.env` file.
+
+2. Copy `.env.example` to `.env` and fill in your Tesla credentials:
+    - `TESLA_EMAIL` and `TESLA_PASSWORD` **or**
+    - `TESLA_ACCESS_TOKEN`
+
+3. Run the server:
+    ```bash
+    python app.py
+    ```
+
+4. Open `http://localhost:5000` in your browser.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,51 @@
+import os
+from flask import Flask, render_template, jsonify
+from dotenv import load_dotenv
+
+try:
+    import teslapy
+except ImportError:
+    teslapy = None
+
+load_dotenv()
+app = Flask(__name__)
+
+
+def get_vehicle_data():
+    """Fetch vehicle data using teslapy if available."""
+    if teslapy is None:
+        return {"error": "teslapy not installed"}
+
+    email = os.getenv("TESLA_EMAIL")
+    password = os.getenv("TESLA_PASSWORD")
+    token = os.getenv("TESLA_ACCESS_TOKEN")
+    if not token and not (email and password):
+        return {"error": "Missing Tesla credentials"}
+
+    with teslapy.Tesla(email) as tesla:
+        if token:
+            tesla.refresh_token({'access_token': token})
+        else:
+            tesla.fetch_token(password=password)
+
+        vehicles = tesla.vehicle_list()
+        if not vehicles:
+            return {"error": "No vehicles found"}
+        vehicle = vehicles[0]
+        vehicle_data = vehicle.get_vehicle_data()
+        return vehicle_data
+
+
+@app.route('/')
+def index():
+    return render_template('index.html')
+
+
+@app.route('/api/data')
+def api_data():
+    data = get_vehicle_data()
+    return jsonify(data)
+
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+flask
+teslapy
+python-dotenv

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -1,0 +1,8 @@
+function fetchData() {
+    $.getJSON('/api/data', function(data) {
+        $('#data').text(JSON.stringify(data, null, 2));
+    });
+}
+
+setInterval(fetchData, 5000);
+fetchData();

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Tesla Dashboard</title>
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+</head>
+<body>
+    <h1>Tesla Dashboard</h1>
+    <pre id="data">Loading...</pre>
+
+    <script src="/static/js/main.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- support `.env` files using python-dotenv
- document `.env` usage in README
- add sample `.env.example` file
- ignore `.env` via `.gitignore`

## Testing
- `python -m py_compile app.py`
- `pytest -q`
- `flake8`


------
https://chatgpt.com/codex/tasks/task_e_684961264f4c8321a890ddaa3d4b07d2