### PR TITLE
Update API list handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ While driving, a blue path is drawn on the map using the reported GPS positions.
 The `/history` page displays this last recorded trip on an interactive map.
 
 Data is streamed to the frontend via `/stream/<vehicle_id>` using Server-Sent Events so the dashboard updates instantly when new information arrives.
+The endpoint `/apiliste` exposes a text file listing all seen API variables and their latest values.
 
 ## Reference
 


### PR DESCRIPTION
## Summary
- store API values in api-liste.txt rather than just keys
- maintain the key order exactly as received from the API
- document the new `/apiliste` endpoint in README

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_684ab6f93fdc8321aa7e6a773803f25a