### PR TITLE
Fix TPMS text placement

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -362,6 +362,8 @@ select {
   font-size: 8px;
   text-anchor: middle;
   dominant-baseline: central;
+  /* ensure rotation uses the text's own bounding box */
+  transform-box: fill-box;
   transform: rotate(180deg);
   transform-origin: center;
 }


### PR DESCRIPTION
## Summary
- adjust TPMS text rotation so it centers inside the tire circles

## Testing
- `python -m py_compile app.py version.py`
- `pip install -r requirements.txt`
- `python app.py` *(fails: server stops after start)*

------
https://chatgpt.com/codex/tasks/task_e_684e0893f8cc8321abd7d966a59093c7