### PR TITLE
Fix thermometer color update

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -173,8 +173,8 @@ function updateThermometers(inside, outside) {
         } else if (temp < 30) {
             color = '#ff9800';
         }
-        $('#' + prefix + '-level').attr('y', y).attr('height', h).attr('fill', color);
-        $('#' + prefix + '-bulb').attr('fill', color);
+        $('#' + prefix + '-level').attr('y', y).attr('height', h).css('fill', color);
+        $('#' + prefix + '-bulb').css('fill', color);
         var label = isNaN(temp) ? '? °C' : temp.toFixed(1) + ' °C';
         $('#' + prefix + '-temp-value').text((prefix === 'inside' ? 'Innen: ' : 'Außen: ') + label);
     }


### PR DESCRIPTION
## Summary
- ensure inline style sets thermometer fill color so CSS isn't overridden

## Testing
- `python -m py_compile app.py`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684acff1aa208321bbf80601c32932ae