### PR TITLE
Add automatic version number

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,17 @@ The `/history` page lists these files so previous trips can be selected and disp
 
 Data is streamed to the frontend via `/stream/<vehicle_id>` using Server-Sent Events so the dashboard updates instantly when new information arrives.
 The endpoint `/apiliste` exposes a text file listing all seen API variables and their latest values.
+
 The same information is also stored as hierarchical JSON in `data/api-liste.json`.
+
+## Version
+
+The dashboard reports its own version in the footer. The version string is derived
+from the number of Git commits so it increases automatically with every pull request.
+The footer also includes a copyright notice:
+```
+Dashboard Version 1.0.X - © <current year> Erik Schauer, do1ffe@darc.de
+```
 
 ## Reference
 

--- a/app.py
+++ b/app.py
@@ -7,6 +7,8 @@ import logging
 from logging.handlers import RotatingFileHandler
 from flask import Flask, render_template, jsonify, Response, request
 from dotenv import load_dotenv
+from version import get_version
+from datetime import datetime
 
 try:
     import teslapy
@@ -15,6 +17,8 @@ except ImportError:
 
 load_dotenv()
 app = Flask(__name__)
+__version__ = get_version()
+CURRENT_YEAR = datetime.now().year
 
 # Ensure data paths are relative to this file regardless of the
 # current working directory.  This allows running the application
@@ -483,7 +487,7 @@ def _start_thread(vehicle_id):
 
 @app.route('/')
 def index():
-    return render_template('index.html')
+    return render_template('index.html', version=__version__, year=CURRENT_YEAR)
 
 
 @app.route('/map')

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -310,3 +310,10 @@
     height: 50vh !important;
   }
 }
+
+.app-version {
+  text-align: center;
+  font-size: 0.8em;
+  margin-top: 10px;
+  color: #666;
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -74,6 +74,8 @@
     <div id="nav-bar"></div>
     <div id="media-player"></div>
 
+    <footer class="app-version">Dashboard Version {{ version }} - © {{ year }} Erik Schauer, do1ffe@darc.de</footer>
+
     <script src="/static/js/main.js"></script>
 </body>
 </html>

--- a/version.py
+++ b/version.py
@@ -1,0 +1,17 @@
+import os
+import subprocess
+
+
+def get_version():
+    """Return a version string based on the Git commit count."""
+    try:
+        root = os.path.dirname(os.path.abspath(__file__))
+        count = subprocess.check_output([
+            'git',
+            'rev-list',
+            '--count',
+            'HEAD'
+        ], cwd=root).decode().strip()
+        return f"1.0.{count}"
+    except Exception:
+        return "0.0.0"


### PR DESCRIPTION
## Summary
- calculate project version from commit count
- show version in the dashboard footer
- document automatic version handling
- include copyright notice in footer

## Testing
- `python -m py_compile app.py version.py`


------
https://chatgpt.com/codex/tasks/task_e_684b85e5ecc88321822eb0953884b228