### PR TITLE
Show car heading on map

### DIFF
--- a/static/js/leaflet.rotatedMarker.js
+++ b/static/js/leaflet.rotatedMarker.js
@@ -1,0 +1,57 @@
+(function() {
+    // save these original methods before they are overwritten
+    var proto_initIcon = L.Marker.prototype._initIcon;
+    var proto_setPos = L.Marker.prototype._setPos;
+
+    var oldIE = (L.DomUtil.TRANSFORM === 'msTransform');
+
+    L.Marker.addInitHook(function () {
+        var iconOptions = this.options.icon && this.options.icon.options;
+        var iconAnchor = iconOptions && this.options.icon.options.iconAnchor;
+        if (iconAnchor) {
+            iconAnchor = (iconAnchor[0] + 'px ' + iconAnchor[1] + 'px');
+        }
+        this.options.rotationOrigin = this.options.rotationOrigin || iconAnchor || 'center bottom' ;
+        this.options.rotationAngle = this.options.rotationAngle || 0;
+
+        // Ensure marker keeps rotated during dragging
+        this.on('drag', function(e) { e.target._applyRotation(); });
+    });
+
+    L.Marker.include({
+        _initIcon: function() {
+            proto_initIcon.call(this);
+        },
+
+        _setPos: function (pos) {
+            proto_setPos.call(this, pos);
+            this._applyRotation();
+        },
+
+        _applyRotation: function () {
+            if(this.options.rotationAngle) {
+                this._icon.style[L.DomUtil.TRANSFORM+'Origin'] = this.options.rotationOrigin;
+
+                if(oldIE) {
+                    // for IE 9, use the 2D rotation
+                    this._icon.style[L.DomUtil.TRANSFORM] = 'rotate(' + this.options.rotationAngle + 'deg)';
+                } else {
+                    // for modern browsers, prefer the 3D accelerated version
+                    this._icon.style[L.DomUtil.TRANSFORM] += ' rotateZ(' + this.options.rotationAngle + 'deg)';
+                }
+            }
+        },
+
+        setRotationAngle: function(angle) {
+            this.options.rotationAngle = angle;
+            this.update();
+            return this;
+        },
+
+        setRotationOrigin: function(origin) {
+            this.options.rotationOrigin = origin;
+            this.update();
+            return this;
+        }
+    });
+})();

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -5,7 +5,18 @@ var map = L.map('map').setView([0, 0], 13);
 L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
     attribution: 'Kartendaten © OpenStreetMap-Mitwirkende'
 }).addTo(map);
-var marker = L.marker([0, 0]).addTo(map);
+
+var carIcon = L.icon({
+    iconUrl: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAUCAYAAAD/Rn+7AAAAnklEQVR4nO2VsRGAIAxFk5x7OIQUTMQS1i7BRBY4hJNooydEQZEiFLyKy4fwjjsAoNFoJMFbxbhNwOPCqsCJglBa7sGBYoEongvyAgDAPA6fe+lpSeZFvaxCqurkOMZt9D5LliZYSvWC3ZdJur/eznktv1M5/TB5i62KrzQuW+xPP+JfS1VYhXQOHsK3xbmb5eWHE/FCFXguFAvEYA47Io8vJd9/NZQAAAAASUVORK5CYII=',
+    iconSize: [40, 20],
+    iconAnchor: [20, 10]
+});
+
+var marker = L.marker([0, 0], {
+    icon: carIcon,
+    rotationAngle: 0,
+    rotationOrigin: 'center center'
+}).addTo(map);
 
 function fetchVehicles() {
     $.getJSON('/api/vehicles', function(vehicles) {
@@ -34,12 +45,16 @@ function fetchData() {
     if (!currentVehicle) return;
     $.getJSON('/api/data/' + currentVehicle, function(data) {
         updateUI(data);
-        var lat = data.drive_state && data.drive_state.latitude;
-        var lng = data.drive_state && data.drive_state.longitude;
+        var drive = data.drive_state || {};
+        var lat = drive.latitude;
+        var lng = drive.longitude;
         if (lat && lng) {
             marker.setLatLng([lat, lng]);
             // Preserve the current zoom level when updating the map position
             map.setView([lat, lng], map.getZoom());
+            if (typeof drive.heading === 'number') {
+                marker.setRotationAngle(drive.heading);
+            }
         }
     });
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -7,6 +7,7 @@
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
     <link rel="stylesheet" href="/static/css/style.css" />
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+    <script src="/static/js/leaflet.rotatedMarker.js"></script>
 </head>
 <body>
     <h1>Tesla Dashboard</h1>


### PR DESCRIPTION
## Summary
- add Leaflet rotated marker plugin
- display a small car icon on the map
- rotate car marker according to heading from API
- replace PNG with base64 data URI

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_684988a7ac58832190e41b1276596f34