### PR TITLE
Flip openings indicator

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -364,7 +364,8 @@ select {
   dominant-baseline: central;
   /* ensure rotation uses the text's own bounding box */
   transform-box: fill-box;
-  transform: rotate(180deg);
+  /* rotate text only when the car is flipped */
+  transform: rotate(0deg);
   transform-origin: center;
 }
 
@@ -395,7 +396,7 @@ select {
 #openings-indicator svg {
   width: 100px;
   height: 200px;
-  transform: rotate(180deg);
+  transform: rotate(0deg);
   transform-origin: center;
 }
 


### PR DESCRIPTION
## Summary
- orient car outline with frunk at the top
- keep TPMS text upright

## Testing
- `python -m compileall -q .`


------
https://chatgpt.com/codex/tasks/task_e_684e0d12d4d08321be0acc28aa524f8d