### PR TITLE
Anzeige von Ladeinfos

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -72,6 +72,7 @@
   margin: 0;
 }
 
+#charging-info,
 /* Navigation bar below the status bar */
 #nav-bar {
   margin: 5px 0 10px;
@@ -80,10 +81,13 @@
   border-radius: 5px;
 }
 
+#charging-info table,
 #nav-bar table {
   border-collapse: collapse;
 }
 
+#charging-info th,
+#charging-info td,
 #nav-bar th,
 #nav-bar td {
   border: 1px solid #ccc;
@@ -91,11 +95,13 @@
   text-align: left;
 }
 
+#charging-info th,
 #nav-bar th {
   white-space: nowrap;
   font-weight: normal;
 }
 
+#charging-info span.icon,
 #nav-bar span.icon {
   margin-right: 4px;
 }

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -106,6 +106,7 @@ function handleData(data) {
         rangeMiles = charge.est_battery_range;
     }
     updateBatteryIndicator(charge.battery_level, rangeMiles);
+    updateChargingInfo(charge);
     var climate = data.climate_state || {};
     updateThermometers(climate.inside_temp, climate.outside_temp);
     updateClimateStatus(climate.is_climate_on);
@@ -378,6 +379,47 @@ function updateBatteryIndicator(level, rangeMiles) {
 function batteryBar(level) {
     var pct = level != null ? level : 0;
     return '<div class="battery-block"><div class="battery"><div class="level" style="height:' + pct + '%;"></div></div><div class="battery-value">' + pct + '%</div></div>';
+}
+
+function updateChargingInfo(charge) {
+    var $info = $('#charging-info');
+    if (!charge || charge.charging_state !== 'Charging') {
+        $info.empty().hide();
+        return;
+    }
+
+    var rows = [];
+    if (charge.charging_state) {
+        rows.push('<tr><th>Status:</th><td>' + charge.charging_state + '</td></tr>');
+    }
+    if (charge.charge_energy_added != null) {
+        rows.push('<tr><th>Geladene Energie:</th><td>' + Number(charge.charge_energy_added).toFixed(2) + ' kWh</td></tr>');
+    }
+    if (charge.charger_actual_current != null) {
+        rows.push('<tr><th>Ladestrom:</th><td>' + Number(charge.charger_actual_current).toFixed(0) + ' A</td></tr>');
+    } else if (charge.charger_power != null) {
+        rows.push('<tr><th>Ladeleistung:</th><td>' + Number(charge.charger_power).toFixed(0) + ' kW</td></tr>');
+    }
+    if (charge.charger_voltage != null) {
+        rows.push('<tr><th>Spannung:</th><td>' + Number(charge.charger_voltage).toFixed(0) + ' V</td></tr>');
+    }
+    if (charge.conn_charge_cable) {
+        rows.push('<tr><th>Kabel:</th><td>' + charge.conn_charge_cable + '</td></tr>');
+    }
+    if (charge.fast_charger_brand) {
+        rows.push('<tr><th>Schnelllader Marke:</th><td>' + charge.fast_charger_brand + '</td></tr>');
+    }
+    if (charge.fast_charger_type) {
+        rows.push('<tr><th>Schnelllader Typ:</th><td>' + charge.fast_charger_type + '</td></tr>');
+    }
+    if (charge.minutes_to_full_charge != null) {
+        rows.push('<tr><th>Minuten bis voll:</th><td>' + Math.round(charge.minutes_to_full_charge) + ' min</td></tr>');
+    }
+    if (charge.time_to_full_charge != null) {
+        rows.push('<tr><th>Zeit bis voll:</th><td>' + Number(charge.time_to_full_charge).toFixed(2) + ' h</td></tr>');
+    }
+
+    $info.html('<table>' + rows.join('') + '</table>').show();
 }
 
 function updateNavBar(drive) {

--- a/templates/index.html
+++ b/templates/index.html
@@ -72,6 +72,7 @@
             </div>
         </div>
     </div>
+    <div id="charging-info"></div>
     <div id="nav-bar"></div>
     <div id="media-player"></div>
 


### PR DESCRIPTION
## Summary
- add a new `#charging-info` container above the navigation
- style charging info like the navigation table
- implement `updateChargingInfo` in the frontend and call it when new data arrives

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python app.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684cb468ac488321b5366bc6ae468712