### PR TITLE
Rotate car orientation in openings indicator

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -391,6 +391,8 @@ select {
 #openings-indicator svg {
   width: 100px;
   height: 200px;
+  transform: rotate(180deg);
+  transform-origin: center;
 }
 
 #openings-indicator .part-open {


### PR DESCRIPTION
## Summary
- rotate the car SVG in the openings indicator so the front points up

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e0406df3483218ce788cee23c9b3f