### PR TITLE
Align icons with flex layout

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -78,19 +78,31 @@
   stroke-width: 1px;
 }
 
+/* Container for lock, gear, battery and temperature icons */
+#status-bar {
+  display: flex;
+  align-items: flex-start;
+  gap: 20px;
+  margin: 10px 0;
+}
+
+#status-bar > div {
+  margin: 0;
+}
+
 /* Simple automatic gear shift display */
 #gear-shift {
   display: inline-block;
   border: 2px solid #555;
   padding: 4px;
-  margin: 10px 0;
+  margin: 0;
   width: 30px;
   font-weight: bold;
 }
 
 #lock-container {
   display: inline-block;
-  margin: 10px 10px 10px 0;
+  margin: 0;
   text-align: center;
   vertical-align: top;
 }
@@ -117,7 +129,7 @@
 /* Battery indicator between gear shift and speedometer */
 #battery-indicator {
   display: inline-block;
-  margin-left: 20px;
+  margin: 0;
   vertical-align: top;
   text-align: center;
   font-weight: bold;
@@ -132,7 +144,7 @@
 /* Simple speedometer next to the gear shift */
 #speedometer {
   display: inline-block;
-  margin-left: 20px;
+  margin: 0;
   vertical-align: top;
   text-align: center;
   font-weight: bold;
@@ -150,7 +162,7 @@
 /* Thermometers for inside/outside temperature */
 #thermometers {
   display: inline-block;
-  margin-left: 20px;
+  margin: 0;
   vertical-align: top;
   text-align: center;
   font-weight: bold;

--- a/templates/index.html
+++ b/templates/index.html
@@ -14,41 +14,43 @@
     <label for="vehicle-select">Fahrzeug auswählen:</label>
     <select id="vehicle-select"></select>
     <div id="map" style="height: 400px; margin-top: 10px;"></div>
-    <div id="lock-container">
-        <div id="lock-status" title="Verriegelt">🔒</div>
-        <div id="user-presence" title="Niemand im Fahrzeug">👤&#xFE0E;</div>
-    </div>
-    <div id="gear-shift">
-        <div data-gear="P">P</div>
-        <div data-gear="R">R</div>
-        <div data-gear="N">N</div>
-        <div data-gear="D">D</div>
-    </div>
-    <div id="battery-indicator"></div>
-    <div id="speedometer">
-        <svg width="120" height="60" viewBox="0 0 120 60">
-            <path d="M10,50 A50,50 0 0,1 110,50" stroke="#ccc" stroke-width="8" fill="none"/>
-            <line id="speedometer-needle" x1="60" y1="50" x2="60" y2="15" stroke="#d00" stroke-width="3" transform="rotate(-90 60 50)" />
-        </svg>
-        <div id="speed-value">0 km/h</div>
-        <div id="power-value" class="power">0 kW</div>
-    </div>
-    <div id="thermometers">
-        <div class="thermometer">
-            <svg width="30" height="60" viewBox="0 0 30 60">
-                <rect x="13" y="5" width="4" height="40" class="tube" />
-                <rect id="inside-level" x="13" y="45" width="4" height="0" class="level" />
-                <circle id="inside-bulb" cx="15" cy="50" r="7" class="bulb" />
+    <div id="status-bar">
+        <div id="lock-container">
+            <div id="lock-status" title="Verriegelt">🔒</div>
+            <div id="user-presence" title="Niemand im Fahrzeug">👤&#xFE0E;</div>
+        </div>
+        <div id="gear-shift">
+            <div data-gear="P">P</div>
+            <div data-gear="R">R</div>
+            <div data-gear="N">N</div>
+            <div data-gear="D">D</div>
+        </div>
+        <div id="battery-indicator"></div>
+        <div id="speedometer">
+            <svg width="120" height="60" viewBox="0 0 120 60">
+                <path d="M10,50 A50,50 0 0,1 110,50" stroke="#ccc" stroke-width="8" fill="none"/>
+                <line id="speedometer-needle" x1="60" y1="50" x2="60" y2="15" stroke="#d00" stroke-width="3" transform="rotate(-90 60 50)" />
+            </svg>
+            <div id="speed-value">0 km/h</div>
+            <div id="power-value" class="power">0 kW</div>
+        </div>
+        <div id="thermometers">
+            <div class="thermometer">
+                <svg width="30" height="60" viewBox="0 0 30 60">
+                    <rect x="13" y="5" width="4" height="40" class="tube" />
+                    <rect id="inside-level" x="13" y="45" width="4" height="0" class="level" />
+                    <circle id="inside-bulb" cx="15" cy="50" r="7" class="bulb" />
             </svg>
             <div id="inside-temp-value" class="label">Innen: -- °C</div>
         </div>
         <div class="thermometer">
-            <svg width="30" height="60" viewBox="0 0 30 60">
-                <rect x="13" y="5" width="4" height="40" class="tube" />
-                <rect id="outside-level" x="13" y="45" width="4" height="0" class="level" />
-                <circle id="outside-bulb" cx="15" cy="50" r="7" class="bulb" />
-            </svg>
-            <div id="outside-temp-value" class="label">Außen: -- °C</div>
+                <svg width="30" height="60" viewBox="0 0 30 60">
+                    <rect x="13" y="5" width="4" height="40" class="tube" />
+                    <rect id="outside-level" x="13" y="45" width="4" height="0" class="level" />
+                    <circle id="outside-bulb" cx="15" cy="50" r="7" class="bulb" />
+                </svg>
+                <div id="outside-temp-value" class="label">Außen: -- °C</div>
+            </div>
         </div>
     </div>
     <div id="info"></div>


### PR DESCRIPTION
## Summary
- group lock, gear, battery, speed and temperature displays inside a new `status-bar` container
- apply flex layout and remove individual margins so icons sit on the same level

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_684b588887708321bb3be49514c50341