### PR TITLE
Align thermometers with speedometer

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -318,15 +318,23 @@ select {
   vertical-align: top;
   text-align: center;
   font-weight: bold;
+  align-self: flex-end;
+  height: 110px;
 }
 
 #thermometers .thermometer {
-  display: inline-block;
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-end;
   margin: 0 5px;
+  height: 100%;
 }
 
 #thermometers svg {
   display: block;
+  height: 70px;
+  width: auto;
 }
 
 #thermometers .label {

--- a/templates/index.html
+++ b/templates/index.html
@@ -52,7 +52,7 @@
             </div>
         <div id="thermometers">
             <div class="thermometer">
-                <svg width="30" height="60" viewBox="0 0 30 60">
+                <svg width="30" height="70" viewBox="0 0 30 60">
                     <rect x="13" y="5" width="4" height="40" class="tube" />
                     <rect id="inside-level" x="13" y="45" width="4" height="0" class="level" />
                     <circle id="inside-bulb" cx="15" cy="50" r="7" class="bulb" />
@@ -60,7 +60,7 @@
                 <div id="inside-temp-value" class="label">Innen: -- °C</div>
             </div>
             <div class="thermometer">
-                <svg width="30" height="60" viewBox="0 0 30 60">
+                <svg width="30" height="70" viewBox="0 0 30 60">
                     <rect x="13" y="5" width="4" height="40" class="tube" />
                     <rect id="outside-level" x="13" y="45" width="4" height="0" class="level" />
                     <circle id="outside-bulb" cx="15" cy="50" r="7" class="bulb" />


### PR DESCRIPTION
## Summary
- match thermometer height to speedometer
- keep thermometer labels centered by using flex layout

## Testing
- `python -m py_compile app.py version.py`

------
https://chatgpt.com/codex/tasks/task_e_684e1784036c83218e67479675ca5ae2