### PR TITLE
Add odometer readout below speedometer

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -229,6 +229,11 @@
   margin-top: 2px;
 }
 
+#speedometer .odometer {
+  font-size: 0.9em;
+  margin-top: 2px;
+}
+
 /* Thermometers for inside/outside temperature */
 #thermometers {
   display: inline-block;

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -99,6 +99,7 @@ function handleData(data) {
     updateGearShift(drive.shift_state);
     updateNavBar(drive);
     updateSpeedometer(drive.speed, drive.power);
+    updateOdometer(vehicle.odometer);
     var charge = data.charge_state || {};
     var rangeMiles = charge.ideal_battery_range;
     if (rangeMiles == null) {
@@ -326,6 +327,15 @@ function updateSpeedometer(speed, power) {
         text += ' (Rekuperation)';
     }
     $('#power-value').text(text);
+}
+
+function updateOdometer(value) {
+    if (value == null || isNaN(value)) {
+        $('#odometer-value').text('--');
+        return;
+    }
+    var km = Number(value) * MILES_TO_KM;
+    $('#odometer-value').text(km.toFixed(1));
 }
 
 function updateThermometers(inside, outside) {

--- a/templates/index.html
+++ b/templates/index.html
@@ -27,14 +27,15 @@
             <div data-gear="D">D</div>
         </div>
         <div id="battery-indicator"></div>
-        <div id="speedometer">
-            <svg width="120" height="60" viewBox="0 0 120 60">
-                <path d="M10,50 A50,50 0 0,1 110,50" stroke="#ccc" stroke-width="8" fill="none"/>
-                <line id="speedometer-needle" x1="60" y1="50" x2="60" y2="15" stroke="#d00" stroke-width="3" transform="rotate(-90 60 50)" />
-            </svg>
-            <div id="speed-value">0 km/h</div>
-            <div id="power-value" class="power">0 kW</div>
-        </div>
+            <div id="speedometer">
+                <svg width="120" height="60" viewBox="0 0 120 60">
+                    <path d="M10,50 A50,50 0 0,1 110,50" stroke="#ccc" stroke-width="8" fill="none"/>
+                    <line id="speedometer-needle" x1="60" y1="50" x2="60" y2="15" stroke="#d00" stroke-width="3" transform="rotate(-90 60 50)" />
+                </svg>
+                <div id="speed-value">0 km/h</div>
+                <div id="power-value" class="power">0 kW</div>
+                <div id="odometer-value" class="odometer">0.0</div>
+            </div>
         <div id="thermometers">
             <div class="thermometer">
                 <svg width="30" height="60" viewBox="0 0 30 60">


### PR DESCRIPTION
## Summary
- show odometer value underneath the speedometer
- style odometer like other speedometer labels
- update UI via new `updateOdometer` function

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684cb0850a34832199fd1e6e032c9751