### PR TITLE
Preserve map zoom on refresh

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -28,7 +28,8 @@ function fetchData() {
         var lng = data.drive_state && data.drive_state.longitude;
         if (lat && lng) {
             marker.setLatLng([lat, lng]);
-            map.setView([lat, lng], 13);
+            // Preserve the current zoom level when updating the map position
+            map.setView([lat, lng], map.getZoom());
         }
     });
 }


### PR DESCRIPTION
## Summary
- keep the current zoom level when updating the map position

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684973776e5083219dae9120487d9c5c