### PR TITLE
Add climate indicators to status bar

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -116,6 +116,18 @@
   color: red;
 }
 
+#climate-indicator {
+  display: inline-block;
+  margin: 0;
+  text-align: center;
+  vertical-align: top;
+}
+
+#climate-indicator div {
+  font-size: 34px;
+  display: block;
+}
+
 #gear-shift div {
   text-align: center;
   padding: 2px 0;

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -81,6 +81,8 @@ function handleData(data) {
     updateBatteryIndicator(charge.battery_level, charge.est_battery_range);
     var climate = data.climate_state || {};
     updateThermometers(climate.inside_temp, climate.outside_temp);
+    updateClimateStatus(climate.is_climate_on);
+    updateFanStatus(climate.fan_status);
     var lat = drive.latitude;
     var lng = drive.longitude;
     if (lat && lng) {
@@ -168,6 +170,34 @@ function updateUserPresence(present) {
     } else {
         $('#user-presence').css('color', '#d00').attr('title', 'Keine Person im Fahrzeug');
     }
+}
+
+function updateClimateStatus(on) {
+    if (on == null) {
+        $('#climate-status').text('').attr('title', '');
+        return;
+    }
+    var active = false;
+    if (typeof on === 'string') {
+        var norm = on.toLowerCase();
+        active = norm === 'true' || norm === '1';
+    } else {
+        active = !!on;
+    }
+    if (active) {
+        $('#climate-status').text('\u2744\uFE0F').attr('title', 'Klimaanlage an');
+    } else {
+        $('#climate-status').text('\uD83D\uDEAB').attr('title', 'Klimaanlage aus');
+    }
+}
+
+function updateFanStatus(speed) {
+    if (speed == null || isNaN(speed)) {
+        $('#fan-status').text('').attr('title', '');
+        return;
+    }
+    var val = Math.max(0, Math.min(11, Number(speed)));
+    $('#fan-status').text('\uD83C\uDF00 ' + val).attr('title', 'L\u00FCfterstufe ' + val);
 }
 
 var MAX_SPEED = 240;

--- a/templates/index.html
+++ b/templates/index.html
@@ -40,10 +40,10 @@
                     <rect x="13" y="5" width="4" height="40" class="tube" />
                     <rect id="inside-level" x="13" y="45" width="4" height="0" class="level" />
                     <circle id="inside-bulb" cx="15" cy="50" r="7" class="bulb" />
-            </svg>
-            <div id="inside-temp-value" class="label">Innen: -- °C</div>
-        </div>
-        <div class="thermometer">
+                </svg>
+                <div id="inside-temp-value" class="label">Innen: -- °C</div>
+            </div>
+            <div class="thermometer">
                 <svg width="30" height="60" viewBox="0 0 30 60">
                     <rect x="13" y="5" width="4" height="40" class="tube" />
                     <rect id="outside-level" x="13" y="45" width="4" height="0" class="level" />
@@ -51,6 +51,10 @@
                 </svg>
                 <div id="outside-temp-value" class="label">Außen: -- °C</div>
             </div>
+        </div>
+        <div id="climate-indicator">
+            <div id="climate-status" title="Klimaanlage aus">🚫</div>
+            <div id="fan-status" title="Lüfterstufe">🌀 0</div>
         </div>
     </div>
     <div id="info"></div>


### PR DESCRIPTION
## Summary
- show AC status and fan speed next to temperatures
- style new climate indicator container
- update JS to draw climate info from API

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `node --check static/js/main.js`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b5b542484832198e2719b168daeb9