### PR TITLE
Add cabin overheat protection indicator

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -133,11 +133,13 @@
 }
 
 #climate-status,
-#climate-mode {
+#climate-mode,
+#cabin-protection {
   display: inline-block;
 }
 
-#climate-mode {
+#climate-mode,
+#cabin-protection {
   margin-left: 4px;
 }
 

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -83,6 +83,7 @@ function handleData(data) {
     updateThermometers(climate.inside_temp, climate.outside_temp);
     updateClimateStatus(climate.is_climate_on);
     updateClimateMode(climate.climate_keeper_mode);
+    updateCabinProtection(climate.cabin_overheat_protection);
     updateFanStatus(climate.fan_status);
     updateDesiredTemp(climate.driver_temp_setting);
     var lat = drive.latitude;
@@ -221,6 +222,15 @@ function updateClimateMode(mode) {
         return;
     }
     $el.text(icon).attr('title', title).show();
+}
+
+function updateCabinProtection(value) {
+    var $el = $('#cabin-protection');
+    if (value === 'On') {
+        $el.text('\u2600\uFE0F').attr('title', 'Kabinenschutz aktiv').show();
+    } else {
+        $el.text('').attr('title', '').hide();
+    }
 }
 
 function updateDesiredTemp(temp) {

--- a/templates/index.html
+++ b/templates/index.html
@@ -55,6 +55,7 @@
         <div id="climate-indicator">
             <div id="climate-status" title="Klimaanlage aus">🚫</div>
             <div id="climate-mode" title=""></div>
+            <div id="cabin-protection" title=""></div>
             <div id="fan-status" title="Lüfterstufe">🌀 0</div>
             <div id="desired-temp" title="Wunschtemperatur">🌡️ -- °C</div>
         </div>


### PR DESCRIPTION
## Summary
- add a new element for cabin overheat protection in the main page
- style the icon next to the climate mode
- handle `cabin_overheat_protection` data in the frontend

## Testing
- `python -m py_compile app.py`
- `node --check static/js/main.js`


------
https://chatgpt.com/codex/tasks/task_e_684b662165c8832184a172bcb3dfdd90