### PR TITLE
Extend frunk drawing

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -80,7 +80,7 @@
                 <path id="car-body" class="car-body"
                       d="M20 20 Q30 10 50 10 Q70 10 80 20 V180 Q70 190 50 190 Q30 190 20 180 Z"/>
                 <path id="frunk" class="part-closed"
-                      d="M30 25 L50 15 L70 25 V35 H30 Z"/>
+                      d="M30 25 L50 15 L70 25 V40 H30 Z"/>
                 <path id="trunk" class="part-closed"
                       d="M30 165 H70 V175 L50 185 L30 175 Z"/>
                 <rect id="door-fl" class="part-closed" x="20" y="40" width="10" height="45"/>


### PR DESCRIPTION
## Summary
- extend the frunk path in the `openings-indicator` drawing so it appears slightly longer

## Testing
- `python -m py_compile app.py version.py`

------
https://chatgpt.com/codex/tasks/task_e_684e0c2698e08321bfb906f0b6fc6fea