### PR TITLE
Adjust Tesla polling interval

### DIFF
--- a/app.py
+++ b/app.py
@@ -459,7 +459,7 @@ def get_vehicle_list():
     return sanitized
 
 
-def _fetch_loop(vehicle_id, interval=5):
+def _fetch_loop(vehicle_id, interval=3):
     """Continuously fetch data for a vehicle and notify subscribers."""
     while True:
         vid = None if vehicle_id == 'default' else vehicle_id


### PR DESCRIPTION
## Summary
- tune `_fetch_loop` to use a 3‑second polling interval

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_684cb6c1969483218c50129151ce778f