### PR TITLE
Allow vehicle to sleep and log states

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This is a simple Flask application that displays real-time data from a Tesla veh
 
 API responses are logged to `data/api.log`. The log file uses rotation and will
 grow to at most 1&nbsp;MB.
+Vehicle state changes are written to `data/state.log`.
 The latest successful API response is also stored in `data/cache_<vehicle_id>.json`
 so the dashboard can display the most recently fetched data if the Tesla API is
 temporarily unavailable.


### PR DESCRIPTION
## Summary
- add `state.log` to record vehicle state changes
- log state transitions in backend
- avoid waking the vehicle by checking `get_vehicle_summary` first
- adjust polling interval based on vehicle state
- document state log in README

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_684e667595708321a817a3d0fb5e2922