### PR TITLE
Display parking duration using park_start

### DIFF
--- a/app.py
+++ b/app.py
@@ -171,6 +171,20 @@ def track_park_time(vehicle_data):
     last_shift_state = shift
 
 
+def park_duration_string(start_ms):
+    """Return human readable parking duration for ``start_ms``."""
+    if start_ms is None:
+        return None
+    diff = int(time.time() * 1000) - start_ms
+    hours = diff // 3600000
+    minutes = (diff % 3600000) // 60000
+    parts = []
+    if hours > 0:
+        parts.append(f"{hours} {'Stunde' if hours == 1 else 'Stunden'}")
+    parts.append(f"{minutes} {'Minute' if minutes == 1 else 'Minuten'}")
+    return ' '.join(parts)
+
+
 def _log_trip_point(ts, lat, lon):
     """Append a GPS point to the trip history CSV."""
     try:
@@ -364,6 +378,7 @@ def get_vehicle_data(vehicle_id=None):
     sanitized = sanitize(vehicle_data)
     log_api_data('get_vehicle_data', sanitized)
     sanitized['park_start'] = park_start_ms
+    sanitized['park_since'] = park_duration_string(park_start_ms)
     sanitized['path'] = trip_path
     return sanitized
 

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -319,9 +319,10 @@ function updateUI(data) {
     var html = '';
     var status = getStatus(data);
     parkStart = data.park_start || null;
+    var parkSinceText = data.park_since || '';
     html += '<h2>' + status + '</h2>';
     if (status === 'Geparkt') {
-        html += '<p id="park-since">Geparkt seit <span id="park-time"></span></p>';
+        html += '<p id="park-since">Geparkt seit <span id="park-time">' + parkSinceText + '</span></p>';
     }
     // Only show status and parking duration, omit detailed tables
     $('#info').html(html);


### PR DESCRIPTION
## Summary
- compute human-readable parking duration on the backend
- expose `park_since` to clients and show it in UI

## Testing
- `python -m py_compile app.py`
- `node -c static/js/main.js`


------
https://chatgpt.com/codex/tasks/task_e_684abd470fb88321863fdaeefba6bda4