### PR TITLE
Add interactive COP temperature endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ The same information is also stored as hierarchical JSON in `data/api-liste.json
 * `/history` – select and display recorded trips
 * `/error` – show recent API errors (JSON via `/api/errors`)
 * `/debug` – display environment info and recent log lines
+* `/cop` – set Cabin Overheat Protection temperature
 * `/api/vehicles` – list available vehicles as JSON
 * `/api/version` – return the current dashboard version as JSON
 * `/stream/<vehicle_id>` – Server-Sent Events endpoint used by the frontend

--- a/templates/cop.html
+++ b/templates/cop.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="de">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Cabin Overheat Protection</title>
+    <style>
+        body { font-family: sans-serif; padding: 20px; }
+        pre { background:#f0f0f0; padding:10px; overflow-x:auto; }
+    </style>
+</head>
+<body>
+    <h1>Cabin Overheat Protection</h1>
+    <form method="post">
+        <label for="temp">Temperatur (°C):</label>
+        <input type="number" step="0.1" id="temp" name="temp" required>
+        <button type="submit">Senden</button>
+    </form>
+    {% if result %}
+    <h2>Antwort:</h2>
+    <pre>{{ result|tojson(indent=2) }}</pre>
+    {% endif %}
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a simple HTML form at `/cop` for setting Cabin Overheat Protection temperature
- return JSON or render template based on request
- document the new endpoint

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_684cc5ad76f08321ab7636dd0184587f