### PR TITLE
Add climate keeper mode icon

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -128,6 +128,15 @@
   display: block;
 }
 
+#climate-status,
+#climate-mode {
+  display: inline-block;
+}
+
+#climate-mode {
+  margin-left: 4px;
+}
+
 #desired-temp {
   font-size: 0.9em;
   margin-top: 2px;

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -82,6 +82,7 @@ function handleData(data) {
     var climate = data.climate_state || {};
     updateThermometers(climate.inside_temp, climate.outside_temp);
     updateClimateStatus(climate.is_climate_on);
+    updateClimateMode(climate.climate_keeper_mode);
     updateFanStatus(climate.fan_status);
     updateDesiredTemp(climate.driver_temp_setting);
     var lat = drive.latitude;
@@ -199,6 +200,27 @@ function updateFanStatus(speed) {
     }
     var val = Math.max(0, Math.min(11, Number(speed)));
     $('#fan-status').text('\uD83C\uDF00 ' + val).attr('title', 'L\u00FCfterstufe ' + val);
+}
+
+function updateClimateMode(mode) {
+    var $el = $('#climate-mode');
+    if (!mode || mode === 'off') {
+        $el.text('').attr('title', '').hide();
+        return;
+    }
+    var icon = '';
+    var title = '';
+    if (mode === 'dog') {
+        icon = '\uD83D\uDC36';
+        title = 'Hundemodus';
+    } else if (mode === 'camp') {
+        icon = '\u26FA';
+        title = 'Camp-Modus';
+    } else {
+        $el.text('').attr('title', '').hide();
+        return;
+    }
+    $el.text(icon).attr('title', title).show();
 }
 
 function updateDesiredTemp(temp) {

--- a/templates/index.html
+++ b/templates/index.html
@@ -54,6 +54,7 @@
         </div>
         <div id="climate-indicator">
             <div id="climate-status" title="Klimaanlage aus">🚫</div>
+            <div id="climate-mode" title=""></div>
             <div id="fan-status" title="Lüfterstufe">🌀 0</div>
             <div id="desired-temp" title="Wunschtemperatur">🌡️ -- °C</div>
         </div>


### PR DESCRIPTION
## Summary
- display climate keeper mode in status bar
- hide climate mode when off and align status + mode icons inline

## Testing
- `python -m py_compile app.py`
- `npx eslint static/js/main.js` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_684b615e852483218d8d9e5bd9f6da23