### PR TITLE
Add SSE cache fallback

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -451,6 +451,21 @@ function startStream() {
             handleData(data);
         }
     };
+    eventSource.onerror = function() {
+        $('#errors').text('Live-Daten konnten nicht geladen werden. Lade Cache.');
+        if (eventSource) {
+            eventSource.close();
+        }
+        var url = '/api/data';
+        if (currentVehicle) {
+            url += '/' + currentVehicle;
+        }
+        $.getJSON(url, function(data) {
+            if (data && !data.error) {
+                handleData(data);
+            }
+        });
+    };
 }
 
 function fetchErrors() {


### PR DESCRIPTION
## Summary
- if the SSE connection fails, load cached vehicle data using `/api/data`

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_684a8f7f31b083218434a1633cb28186