### PR TITLE
Fix user presence icon coloring

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -160,7 +160,8 @@ function updateUserPresence(present) {
     } else {
         isPresent = !!present;
     }
-    $('#user-presence').text('\uD83D\uDC64');
+    // use text variant of the bust in silhouette emoji so color can be applied
+    $('#user-presence').text('\uD83D\uDC64\uFE0E');
     if (isPresent) {
         $('#user-presence').css('color', '#4caf50').attr('title', 'Person im Fahrzeug');
     } else {

--- a/templates/index.html
+++ b/templates/index.html
@@ -16,7 +16,7 @@
     <div id="map" style="height: 400px; margin-top: 10px;"></div>
     <div id="lock-container">
         <div id="lock-status" title="Verriegelt">🔒</div>
-        <div id="user-presence" title="Niemand im Fahrzeug">👤</div>
+        <div id="user-presence" title="Niemand im Fahrzeug">👤&#xFE0E;</div>
     </div>
     <div id="gear-shift">
         <div data-gear="P">P</div>


### PR DESCRIPTION
## Summary
- show user icon using monochrome variant in `index.html`
- update `main.js` to use colorable text variant

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_684b52077cfc83219cd121655f1439c4