### PR TITLE
Add battery indicator with range

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -84,6 +84,20 @@
   color: white;
 }
 
+/* Battery indicator between gear shift and speedometer */
+#battery-indicator {
+  display: inline-block;
+  margin-left: 20px;
+  vertical-align: top;
+  text-align: center;
+  font-weight: bold;
+}
+
+#battery-indicator .range {
+  font-size: 0.9em;
+  margin-top: 2px;
+}
+
 /* Simple speedometer next to the gear shift */
 #speedometer {
   display: inline-block;

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -76,6 +76,8 @@ function handleData(data) {
     updateLockStatus(vehicle.locked);
     updateGearShift(drive.shift_state);
     updateSpeedometer(drive.speed, drive.power);
+    var charge = data.charge_state || {};
+    updateBatteryIndicator(charge.battery_level, charge.battery_range);
     var climate = data.climate_state || {};
     updateThermometers(climate.inside_temp, climate.outside_temp);
     var lat = drive.latitude;
@@ -180,6 +182,20 @@ function updateThermometers(inside, outside) {
     }
     set('inside', inside);
     set('outside', outside);
+}
+
+function updateBatteryIndicator(level, rangeMiles) {
+    var pct = level != null ? level : 0;
+    var color = '#4caf50';
+    if (pct < 20) {
+        color = '#f44336';
+    } else if (pct < 50) {
+        color = '#ffc107';
+    }
+    var range = rangeMiles != null ? Math.round(rangeMiles * MILES_TO_KM) : '?';
+    var html = '<div class="battery"><div class="level" style="width:' + pct + '%; background:' + color + '"></div></div> ' + pct + '%';
+    html += '<div class="range">' + range + ' km</div>';
+    $('#battery-indicator').html(html);
 }
 
 function batteryBar(level) {

--- a/templates/index.html
+++ b/templates/index.html
@@ -21,6 +21,7 @@
         <div data-gear="N">N</div>
         <div data-gear="D">D</div>
     </div>
+    <div id="battery-indicator"></div>
     <div id="speedometer">
         <svg width="120" height="60" viewBox="0 0 120 60">
             <path d="M10,50 A50,50 0 0,1 110,50" stroke="#ccc" stroke-width="8" fill="none"/>


### PR DESCRIPTION
## Summary
- add battery indicator UI and styling
- show charge level and remaining range in km

## Testing
- `flake8`
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_684ad29016a08321876f683ba0ca3f47