### PR TITLE
Fix TPMS text orientation

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -362,6 +362,8 @@ select {
   font-size: 8px;
   text-anchor: middle;
   dominant-baseline: central;
+  transform: rotate(180deg);
+  transform-origin: center;
 }
 
 /* Responsive adjustments */


### PR DESCRIPTION
## Summary
- rotate the TPMS pressure text so it shows upright

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- *(fail: flask missing for running `app.py`)*

------
https://chatgpt.com/codex/tasks/task_e_684e06fe13148321b64cbc5cf3680969