### PR TITLE
Display errors only at dedicated route

### DIFF
--- a/app.py
+++ b/app.py
@@ -585,8 +585,21 @@ def api_vehicles():
 
 
 @app.route('/error')
-def get_errors():
-    """Return collected API errors."""
+def error_page():
+    """Display collected API errors."""
+    with api_errors_lock:
+        errors = list(api_errors)
+    for e in errors:
+        try:
+            e['time_str'] = time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(e['timestamp']))
+        except Exception:
+            e['time_str'] = str(e['timestamp'])
+    return render_template('errors.html', errors=errors)
+
+
+@app.route('/api/errors')
+def api_errors_route():
+    """Return collected API errors as JSON."""
     with api_errors_lock:
         return jsonify(list(api_errors))
 
@@ -620,11 +633,8 @@ def debug_info():
     except Exception:
         pass
 
-    with api_errors_lock:
-        errors = list(api_errors)
-
     return render_template('debug.html', env_info=env_info, log_lines=log_lines,
-                          errors=errors, latest=latest_data)
+                          latest=latest_data)
 
 
 if __name__ == '__main__':

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -46,7 +46,6 @@ function fetchVehicles() {
         var $label = $('label[for="vehicle-select"]');
         $select.empty();
         if (!vehicles.length) {
-            $('#errors').text(resp.error || 'Keine Fahrzeuge gefunden. Bitte Tesla-Zugangsdaten pr\xC3\xBCfen.');
             return;
         }
         vehicles.forEach(function(v) {
@@ -464,7 +463,6 @@ $('#vehicle-select').on('change', function() {
 
 function startStream() {
     if (!currentVehicle) {
-        $('#errors').text('Kein Fahrzeug ausgew\xC3\xA4hlt.');
         return;
     }
     if (eventSource) {
@@ -473,14 +471,11 @@ function startStream() {
     eventSource = new EventSource('/stream/' + currentVehicle);
     eventSource.onmessage = function(e) {
         var data = JSON.parse(e.data);
-        if (data.error) {
-            $('#errors').text(data.error);
-        } else {
+        if (!data.error) {
             handleData(data);
         }
     };
     eventSource.onerror = function() {
-        $('#errors').text('Live-Daten konnten nicht geladen werden. Lade Cache.');
         if (eventSource) {
             eventSource.close();
         }
@@ -498,22 +493,4 @@ function startStream() {
     };
 }
 
-function fetchErrors() {
-    $.getJSON('/error', function(errs) {
-        if (!errs.length) {
-            $('#errors').text('');
-            return;
-        }
-        var html = '<h3>Fehler</h3><ul>';
-        errs.forEach(function(e) {
-            var d = new Date(e.timestamp * 1000);
-            html += '<li>' + d.toLocaleString() + ': ' + e.message + '</li>';
-        });
-        html += '</ul>';
-        $('#errors').html(html);
-    });
-}
-
 fetchVehicles();
-fetchErrors();
-setInterval(fetchErrors, 10000);

--- a/templates/debug.html
+++ b/templates/debug.html
@@ -20,8 +20,6 @@
     </ul>
     <h2>Latest fetched data</h2>
     <pre>{{ latest|tojson(indent=2) }}</pre>
-    <h2>API errors</h2>
-    <pre>{{ errors|tojson(indent=2) }}</pre>
     <h2>Last log entries (api.log)</h2>
     <pre>{{ log_lines|join('') }}</pre>
 </body>

--- a/templates/errors.html
+++ b/templates/errors.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="de">
+<head>
+    <meta charset="utf-8">
+    <title>API Fehler</title>
+    <style>
+        body { font-family: sans-serif; padding: 20px; }
+    </style>
+</head>
+<body>
+    <h1>API Fehler</h1>
+    {% if errors %}
+    <ul>
+        {% for e in errors %}
+        <li>{{ e.time_str }}: {{ e.message }}</li>
+        {% endfor %}
+    </ul>
+    {% else %}
+    <p>Keine Fehler gespeichert.</p>
+    {% endif %}
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -59,8 +59,6 @@
         <div id="module-media" class="module"></div>
         <div id="module-updates" class="module"></div>
     </div>
-    <div id="errors" style="color:red;"></div>
-
     <script src="/static/js/main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- remove inline error display
- provide new `/error` page and add `/api/errors`
- clean up debug view

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_684b4af3dc6c8321bead38e670a7933c