### PR TITLE
Add tick marks to speedometer

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -312,7 +312,7 @@ function updateTPMS(fl, fr, rl, rr) {
     set('HR', rr);
 }
 
-var MAX_SPEED = 240;
+var MAX_SPEED = 250;
 var MIN_TEMP = -20;
 var MAX_TEMP = 50;
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -30,6 +30,20 @@
             <div id="speedometer">
                 <svg width="120" height="60" viewBox="0 0 120 60">
                     <path d="M10,50 A50,50 0 0,1 110,50" stroke="#ccc" stroke-width="8" fill="none"/>
+                    <g id="speedometer-ticks" stroke="#000" stroke-width="2">
+                        <!--30km/h-->
+                        <line x1="76.9" y1="7.2" x2="78.4" y2="3.5" />
+                        <!--50km/h-->
+                        <line x1="87.0" y1="12.8" x2="89.4" y2="9.5" />
+                        <!--100km/h-->
+                        <line x1="103.7" y1="35.8" x2="107.6" y2="34.5" />
+                        <!--150km/h-->
+                        <line x1="103.7" y1="64.2" x2="107.6" y2="65.5" />
+                        <!--200km/h-->
+                        <line x1="87.0" y1="87.2" x2="89.4" y2="90.5" />
+                        <!--250km/h-->
+                        <line x1="60.0" y1="96.0" x2="60.0" y2="100.0" />
+                    </g>
                     <line id="speedometer-needle" x1="60" y1="50" x2="60" y2="15" stroke="#d00" stroke-width="3" transform="rotate(-90 60 50)" />
                 </svg>
                 <div id="speed-value">0 km/h</div>


### PR DESCRIPTION
## Summary
- show tick marks on the dashboard speedometer
- extend speedometer range to 250 km/h

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684ccf9e95a88321bad0fef091227d68