### PR TITLE
Enable automatic page reload when version changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,12 +56,15 @@ The same information is also stored as hierarchical JSON in `data/api-liste.json
 * `/error` – show recent API errors (JSON via `/api/errors`)
 * `/debug` – display environment info and recent log lines
 * `/api/vehicles` – list available vehicles as JSON
+* `/api/version` – return the current dashboard version as JSON
 * `/stream/<vehicle_id>` – Server-Sent Events endpoint used by the frontend
 
 ## Version
 
 The dashboard reports its own version in the footer. The version string is derived
 from the number of Git commits so it increases automatically with every pull request.
+Clients periodically fetch `/api/version` and reload the page when the version changes
+so the browser always shows the latest release.
 The footer also includes a copyright notice:
 ```
 Tesla-Dashboard Version 1.0.X - © <current year> Erik Schauer, do1ffe@darc.de

--- a/app.py
+++ b/app.py
@@ -493,7 +493,7 @@ def index():
 @app.route('/map')
 def map_only():
     """Display only the map without additional modules."""
-    return render_template('map.html')
+    return render_template('map.html', version=__version__)
 
 
 @app.route('/history')
@@ -586,6 +586,12 @@ def stream_vehicle(vehicle_id='default'):
 def api_vehicles():
     vehicles = get_vehicle_list()
     return jsonify(vehicles)
+
+
+@app.route('/api/version')
+def api_version():
+    """Return the current application version."""
+    return jsonify({'version': __version__})
 
 
 @app.route('/error')

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -1,4 +1,5 @@
 var currentVehicle = null;
+var APP_VERSION = window.APP_VERSION || null;
 var MILES_TO_KM = 1.60934;
 // Default view if no coordinates are available
 var DEFAULT_POS = [51.4556, 7.0116];
@@ -509,3 +510,13 @@ function startStream() {
 }
 
 fetchVehicles();
+
+function checkAppVersion() {
+    $.getJSON('/api/version', function(resp) {
+        if (resp.version && APP_VERSION && resp.version !== APP_VERSION) {
+            location.reload(true);
+        }
+    });
+}
+
+setInterval(checkAppVersion, 60000);

--- a/templates/index.html
+++ b/templates/index.html
@@ -76,6 +76,9 @@
 
     <footer class="app-version">Tesla-Dashboard Version {{ version }} - © {{ year }} Erik Schauer, do1ffe@darc.de</footer>
 
+    <script>
+        window.APP_VERSION = "{{ version }}";
+    </script>
     <script src="/static/js/main.js"></script>
 </body>
 </html>

--- a/templates/map.html
+++ b/templates/map.html
@@ -18,6 +18,9 @@
 </head>
 <body>
     <div id="map"></div>
+    <script>
+        window.APP_VERSION = "{{ version }}";
+    </script>
     <script src="/static/js/main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- expose a new `/api/version` endpoint
- inject `APP_VERSION` into index and map templates
- reload the frontend when a new version is detected
- update README documentation

## Testing
- `python -m py_compile app.py version.py`

------
https://chatgpt.com/codex/tasks/task_e_684be2f8a6388321b91cbef24761a301