### PR TITLE
Format odometer display

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -335,7 +335,10 @@ function updateOdometer(value) {
         return;
     }
     var km = Number(value) * MILES_TO_KM;
-    $('#odometer-value').text(km.toFixed(1));
+    var formatted = km
+        .toFixed(0)
+        .replace(/\B(?=(\d{3})+(?!\d))/g, '.');
+    $('#odometer-value').text(formatted + ' km');
 }
 
 function updateThermometers(inside, outside) {

--- a/templates/index.html
+++ b/templates/index.html
@@ -34,7 +34,7 @@
                 </svg>
                 <div id="speed-value">0 km/h</div>
                 <div id="power-value" class="power">0 kW</div>
-                <div id="odometer-value" class="odometer">0.0</div>
+                <div id="odometer-value" class="odometer">0 km</div>
             </div>
         <div id="thermometers">
             <div class="thermometer">


### PR DESCRIPTION
## Summary
- show `0 km` by default in the template
- format odometer value with thousand separators and no decimals

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684cb25266a483219e95b208e9c2ccfb