### PR TITLE
Support per-trip history files

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ The backend continuously polls the Tesla API and pushes new data to clients usin
 
 The dashboard shows a short overview depending on whether the vehicle is parked, driving or charging. Below this, additional tables are grouped by category (battery/charging, climate, drive state, vehicle status and media information) to make the raw API data easier to read. While parked the dashboard also displays tire pressures, power usage of the drive unit and the 12V battery as well as how long the vehicle has been parked.
 
-While driving, a blue path is drawn on the map using the reported GPS positions. These points are also logged to `data/trip_history.csv` for later analysis.
-The `/history` page displays this last recorded trip on an interactive map.
+While driving, a blue path is drawn on the map using the reported GPS positions. Each trip is logged to its own CSV file under `data/trips` for later analysis.
+The `/history` page lists these files so previous trips can be selected and displayed on an interactive map.
 
 Data is streamed to the frontend via `/stream/<vehicle_id>` using Server-Sent Events so the dashboard updates instantly when new information arrives.
 The endpoint `/apiliste` exposes a text file listing all seen API variables and their latest values.

--- a/templates/history.html
+++ b/templates/history.html
@@ -2,7 +2,7 @@
 <html lang="de">
 <head>
     <meta charset="utf-8">
-    <title>Letzte Fahrt</title>
+    <title>Fahrtverlauf</title>
     <script src="/static/js/jquery.min.js"></script>
     <link rel="stylesheet" href="/static/css/leaflet.css" />
     <link rel="stylesheet" href="/static/css/style.css" />
@@ -16,6 +16,14 @@
     </style>
 </head>
 <body>
+    <form id="trip-form" method="get" style="position:absolute;top:10px;left:10px;z-index:1000;background:#fff;padding:5px;">
+        <label for="file">Fahrt auswählen:</label>
+        <select id="file" name="file" onchange="document.getElementById('trip-form').submit();">
+            {% for f in files %}
+            <option value="{{ f }}" {% if f == selected %}selected{% endif %}>{{ f }}</option>
+            {% endfor %}
+        </select>
+    </form>
     <div id="map"></div>
     <script>
         var tripPath = {{ path|tojson }};


### PR DESCRIPTION
## Summary
- create a new `data/trips` folder and write each drive path to its own CSV
- allow selection of past trips on `/history`
- update documentation accordingly

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_684adecf2f5c8321a098ac60cc168d28