### PR TITLE
Add temperature-based coloring for thermometers

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -165,7 +165,16 @@ function updateThermometers(inside, outside) {
         var clamped = Math.max(MIN_TEMP, Math.min(MAX_TEMP, temp));
         var h = (clamped - MIN_TEMP) / range * 40;
         var y = 5 + 40 - h;
-        $('#' + prefix + '-level').attr('y', y).attr('height', h);
+        var color = '#d00';
+        if (temp < 15) {
+            color = '#06c';
+        } else if (temp < 25) {
+            color = '#4caf50';
+        } else if (temp < 30) {
+            color = '#ff9800';
+        }
+        $('#' + prefix + '-level').attr('y', y).attr('height', h).attr('fill', color);
+        $('#' + prefix + '-bulb').attr('fill', color);
         var label = isNaN(temp) ? '? °C' : temp.toFixed(1) + ' °C';
         $('#' + prefix + '-temp-value').text((prefix === 'inside' ? 'Innen: ' : 'Außen: ') + label);
     }

--- a/templates/index.html
+++ b/templates/index.html
@@ -34,7 +34,7 @@
             <svg width="30" height="60" viewBox="0 0 30 60">
                 <rect x="13" y="5" width="4" height="40" class="tube" />
                 <rect id="inside-level" x="13" y="45" width="4" height="0" class="level" />
-                <circle cx="15" cy="50" r="7" class="bulb" />
+                <circle id="inside-bulb" cx="15" cy="50" r="7" class="bulb" />
             </svg>
             <div id="inside-temp-value" class="label">Innen: -- °C</div>
         </div>
@@ -42,7 +42,7 @@
             <svg width="30" height="60" viewBox="0 0 30 60">
                 <rect x="13" y="5" width="4" height="40" class="tube" />
                 <rect id="outside-level" x="13" y="45" width="4" height="0" class="level" />
-                <circle cx="15" cy="50" r="7" class="bulb" />
+                <circle id="outside-bulb" cx="15" cy="50" r="7" class="bulb" />
             </svg>
             <div id="outside-temp-value" class="label">Außen: -- °C</div>
         </div>


### PR DESCRIPTION
## Summary
- color thermometer level and bulb according to temperature range
- add IDs for thermometer bulbs so they can be targeted from JS

## Testing
- `python -m compileall -q .`


------
https://chatgpt.com/codex/tasks/task_e_684ace3f0be883218aab2ae810b80108