### PR TITLE
Use ideal battery range

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -100,7 +100,11 @@ function handleData(data) {
     updateNavBar(drive);
     updateSpeedometer(drive.speed, drive.power);
     var charge = data.charge_state || {};
-    updateBatteryIndicator(charge.battery_level, charge.est_battery_range);
+    var rangeMiles = charge.ideal_battery_range;
+    if (rangeMiles == null) {
+        rangeMiles = charge.est_battery_range;
+    }
+    updateBatteryIndicator(charge.battery_level, rangeMiles);
     var climate = data.climate_state || {};
     updateThermometers(climate.inside_temp, climate.outside_temp);
     updateClimateStatus(climate.is_climate_on);


### PR DESCRIPTION
## Summary
- prefer `charge_state.ideal_battery_range` when displaying remaining range

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_684caee2898c83218cc8ce2e00c09ddc