### PR TITLE
Fix speedometer clipping and size

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -28,7 +28,7 @@
         </div>
         <div id="battery-indicator"></div>
             <div id="speedometer">
-                <svg width="120" height="60" viewBox="0 0 120 60">
+                <svg width="140" height="70" viewBox="0 -5 120 60">
                     <path d="M10,50 A50,50 0 0,1 110,50" stroke="#ccc" stroke-width="8" fill="none"/>
                     <g id="speedometer-ticks" stroke="#000" stroke-width="2">
                         <!--0 km/h-->


### PR DESCRIPTION
## Summary
- enlarge the speedometer SVG
- adjust its viewBox so the gauge is no longer clipped

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e146b6a8c83219a6ec07acd300943