### PR TITLE
Cache Tesla vehicle list

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -435,8 +435,30 @@ function startStream() {
     eventSource = new EventSource('/stream/' + currentVehicle);
     eventSource.onmessage = function(e) {
         var data = JSON.parse(e.data);
-        handleData(data);
+        if (data.error) {
+            $('#errors').text(data.error);
+        } else {
+            handleData(data);
+        }
     };
 }
 
+function fetchErrors() {
+    $.getJSON('/error', function(errs) {
+        if (!errs.length) {
+            $('#errors').text('');
+            return;
+        }
+        var html = '<h3>Fehler</h3><ul>';
+        errs.forEach(function(e) {
+            var d = new Date(e.timestamp * 1000);
+            html += '<li>' + d.toLocaleString() + ': ' + e.message + '</li>';
+        });
+        html += '</ul>';
+        $('#errors').html(html);
+    });
+}
+
 fetchVehicles();
+fetchErrors();
+setInterval(fetchErrors, 10000);

--- a/templates/index.html
+++ b/templates/index.html
@@ -23,6 +23,7 @@
         <div id="module-tires" class="module"></div>
         <div id="module-media" class="module"></div>
     </div>
+    <div id="errors" style="color:red;"></div>
 
     <script src="/static/js/main.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- cache vehicle list to reduce requests to Tesla API
- handle Tesla API failures and expose them via `/error`
- show API errors on the dashboard

## Testing
- `python -m py_compile app.py`
- `pip install -r requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_684a0b994bd0832194b3896a5092dcf6