### PR TITLE
Remove redundant park_since value

### DIFF
--- a/app.py
+++ b/app.py
@@ -378,7 +378,6 @@ def get_vehicle_data(vehicle_id=None):
     sanitized = sanitize(vehicle_data)
     log_api_data('get_vehicle_data', sanitized)
     sanitized['park_start'] = park_start_ms
-    sanitized['park_since'] = park_duration_string(park_start_ms)
     sanitized['path'] = trip_path
     return sanitized
 

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -96,12 +96,11 @@ function handleData(data) {
     }
 }
 
-function updateParkTime() {
-    if (!parkStart) {
-        $('#park-time').text('?');
-        return;
+function formatParkDuration(start) {
+    if (!start) {
+        return '?';
     }
-    var diff = Date.now() - parkStart;
+    var diff = Date.now() - start;
     var hours = Math.floor(diff / 3600000);
     var minutes = Math.floor((diff % 3600000) / 60000);
     var parts = [];
@@ -109,7 +108,11 @@ function updateParkTime() {
         parts.push(hours + ' ' + (hours === 1 ? 'Stunde' : 'Stunden'));
     }
     parts.push(minutes + ' ' + (minutes === 1 ? 'Minute' : 'Minuten'));
-    $('#park-time').text(parts.join(' '));
+    return parts.join(' ');
+}
+
+function updateParkTime() {
+    $('#park-time').text(formatParkDuration(parkStart));
 }
 
 function batteryBar(level) {
@@ -319,7 +322,7 @@ function updateUI(data) {
     var html = '';
     var status = getStatus(data);
     parkStart = data.park_start || null;
-    var parkSinceText = data.park_since || '';
+    var parkSinceText = parkStart ? formatParkDuration(parkStart) : '';
     html += '<h2>' + status + '</h2>';
     if (status === 'Geparkt') {
         html += '<p id="park-since">Geparkt seit <span id="park-time">' + parkSinceText + '</span></p>';


### PR DESCRIPTION
## Summary
- drop park_since from API response
- compute parking duration on the client using park_start

## Testing
- `python -m py_compile app.py`
- `node --check static/js/main.js`


------
https://chatgpt.com/codex/tasks/task_e_684abfce1aa48321b212a14380a8041f