### PR TITLE
Update README with endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,24 @@ The dashboard shows a short overview depending on whether the vehicle is parked,
 
 While driving, a blue path is drawn on the map using the reported GPS positions. Each trip is logged to its own CSV file under `data/trips` for later analysis.
 The `/history` page lists these files so previous trips can be selected and displayed on an interactive map.
+When multiple cars are available a drop-down menu lets you switch between vehicles.
+Below the navigation bar a small media player section shows details of the currently playing track if provided by the API.
 
 Data is streamed to the frontend via `/stream/<vehicle_id>` using Server-Sent Events so the dashboard updates instantly when new information arrives.
 The endpoint `/apiliste` exposes a text file listing all seen API variables and their latest values.
 
 The same information is also stored as hierarchical JSON in `data/api-liste.json`.
+
+## Endpoints
+
+* `/` – main dashboard with map and status information
+* `/map` – map-only view without additional details
+* `/daten` – vehicle data without the map
+* `/history` – select and display recorded trips
+* `/error` – show recent API errors (JSON via `/api/errors`)
+* `/debug` – display environment info and recent log lines
+* `/api/vehicles` – list available vehicles as JSON
+* `/stream/<vehicle_id>` – Server-Sent Events endpoint used by the frontend
 
 ## Version
 


### PR DESCRIPTION
## Summary
- document media player and vehicle selection
- list the available routes in a new section

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_684b887d31ec8321ac819230cc3fa500