### PR TITLE
Add door, window and trunk indicator

### DIFF
--- a/app.py
+++ b/app.py
@@ -207,6 +207,7 @@ CONFIG_ITEMS = [
     {'id': 'thermometers', 'desc': 'Temperaturen'},
     {'id': 'climate-indicator', 'desc': 'Klimaanlage'},
     {'id': 'tpms-indicator', 'desc': 'Reifendruck'},
+    {'id': 'openings-indicator', 'desc': 'Türen/Fenster'},
     {'id': 'charging-info', 'desc': 'Ladeinformationen'},
     {'id': 'nav-bar', 'desc': 'Navigationsleiste'},
     {'id': 'media-player', 'desc': 'Medienwiedergabe'},

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -394,6 +394,31 @@ select {
   }
 }
 
+#openings-indicator {
+  display: inline-block;
+  margin: 0;
+  vertical-align: top;
+  text-align: left;
+  font-weight: bold;
+}
+
+#openings-indicator table {
+  border-collapse: collapse;
+}
+
+#openings-indicator th,
+#openings-indicator td {
+  padding: 2px 4px;
+}
+
+#openings-indicator .status-open {
+  color: #4caf50;
+}
+
+#openings-indicator .status-closed {
+  color: #d32f2f;
+}
+
 .app-version {
   text-align: center;
   font-size: 0.8em;

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -133,6 +133,7 @@ function handleData(data) {
                vehicle.tpms_pressure_fr,
                vehicle.tpms_pressure_rl,
                vehicle.tpms_pressure_rr);
+    updateOpenings(vehicle);
     updateMediaPlayer(vehicle.media_info);
     var lat = drive.latitude;
     var lng = drive.longitude;
@@ -325,6 +326,43 @@ function updateTPMS(fl, fr, rl, rr) {
     set('VR', fr);
     set('HL', rl);
     set('HR', rr);
+}
+
+function updateOpenings(vehicle) {
+    var entries = [
+        {key: 'df', label: 'T\u00FCr VL'},
+        {key: 'dr', label: 'T\u00FCr HL'},
+        {key: 'pf', label: 'T\u00FCr VR'},
+        {key: 'pr', label: 'T\u00FCr HR'},
+        {key: 'fd_window', label: 'Fenster VL'},
+        {key: 'rd_window', label: 'Fenster HL'},
+        {key: 'fp_window', label: 'Fenster VR'},
+        {key: 'rp_window', label: 'Fenster HR'},
+        {key: 'ft', label: 'Frunk'},
+        {key: 'rt', label: 'Kofferraum'}
+    ];
+
+    var rows = [];
+    entries.forEach(function(e) {
+        if (vehicle[e.key] == null) return;
+        var val = Number(vehicle[e.key]);
+        var open = val === 1;
+        var cls = open ? 'status-open' : 'status-closed';
+        var text = open ? 'Offen' : 'Zu';
+        rows.push('<tr><th>' + e.label + ':</th><td class="' + cls + '">' + text + '</td></tr>');
+    });
+
+    var srPct = vehicle.sun_roof_percent_open;
+    var srState = vehicle.sun_roof_state;
+    if (srPct != null || srState) {
+        var pctStr = srPct != null && !isNaN(srPct) ? Math.round(Number(srPct)) + '%' : '';
+        var open = srState && srState.toLowerCase() !== 'closed' && Number(srPct) > 0;
+        var cls = open ? 'status-open' : 'status-closed';
+        var text = (srState || '') + (pctStr ? ' (' + pctStr + ')' : '');
+        rows.push('<tr><th>Schiebedach:</th><td class="' + cls + '">' + text + '</td></tr>');
+    }
+
+    $('#openings-indicator').html('<table>' + rows.join('') + '</table>');
 }
 
 var MAX_SPEED = 250;

--- a/templates/index.html
+++ b/templates/index.html
@@ -85,6 +85,7 @@
                 <div id="tpms-HR" class="tpms-tire" title="Hinten rechts">--</div>
             </div>
         </div>
+        <div id="openings-indicator"></div>
     </div>
     <div id="charging-info"></div>
     <div id="nav-bar"></div>


### PR DESCRIPTION
## Summary
- add new openings indicator to show door/window/trunk/sunroof states
- support toggling the indicator via config
- render indicator on dashboard and style it

## Testing
- `python -m py_compile app.py version.py`

------
https://chatgpt.com/codex/tasks/task_e_684dfc587c648321ad17be2a41e5bd6c