### PR TITLE
Fix syntax error preventing map display

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -194,7 +194,7 @@ function updateBatteryIndicator(level, rangeMiles) {
 
 function batteryBar(level) {
     var pct = level != null ? level : 0;
-    return '<div class="battery"><div class="level" style="height:' + pct + '%;'></div></div> ' + pct + '%';
+    return '<div class="battery"><div class="level" style="height:' + pct + '%;"></div></div> ' + pct + '%';
 }
 
 function getStatus(data) {


### PR DESCRIPTION
## Summary
- fix syntax error in `batteryBar` HTML string

## Testing
- `python -m py_compile app.py`
- `node -c static/js/main.js`

------
https://chatgpt.com/codex/tasks/task_e_684ad73f4a608321b63ec9306382f618