### PR TITLE
Add optional blue highlight for doors and windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ While driving, a blue path is drawn on the map using the reported GPS positions.
 The `/history` page lists these files so previous trips can be selected and displayed on an interactive map.
 When multiple cars are available a drop-down menu lets you switch between vehicles.
 Below the navigation bar a small media player section shows details of the currently playing track if provided by the API.
+The configuration page also offers an option to highlight doors and windows in blue.
 
 Data is streamed to the frontend via `/stream/<vehicle_id>` using Server-Sent Events so the dashboard updates instantly when new information arrives.
 The endpoint `/apiliste` exposes a text file listing all seen API variables and their latest values.

--- a/app.py
+++ b/app.py
@@ -208,6 +208,7 @@ CONFIG_ITEMS = [
     {'id': 'climate-indicator', 'desc': 'Klimaanlage'},
     {'id': 'tpms-indicator', 'desc': 'Reifendruck'},
     {'id': 'openings-indicator', 'desc': 'Türen/Fenster'},
+    {'id': 'blue-openings', 'desc': 'Türen/Fenster blau einfärben', 'default': False},
     {'id': 'charging-info', 'desc': 'Ladeinformationen'},
     {'id': 'nav-bar', 'desc': 'Navigationsleiste'},
     {'id': 'media-player', 'desc': 'Medienwiedergabe'},

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -408,6 +408,10 @@ select {
   fill: #555;
 }
 
+#openings-indicator .blue-highlight {
+  fill: blue;
+}
+
 #openings-indicator .car-body {
   fill: #333;
   stroke: #777;

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -12,11 +12,15 @@ L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
 }).addTo(map);
 var polyline = null;
 var lastDataTimestamp = null;
+var CONFIG = {};
+var HIGHLIGHT_BLUE = false;
 
 function applyConfig(cfg) {
     if (!cfg) return;
-    Object.keys(cfg).forEach(function(id) {
-        if (!cfg[id]) {
+    CONFIG = cfg;
+    HIGHLIGHT_BLUE = !!CONFIG['blue-openings'];
+    Object.keys(CONFIG).forEach(function(id) {
+        if (!CONFIG[id]) {
             $('#' + id).hide();
         }
     });
@@ -351,6 +355,14 @@ function updateOpenings(vehicle) {
         // Use loose inequality to handle any non-zero value as "open".
         var open = Number(vehicle[p.key]) !== 0;
         $('#' + p.id).attr('class', open ? 'part-open' : 'part-closed');
+    });
+
+    var highlightParts = [
+        'door-fl', 'door-fr', 'door-rl', 'door-rr',
+        'window-fl', 'window-fr', 'window-rl', 'window-rr'
+    ];
+    highlightParts.forEach(function(id) {
+        $('#' + id).toggleClass('blue-highlight', HIGHLIGHT_BLUE);
     });
 
     var srPct = vehicle.sun_roof_percent_open;

--- a/templates/config.html
+++ b/templates/config.html
@@ -11,7 +11,8 @@
         {% for item in items %}
         <div>
             <label>
-                <input type="checkbox" name="{{ item.id }}" value="1" {% if config.get(item.id, True) %}checked{% endif %}>
+                {% set default_checked = item.get('default', True) %}
+                <input type="checkbox" name="{{ item.id }}" value="1" {% if config.get(item.id, default_checked) %}checked{% endif %}>
                 {{ item.desc }}
             </label>
         </div>


### PR DESCRIPTION
## Summary
- add `blue-openings` config item and allow default values in config template
- make doors and windows turn blue when the option is enabled
- expose the new option via CSS, JS and templates
- mention the new feature in the README

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_684e11ed629083219e230a89af2f36e5