### PR TITLE
Add timestamps to trip history info

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ The dashboard shows a short overview depending on whether the vehicle is parked,
 
 While driving, a blue path is drawn on the map using the reported GPS positions. Each trip is logged to its own CSV file under `data/trips` for later analysis.
 The `/history` page lists these files so previous trips can be selected and displayed on an interactive map.
+Using the slider you can inspect each recorded point and see the exact timestamp along with speed and power information.
 When multiple cars are available a drop-down menu lets you switch between vehicles.
 Below the navigation bar a small media player section shows details of the currently playing track if provided by the API.
 The configuration page also offers an option to highlight doors and windows in blue.

--- a/app.py
+++ b/app.py
@@ -409,17 +409,18 @@ def _load_trip(filename):
                 parts = line.strip().split(',')
                 if len(parts) < 3:
                     continue
-                _ts, lat, lon = parts[:3]
+                ts, lat, lon = parts[:3]
                 speed = parts[3] if len(parts) >= 4 and parts[3] else None
                 power = parts[4] if len(parts) >= 5 and parts[4] else None
                 try:
+                    ts = int(float(ts)) if ts else None
                     lat = float(lat)
                     lon = float(lon)
                     speed = float(speed) if speed is not None else None
                     power = float(power) if power is not None else None
                 except Exception:
                     continue
-                points.append([lat, lon, speed, power])
+                points.append([lat, lon, speed, power, ts])
     except Exception:
         pass
     return points

--- a/static/js/history.js
+++ b/static/js/history.js
@@ -36,6 +36,10 @@ if (Array.isArray(tripPath) && tripPath.length) {
     function updateInfo(idx) {
         var point = tripPath[idx];
         var text = [];
+        if (point[4]) {
+            var date = new Date(point[4]);
+            text.push(date.toLocaleString());
+        }
         if (point[2] !== null && point[2] !== undefined && point[2] !== '') {
             text.push('Geschwindigkeit: ' + point[2] + ' km/h');
         }


### PR DESCRIPTION
## Summary
- load timestamps from trip CSV files
- display timestamp in history slider info
- document timestamp information in README

## Testing
- `python -m compileall -q .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e22541f9c83218191ede5ddef3551