### PR TITLE
Fix openings indicator logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,8 @@ Tesla-Dashboard Version 1.0.X - © <current year> Erik Schauer, do1ffe@darc.de
 ## Reference
 
 For a sample API response from Tesla, see [docs/sample_api_response.json](docs/sample_api_response.json).
+
+The API reports doors, windows, trunk and frunk using numeric values. These
+values are `0` when the part is closed and `1` (or any non-zero value) when the
+part is open. The dashboard therefore treats any non-zero value as "open" to
+handle potential future variations.

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -347,7 +347,9 @@ function updateOpenings(vehicle) {
 
     parts.forEach(function(p) {
         if (vehicle[p.key] == null) return;
-        var open = Number(vehicle[p.key]) === 1;
+        // Values are 0 when the part is closed and non-zero when open.
+        // Use loose inequality to handle any non-zero value as "open".
+        var open = Number(vehicle[p.key]) !== 0;
         $('#' + p.id).attr('class', open ? 'part-open' : 'part-closed');
     });
 


### PR DESCRIPTION
## Summary
- treat door, window, frunk and trunk values as non-zero = open
- document that 0 means closed in API responses

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684e0989c19c83219275a37c4c0e063c