### PR TITLE
Improve Tesla look on openings indicator

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -77,17 +77,24 @@
         </div>
         <div id="openings-indicator">
             <svg viewBox="0 0 100 200">
-                <rect id="car-body" class="car-body" x="20" y="10" width="60" height="180" rx="10"/>
-                <rect id="frunk" class="part-closed" x="30" y="15" width="40" height="20"/>
-                <rect id="trunk" class="part-closed" x="30" y="165" width="40" height="20"/>
+                <path id="car-body" class="car-body"
+                      d="M20 20 Q30 10 50 10 Q70 10 80 20 V180 Q70 190 50 190 Q30 190 20 180 Z"/>
+                <path id="frunk" class="part-closed"
+                      d="M30 25 L50 15 L70 25 V35 H30 Z"/>
+                <path id="trunk" class="part-closed"
+                      d="M30 165 H70 V175 L50 185 L30 175 Z"/>
                 <rect id="door-fl" class="part-closed" x="20" y="40" width="10" height="45"/>
                 <rect id="door-fr" class="part-closed" x="70" y="40" width="10" height="45"/>
                 <rect id="door-rl" class="part-closed" x="20" y="95" width="10" height="45"/>
                 <rect id="door-rr" class="part-closed" x="70" y="95" width="10" height="45"/>
-                <rect id="window-fl" class="part-closed" x="30" y="40" width="20" height="20"/>
-                <rect id="window-fr" class="part-closed" x="50" y="40" width="20" height="20"/>
-                <rect id="window-rl" class="part-closed" x="30" y="95" width="20" height="20"/>
-                <rect id="window-rr" class="part-closed" x="50" y="95" width="20" height="20"/>
+                <path id="window-fl" class="part-closed"
+                      d="M30 60 V45 L45 35 H50 V60 Z"/>
+                <path id="window-fr" class="part-closed"
+                      d="M50 60 V35 H55 L70 45 V60 Z"/>
+                <path id="window-rl" class="part-closed"
+                      d="M30 115 V100 L45 90 H50 V115 Z"/>
+                <path id="window-rr" class="part-closed"
+                      d="M50 115 V90 H55 L70 100 V115 Z"/>
                 <rect id="sunroof" class="part-closed" x="30" y="120" width="40" height="30"/>
                 <g id="tpms-VL" class="tpms-tire" title="Vorne links">
                     <circle cx="20" cy="35" r="8" />


### PR DESCRIPTION
## Summary
- adjust the car drawing inside the `openings-indicator` to better match Tesla styling

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_684e05171d2c8321ae3e57f5015919d1