### PR TITLE
Fix user presence icon color on mobile

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -189,7 +189,7 @@ function updateLockStatus(locked) {
 
 function updateUserPresence(present) {
     if (present == null) {
-        $('#user-presence').text('');
+        $('#user-presence').empty();
         return;
     }
     var isPresent = false;
@@ -199,8 +199,12 @@ function updateUserPresence(present) {
     } else {
         isPresent = !!present;
     }
-    // use text variant of the bust in silhouette emoji so color can be applied
-    $('#user-presence').text('\uD83D\uDC64\uFE0E');
+    var icon = '<svg width="30" height="30" viewBox="0 0 24 24" ' +
+               'fill="currentColor" aria-hidden="true">' +
+               '<circle cx="12" cy="7" r="5" />' +
+               '<path d="M2 22c0-5.5 4.5-10 10-10s10 4.5 10 10" />' +
+               '</svg>';
+    $('#user-presence').html(icon);
     if (isPresent) {
         $('#user-presence').css('color', '#4caf50').attr('title', 'Person im Fahrzeug');
     } else {

--- a/templates/index.html
+++ b/templates/index.html
@@ -18,7 +18,7 @@
     <div id="status-bar">
         <div id="lock-container">
             <div id="lock-status" title="Verriegelt">🔒</div>
-            <div id="user-presence" title="Niemand im Fahrzeug">👤&#xFE0E;</div>
+            <div id="user-presence" title="Niemand im Fahrzeug"></div>
         </div>
         <div id="gear-shift">
             <div data-gear="P">P</div>


### PR DESCRIPTION
## Summary
- replace text emoji with inline SVG icon in dashboard
- adjust JS to set icon via HTML and change color

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_684bdfbb662483219f524e83922ef5d0