### PR TITLE
Add persistent state logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ The same information is also stored as hierarchical JSON in `data/api-liste.json
 * `/daten` – vehicle data without the map
 * `/history` – select and display recorded trips
 * `/error` – show recent API errors (JSON via `/api/errors`)
+* `/state` – display the vehicle state log
 * `/debug` – display environment info and recent log lines
 * `/api/vehicles` – list available vehicles as JSON
 * `/api/version` – return the current dashboard version as JSON

--- a/templates/state.html
+++ b/templates/state.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>State Log</title>
+    <link rel="stylesheet" href="/static/css/style.css" />
+    <style>
+        pre { background:#1f1f1f; padding:10px; overflow-x:auto; color: var(--text-color); }
+    </style>
+</head>
+<body>
+    <h1>Vehicle State Log</h1>
+    <pre>{{ log_lines|join('') }}</pre>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- load last vehicle state from `data/state.log` on startup
- log state changes only
- add `/state` endpoint with template
- document the new endpoint

## Testing
- `python -m py_compile app.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684e73f46ad08321b22118c6eefd2260