### PR TITLE
Implement connected clients display

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ The same information is also stored as hierarchical JSON in `data/api-liste.json
 * `/debug` – display environment info and recent log lines
 * `/api/vehicles` – list available vehicles as JSON
 * `/api/version` – return the current dashboard version as JSON
+* `/api/clients` – number of connected clients as JSON
 * `/stream/<vehicle_id>` – Server-Sent Events endpoint used by the frontend
 
 ## Version

--- a/app.py
+++ b/app.py
@@ -673,6 +673,13 @@ def api_version():
     return jsonify({'version': __version__})
 
 
+@app.route('/api/clients')
+def api_clients():
+    """Return the current number of connected streaming clients."""
+    count = sum(len(v) for v in subscribers.values())
+    return jsonify({'clients': count})
+
+
 @app.route('/api/config')
 def api_config():
     """Return visibility configuration as JSON."""

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -474,3 +474,10 @@ select {
   bottom: 0;
   color: var(--accent-color);
 }
+
+.app-version #client-count {
+  position: absolute;
+  left: 10px;
+  bottom: 0;
+  color: var(--accent-color);
+}

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -612,6 +612,14 @@ function updateDataAge(ts) {
     $el.text('Letztes Update vor ' + text + ' (' + timeStr + ')');
 }
 
+function updateClientCount() {
+    $.getJSON('/api/clients', function(resp) {
+        if (typeof resp.clients === 'number') {
+            $('#client-count').text('Clients: ' + resp.clients);
+        }
+    });
+}
+
 
 
 
@@ -674,3 +682,5 @@ function checkAppVersion() {
 
 setInterval(checkAppVersion, 60000);
 setInterval(function() { updateDataAge(); }, 1000);
+setInterval(updateClientCount, 5000);
+updateClientCount();

--- a/templates/index.html
+++ b/templates/index.html
@@ -120,6 +120,7 @@
     <div id="media-player"></div>
 
     <footer class="app-version">
+        <span id="client-count"></span>
         <span>Tesla-Dashboard V{{ version }} - © {{ year }} Erik Schauer, do1ffe@darc.de</span>
         <span id="data-age"></span>
     </footer>


### PR DESCRIPTION
## Summary
- show the number of SSE clients via `/api/clients`
- poll client count and show it in the footer
- position the count on the left side of the footer
- document new endpoint in README

## Testing
- `python -m py_compile app.py version.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e18d47e4c8321a0a25ce185ab5301