### PR TITLE
Improve battery indicator visualization

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -23,8 +23,8 @@
 }
 
 .battery {
-  width: 100px;
-  height: 10px;
+  width: 20px;
+  height: 60px;
   border: 1px solid #999;
   display: inline-block;
   margin-right: 5px;
@@ -32,8 +32,19 @@
 }
 
 .battery .level {
-  height: 100%;
-  background-color: #4caf50;
+  position: absolute;
+  bottom: 0;
+  width: 100%;
+  height: 0;
+  background: linear-gradient(
+    to top,
+    #f44336 0%,
+    #f44336 10%,
+    #ffc107 10%,
+    #ffc107 20%,
+    #4caf50 20%,
+    #4caf50 100%
+  );
 }
 
 #park-since {

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -186,27 +186,15 @@ function updateThermometers(inside, outside) {
 
 function updateBatteryIndicator(level, rangeMiles) {
     var pct = level != null ? level : 0;
-    var color = '#4caf50';
-    if (pct < 20) {
-        color = '#f44336';
-    } else if (pct < 50) {
-        color = '#ffc107';
-    }
     var range = rangeMiles != null ? Math.round(rangeMiles * MILES_TO_KM) : '?';
-    var html = '<div class="battery"><div class="level" style="width:' + pct + '%; background:' + color + '"></div></div> ' + pct + '%';
+    var html = '<div class="battery"><div class="level" style="height:' + pct + '%;"></div></div> ' + pct + '%';
     html += '<div class="range">' + range + ' km</div>';
     $('#battery-indicator').html(html);
 }
 
 function batteryBar(level) {
     var pct = level != null ? level : 0;
-    var color = '#4caf50';
-    if (pct < 20) {
-        color = '#f44336';
-    } else if (pct < 50) {
-        color = '#ffc107';
-    }
-    return '<div class="battery"><div class="level" style="width:' + pct + '%; background:' + color + '"></div></div> ' + pct + '%';
+    return '<div class="battery"><div class="level" style="height:' + pct + '%;'></div></div> ' + pct + '%';
 }
 
 function getStatus(data) {


### PR DESCRIPTION
## Summary
- redesign battery indicator to be vertical
- show red/yellow/green segments like a common battery icon
- update JS logic to use height instead of width

## Testing
- `python -m py_compile app.py`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684ad460c79c8321abdb8b03a34869d8