### PR TITLE
Show vehicle name in header

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -20,6 +20,18 @@ var marker = L.marker([0, 0], {
     rotationOrigin: 'center center'
 }).addTo(map);
 
+function updateHeader(data) {
+    var info = '';
+    if (data && data.display_name) {
+        info = 'für ' + data.display_name;
+        var version = data.vehicle_state && data.vehicle_state.car_version;
+        if (version) {
+            info += ' (' + version + ')';
+        }
+    }
+    $('#vehicle-info').text(info);
+}
+
 function fetchVehicles() {
     $.getJSON('/api/vehicles', function(vehicles) {
         var $select = $('#vehicle-select');
@@ -46,6 +58,7 @@ function fetchVehicles() {
 function fetchData() {
     if (!currentVehicle) return;
     $.getJSON('/api/data/' + currentVehicle, function(data) {
+        updateHeader(data);
         updateUI(data);
         var drive = data.drive_state || {};
         var lat = drive.latitude;

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,7 +10,7 @@
     <script src="/static/js/leaflet.rotatedMarker.js"></script>
 </head>
 <body>
-    <h1>Tesla Dashboard</h1>
+    <h1>Tesla Dashboard <span id="vehicle-info"></span></h1>
     <label for="vehicle-select">Fahrzeug auswählen:</label>
     <select id="vehicle-select"></select>
     <div id="map" style="height: 400px; margin-top: 10px;"></div>


### PR DESCRIPTION
## Summary
- show selected vehicle name and version in the page header
- drop previous heading logic and update header when data is fetched

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6849c6f77b3c8321bad8578df1f55008