### PR TITLE
Add vehicle state display

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -494,9 +494,16 @@ select {
   color: var(--accent-color);
 }
 
-.app-version #client-count {
+.app-version #vehicle-state {
   position: absolute;
   left: 10px;
+  bottom: 0;
+  color: var(--accent-color);
+}
+
+.app-version #client-count {
+  position: absolute;
+  left: 120px;
   bottom: 0;
   color: var(--accent-color);
 }

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -110,6 +110,7 @@ function fetchVehicles() {
 function handleData(data) {
     updateHeader(data);
     updateUI(data);
+    updateVehicleState(data.state);
     var drive = data.drive_state || {};
     var vehicle = data.vehicle_state || {};
     updateDataAge(vehicle.timestamp);
@@ -610,6 +611,14 @@ function updateDataAge(ts) {
     }
     var timeStr = new Date(lastDataTimestamp).toLocaleTimeString([], {hour: '2-digit', minute: '2-digit', second: '2-digit'});
     $el.text('Letztes Update vor ' + text + ' (' + timeStr + ')');
+}
+
+function updateVehicleState(state) {
+    if (typeof state === 'string' && state.length > 0) {
+        $('#vehicle-state').text('State: ' + state);
+    } else {
+        $('#vehicle-state').text('');
+    }
 }
 
 function updateClientCount() {

--- a/templates/index.html
+++ b/templates/index.html
@@ -120,6 +120,7 @@
     <div id="media-player"></div>
 
     <footer class="app-version">
+        <span id="vehicle-state"></span>
         <span id="client-count"></span>
         <span>Tesla-Dashboard V{{ version }} - © {{ year }} Erik Schauer, do1ffe@darc.de</span>
         <span id="data-age"></span>


### PR DESCRIPTION
## Summary
- show vehicle `state` before the client count in the footer
- style the new state element
- update client-side logic to display the state

## Testing
- `pytest -q`
- `flake8` *(fails: command not found)*
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684e25c09f94832197c926dc0a2af927