### PR TITLE
Implement offline cache for API data

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ This is a simple Flask application that displays real-time data from a Tesla veh
 
 API responses are logged to `data/api.log`. The log file uses rotation and will
 grow to at most 1&nbsp;MB.
+The latest successful API response is also stored in `data/cache_<vehicle_id>.json`
+so the dashboard can display the most recently fetched data if the Tesla API is
+temporarily unavailable.
 
 All required JavaScript and CSS libraries are bundled under `static/` so the dashboard works even without Internet access.
 


### PR DESCRIPTION
## Summary
- cache API responses on disk
- load cached data if new data cannot be fetched
- document data caching in README

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_684a2579112083219cc0a88a36499792