### PR TITLE
Improve battery indicator display

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -24,11 +24,21 @@
 
 .battery {
   width: 20px;
-  height: 60px;
+  height: 72px;
   border: 1px solid #999;
   display: inline-block;
   margin-right: 5px;
   position: relative;
+}
+
+.battery-block {
+  display: inline-block;
+  text-align: center;
+}
+
+.battery-value {
+  font-size: 0.9em;
+  margin-top: 2px;
 }
 
 .battery .level {
@@ -103,6 +113,7 @@
   text-align: center;
   font-weight: bold;
 }
+
 
 #battery-indicator .range {
   font-size: 0.9em;

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -187,14 +187,15 @@ function updateThermometers(inside, outside) {
 function updateBatteryIndicator(level, rangeMiles) {
     var pct = level != null ? level : 0;
     var range = rangeMiles != null ? Math.round(rangeMiles * MILES_TO_KM) : '?';
-    var html = '<div class="battery"><div class="level" style="height:' + pct + '%;"></div></div> ' + pct + '%';
+    var html = '<div class="battery"><div class="level" style="height:' + pct + '%;"></div></div>';
+    html += '<div class="battery-value">' + pct + '%</div>';
     html += '<div class="range">' + range + ' km</div>';
     $('#battery-indicator').html(html);
 }
 
 function batteryBar(level) {
     var pct = level != null ? level : 0;
-    return '<div class="battery"><div class="level" style="height:' + pct + '%;"></div></div> ' + pct + '%';
+    return '<div class="battery-block"><div class="battery"><div class="level" style="height:' + pct + '%;"></div></div><div class="battery-value">' + pct + '%</div></div>';
 }
 
 function getStatus(data) {


### PR DESCRIPTION
## Summary
- enlarge battery indicator to 72px height
- move battery percentage and range labels below the icon

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ada17b3f083219f6911a8f9909fc3