### PR TITLE
Add endpoints for map and data views

### DIFF
--- a/app.py
+++ b/app.py
@@ -289,6 +289,29 @@ def index():
     return render_template('index.html')
 
 
+@app.route('/map')
+def map_only():
+    """Display only the map without additional modules."""
+    return render_template('map.html')
+
+
+@app.route('/daten')
+def data_only():
+    """Display live or cached vehicle data without extra UI."""
+    _start_thread('default')
+    data = latest_data.get('default')
+    if data is None:
+        data = get_vehicle_data()
+        if isinstance(data, dict) and not data.get('error'):
+            _save_cached('default', data)
+        else:
+            cached = _load_cached('default')
+            if cached is not None:
+                data = cached
+        latest_data['default'] = data
+    return render_template('data.html', data=data)
+
+
 @app.route('/api/data')
 def api_data():
     _start_thread('default')

--- a/templates/data.html
+++ b/templates/data.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="de">
+<head>
+    <meta charset="utf-8">
+    <title>Tesla Daten</title>
+    <style>
+        body { font-family: sans-serif; padding: 20px; }
+        pre { background:#f0f0f0; padding:10px; overflow-x:auto; }
+    </style>
+</head>
+<body>
+    <pre>{{ data|tojson(indent=2) }}</pre>
+</body>
+</html>

--- a/templates/map.html
+++ b/templates/map.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="de">
+<head>
+    <meta charset="utf-8">
+    <title>Tesla Map</title>
+    <script src="/static/js/jquery.min.js"></script>
+    <link rel="stylesheet" href="/static/css/leaflet.css" />
+    <link rel="stylesheet" href="/static/css/style.css" />
+    <script src="/static/js/leaflet.js"></script>
+    <script src="/static/js/leaflet.rotatedMarker.js"></script>
+    <style>
+        html, body, #map {
+            height: 100%;
+            margin: 0;
+        }
+    </style>
+</head>
+<body>
+    <div id="map"></div>
+    <script src="/static/js/main.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `/map` endpoint that shows the map only
- add `/daten` endpoint to display live or cached data
- create a minimal page for `/daten`

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_684a9d0137288321984bbac295e4dfee