### PR TITLE
Add debug endpoint

### DIFF
--- a/app.py
+++ b/app.py
@@ -356,5 +356,30 @@ def get_errors():
         return jsonify(list(api_errors))
 
 
+@app.route('/debug')
+def debug_info():
+    """Display diagnostic information about the server."""
+    env_info = {
+        'teslapy_available': teslapy is not None,
+        'has_email': bool(os.getenv('TESLA_EMAIL')),
+        'has_password': bool(os.getenv('TESLA_PASSWORD')),
+        'has_access_token': bool(os.getenv('TESLA_ACCESS_TOKEN')),
+        'has_refresh_token': bool(os.getenv('TESLA_REFRESH_TOKEN')),
+    }
+
+    log_lines = []
+    try:
+        with open(os.path.join('data', 'api.log'), 'r', encoding='utf-8') as f:
+            log_lines = f.readlines()[-50:]
+    except Exception:
+        pass
+
+    with api_errors_lock:
+        errors = list(api_errors)
+
+    return render_template('debug.html', env_info=env_info, log_lines=log_lines,
+                          errors=errors, latest=latest_data)
+
+
 if __name__ == '__main__':
     app.run(host='0.0.0.0', port=8013, debug=True)

--- a/templates/debug.html
+++ b/templates/debug.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Debug Info</title>
+    <style>
+        body { font-family: sans-serif; padding: 20px; }
+        pre { background:#f0f0f0; padding:10px; overflow-x:auto; }
+    </style>
+</head>
+<body>
+    <h1>Debug Information</h1>
+    <h2>Environment</h2>
+    <ul>
+        <li>teslapy available: {{ env_info.teslapy_available }}</li>
+        <li>TESLA_EMAIL provided: {{ env_info.has_email }}</li>
+        <li>TESLA_PASSWORD provided: {{ env_info.has_password }}</li>
+        <li>TESLA_ACCESS_TOKEN provided: {{ env_info.has_access_token }}</li>
+        <li>TESLA_REFRESH_TOKEN provided: {{ env_info.has_refresh_token }}</li>
+    </ul>
+    <h2>Latest fetched data</h2>
+    <pre>{{ latest|tojson(indent=2) }}</pre>
+    <h2>API errors</h2>
+    <pre>{{ errors|tojson(indent=2) }}</pre>
+    <h2>Last log entries (api.log)</h2>
+    <pre>{{ log_lines|join('') }}</pre>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `/debug` endpoint to show diagnostic info
- include a simple template that lists environment indicators, recent API errors, and log lines

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile app.py`
- `python app.py >/tmp/server.log 2>&1 &`
- `curl -I http://localhost:8013/debug`

------
https://chatgpt.com/codex/tasks/task_e_684a9a3ad7048321a3c9e373ef42b14d