### PR TITLE
Add battery status module

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -125,6 +125,7 @@ var DESCRIPTIONS = {
     // Wichtige Felder mit fest hinterlegter Übersetzung
     'battery_level': 'Akkustand (%)',
     'battery_range': 'Reichweite (km)',
+    'est_battery_range': 'Restreichweite (km)',
     'odometer': 'Kilometerstand (km)',
     'outside_temp': 'Außen­temperatur (°C)',
     'inside_temp': 'Innenraum­temperatur (°C)',
@@ -396,6 +397,13 @@ function updateModules(data) {
 
     var climate = data.climate_state || {};
     $('#module-climate').html('<h3>Klima</h3>' + generateTable(climate));
+
+    var charge = data.charge_state || {};
+    var battery = {
+        battery_level: charge.battery_level,
+        est_battery_range: charge.est_battery_range != null ? (charge.est_battery_range * MILES_TO_KM).toFixed(1) : null
+    };
+    $('#module-battery').html('<h3>Batterie</h3>' + generateTable(battery));
 
     var vehicle = data.vehicle_state || {};
     var tires = {

--- a/templates/index.html
+++ b/templates/index.html
@@ -19,6 +19,7 @@
     <div id="modules">
         <div id="module-drive" class="module"></div>
         <div id="module-climate" class="module"></div>
+        <div id="module-battery" class="module"></div>
         <div id="module-tires" class="module"></div>
         <div id="module-media" class="module"></div>
     </div>


### PR DESCRIPTION
## Summary
- show battery status and range as dedicated module
- translate `est_battery_range` field

## Testing
- `python -m py_compile app.py`
- `node --check static/js/main.js`


------
https://chatgpt.com/codex/tasks/task_e_6849d5423a488321be3dedbedcea4c7b