### PR TITLE
Add API logging with rotating file

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ This is a simple Flask application that displays real-time data from a Tesla veh
 
 4. Open `http://localhost:8013` in your browser (the server listens on `0.0.0.0:8013`).
 
+API responses are logged to `data/api.log`. The log file uses rotation and will
+grow to at most 1&nbsp;MB.
+
 All required JavaScript and CSS libraries are bundled under `static/` so the dashboard works even without Internet access.
 
 The backend continuously polls the Tesla API and pushes new data to clients using Server-Sent Events (SSE).


### PR DESCRIPTION
## Summary
- record Tesla API calls in `data/api.log`
- add rotating file handler to keep API log under 1 MB
- mention API log in README

## Testing
- `python -m py_compile app.py`
- `python app.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684a1fcbc0e883218f3a31358302ed07