### PR TITLE
Add Lade module

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -426,6 +426,8 @@ function updateModules(data) {
     };
     $('#module-battery').html('<h3>Batterie</h3>' + generateTable(battery));
 
+    $('#module-charge').html('<h3>Laden</h3>' + generateTable(charge));
+
     var vehicle = data.vehicle_state || {};
     var tires = {
         tpms_pressure_fl: vehicle.tpms_pressure_fl,

--- a/templates/index.html
+++ b/templates/index.html
@@ -53,6 +53,7 @@
         <div id="module-drive" class="module"></div>
         <div id="module-climate" class="module"></div>
         <div id="module-battery" class="module"></div>
+        <div id="module-charge" class="module"></div>
         <div id="module-tires" class="module"></div>
         <div id="module-media" class="module"></div>
         <div id="module-updates" class="module"></div>


### PR DESCRIPTION
## Summary
- display a new *Laden* module in the dashboard
- show all `charge_state` fields in the new module

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_684ad12e30a883219107e54b5872fae9