### PR TITLE
Add JSON snapshot of API list

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ The `/history` page displays this last recorded trip on an interactive map.
 
 Data is streamed to the frontend via `/stream/<vehicle_id>` using Server-Sent Events so the dashboard updates instantly when new information arrives.
 The endpoint `/apiliste` exposes a text file listing all seen API variables and their latest values.
+The same information is also stored as hierarchical JSON in `data/api-liste.json`.
 
 ## Reference
 


### PR DESCRIPTION
## Summary
- store hierarchical API data in `api-liste.json`
- mention the new JSON file in the README

## Testing
- `python -m py_compile app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684adb84ab6c8321b470807beb775478