### PR TITLE
Add precise seconds to data age

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -316,4 +316,11 @@
   font-size: 0.8em;
   margin-top: 10px;
   color: #666;
+  position: relative;
+}
+
+.app-version #data-age {
+  position: absolute;
+  right: 10px;
+  bottom: 0;
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -74,7 +74,10 @@
     <div id="nav-bar"></div>
     <div id="media-player"></div>
 
-    <footer class="app-version">Tesla-Dashboard Version {{ version }} - © {{ year }} Erik Schauer, do1ffe@darc.de</footer>
+    <footer class="app-version">
+        <span>Tesla-Dashboard Version {{ version }} - © {{ year }} Erik Schauer, do1ffe@darc.de</span>
+        <span id="data-age"></span>
+    </footer>
 
     <script>
         window.APP_VERSION = "{{ version }}";


### PR DESCRIPTION
## Summary
- enhance data age indicator with seconds

## Testing
- `python -m py_compile app.py version.py`


------
https://chatgpt.com/codex/tasks/task_e_684be5f0e1c883218748e102ae1cf1fb