### PR TITLE
Fix footer app name

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The dashboard reports its own version in the footer. The version string is deriv
 from the number of Git commits so it increases automatically with every pull request.
 The footer also includes a copyright notice:
 ```
-Dashboard Version 1.0.X - © <current year> Erik Schauer, do1ffe@darc.de
+Tesla-Dashboard Version 1.0.X - © <current year> Erik Schauer, do1ffe@darc.de
 ```
 
 ## Reference

--- a/templates/index.html
+++ b/templates/index.html
@@ -74,7 +74,7 @@
     <div id="nav-bar"></div>
     <div id="media-player"></div>
 
-    <footer class="app-version">Dashboard Version {{ version }} - © {{ year }} Erik Schauer, do1ffe@darc.de</footer>
+    <footer class="app-version">Tesla-Dashboard Version {{ version }} - © {{ year }} Erik Schauer, do1ffe@darc.de</footer>
 
     <script src="/static/js/main.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- mention the full application name in the footer
- update the example footer line in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684be1ebd1d08321a8797c446595d79c