### PR TITLE
Add authenticated dashboard config page

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -13,6 +13,15 @@ L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
 var polyline = null;
 var lastDataTimestamp = null;
 
+function applyConfig(cfg) {
+    if (!cfg) return;
+    Object.keys(cfg).forEach(function(id) {
+        if (!cfg[id]) {
+            $('#' + id).hide();
+        }
+    });
+}
+
 // Marker and polyline for active navigation destination
 var flagIcon = L.divIcon({
     html: [
@@ -604,7 +613,10 @@ function startStream() {
     };
 }
 
-fetchVehicles();
+$.getJSON('/api/config', function(cfg) {
+    applyConfig(cfg);
+    fetchVehicles();
+});
 
 function checkAppVersion() {
     $.getJSON('/api/version', function(resp) {

--- a/templates/config.html
+++ b/templates/config.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="de">
+<head>
+    <meta charset="utf-8">
+    <title>Dashboard Konfiguration</title>
+    <link rel="stylesheet" href="/static/css/style.css" />
+</head>
+<body>
+    <h1>Dashboard Konfiguration</h1>
+    <form method="post">
+        {% for item in items %}
+        <div>
+            <label>
+                <input type="checkbox" name="{{ item.id }}" value="1" {% if config.get(item.id, True) %}checked{% endif %}>
+                {{ item.desc }}
+            </label>
+        </div>
+        {% endfor %}
+        <button type="submit">Speichern</button>
+    </form>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add config JSON storage and load/save helpers
- secure `/config` with basic auth using Tesla credentials
- add `/api/config` endpoint
- implement config template with checkboxes
- hide dashboard elements based on config in JS

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_684df56dd52083218c94cc40b432b1fe