### PR TITLE
Add refresh token support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 # Tesla credentials
 TESLA_EMAIL=your_email@example.com
 TESLA_PASSWORD=your_password
-# Alternatively use an access token
+# Alternatively use access and refresh tokens
 TESLA_ACCESS_TOKEN=
+TESLA_REFRESH_TOKEN=

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This is a simple Flask application that displays real-time data from a Tesla veh
 
 2. Copy `.env.example` to `.env` and fill in your Tesla credentials:
     - `TESLA_EMAIL` and `TESLA_PASSWORD` **or**
-    - `TESLA_ACCESS_TOKEN`
+    - `TESLA_ACCESS_TOKEN` and `TESLA_REFRESH_TOKEN`
 
 3. Run the server:
     ```bash

--- a/app.py
+++ b/app.py
@@ -18,13 +18,19 @@ def get_vehicle_data():
 
     email = os.getenv("TESLA_EMAIL")
     password = os.getenv("TESLA_PASSWORD")
-    token = os.getenv("TESLA_ACCESS_TOKEN")
-    if not token and not (email and password):
+    access_token = os.getenv("TESLA_ACCESS_TOKEN")
+    refresh_token = os.getenv("TESLA_REFRESH_TOKEN")
+
+    tokens_provided = access_token and refresh_token
+    if not tokens_provided and not (email and password):
         return {"error": "Missing Tesla credentials"}
 
     with teslapy.Tesla(email) as tesla:
-        if token:
-            tesla.refresh_token({'access_token': token})
+        if tokens_provided:
+            tesla.sso_token = {"access_token": access_token, "refresh_token": refresh_token}
+            tesla.refresh_token()
+        elif access_token:
+            tesla.refresh_token({'access_token': access_token})
         else:
             tesla.fetch_token(password=password)
 


### PR DESCRIPTION
## Summary
- support new `TESLA_REFRESH_TOKEN` env var
- document both access and refresh tokens
- obtain new Owner API token using refresh token when provided

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6849653946408321892661381081f00b