### PR TITLE
Improve parked time display

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,4 @@
 import os
-import time
 from flask import Flask, render_template, jsonify
 from dotenv import load_dotenv
 
@@ -25,7 +24,7 @@ def track_park_time(vehicle_data):
         ts = int(ts * 1000)
     if shift in (None, 'P'):
         if park_start_ms is None or last_shift_state not in (None, 'P'):
-            park_start_ms = ts if ts else int(time.time() * 1000)
+            park_start_ms = int(ts) if ts is not None else None
     else:
         park_start_ms = None
     last_shift_state = shift

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -35,3 +35,9 @@
   height: 100%;
   background-color: #4caf50;
 }
+
+#park-since {
+  font-size: 1.2em;
+  font-weight: bold;
+  margin: 10px 0;
+}

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -68,7 +68,12 @@ function updateParkTime() {
     var diff = Date.now() - parkStart;
     var hours = Math.floor(diff / 3600000);
     var minutes = Math.floor((diff % 3600000) / 60000);
-    $('#park-time').text(hours + ' h ' + minutes + ' min');
+    var parts = [];
+    if (hours > 0) {
+        parts.push(hours + ' ' + (hours === 1 ? 'Stunde' : 'Stunden'));
+    }
+    parts.push(minutes + ' ' + (minutes === 1 ? 'Minute' : 'Minuten'));
+    $('#park-time').text(parts.join(' '));
 }
 
 function batteryBar(level) {
@@ -311,7 +316,7 @@ function updateUI(data) {
     }
     html += '<h2>' + status + '</h2>';
     if (status === 'Geparkt') {
-        html += '<p>Geparkt seit <span id="park-time"></span></p>';
+        html += '<p id="park-since">Geparkt seit <span id="park-time"></span></p>';
     }
     html += generateTable(simpleData(data));
     html += generateCategoryTables(categorizedData(data), status);


### PR DESCRIPTION
## Summary
- add a new style for parked time display
- rework `updateParkTime` to show German phrases
- display the parking status in a dedicated element
- rely on the API-provided timestamp when determining park start

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt`
- `python app.py` *(fails: Missing Tesla credentials)*


------
https://chatgpt.com/codex/tasks/task_e_6849999118508321abe565ef704fc289