### PR TITLE
Fix parked timer using API timestamp

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -281,6 +281,8 @@ function updateUI(data) {
             var stored = localStorage.getItem('parkStart');
             if (stored) {
                 parkStart = parseInt(stored, 10);
+            } else if (drive.timestamp) {
+                parkStart = drive.timestamp;
             } else if (drive.gps_as_of) {
                 parkStart = drive.gps_as_of * 1000;
             } else {


### PR DESCRIPTION
## Summary
- keep track of when the car was parked
- set `parkStart` from `drive.timestamp` if available

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68498701cdd4832199163b2527707e8c