### PR TITLE
Show sunroof percent

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -451,6 +451,17 @@ select {
   fill: blue;
 }
 
+#openings-indicator .window-highlight {
+  fill: #00bfff;
+}
+
+#openings-indicator #sunroof-percent {
+  fill: var(--text-color);
+  font-size: 8px;
+  text-anchor: middle;
+  dominant-baseline: central;
+}
+
 #openings-indicator .car-body {
   fill: #333;
   stroke: #777;

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -376,19 +376,23 @@ function updateOpenings(vehicle) {
         $('#' + p.id).attr('class', open ? 'part-open' : 'part-closed');
     });
 
-    var highlightParts = [
-        'door-fl', 'door-fr', 'door-rl', 'door-rr',
-        'window-fl', 'window-fr', 'window-rl', 'window-rr'
-    ];
-    highlightParts.forEach(function(id) {
+    var doorParts = ['door-fl', 'door-fr', 'door-rl', 'door-rr'];
+    doorParts.forEach(function(id) {
         $('#' + id).toggleClass('blue-highlight', HIGHLIGHT_BLUE);
+    });
+
+    var windowParts = ['window-fl', 'window-fr', 'window-rl', 'window-rr'];
+    windowParts.forEach(function(id) {
+        $('#' + id).toggleClass('window-highlight', HIGHLIGHT_BLUE);
     });
 
     var srPct = vehicle.sun_roof_percent_open;
     var srState = vehicle.sun_roof_state;
     if (srPct != null || srState) {
-        var open = srState && srState.toLowerCase() !== 'closed' && Number(srPct) > 0;
+        var pct = Number(srPct);
+        var open = srState && srState.toLowerCase() !== 'closed' && pct > 0;
         $('#sunroof').attr('class', open ? 'part-open' : 'part-closed');
+        $('#sunroof-percent').text(open && !isNaN(pct) ? Math.round(pct) + '%' : '');
     }
 }
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -97,6 +97,7 @@
                 <path id="window-rr" class="part-closed"
                       d="M50 115 V90 H55 L70 100 V115 Z"/>
                 <rect id="sunroof" class="part-closed" x="30" y="50" width="40" height="30"/>
+                <text id="sunroof-percent" x="50" y="65" text-anchor="middle" dominant-baseline="central"></text>
                 <g id="tpms-VL" class="tpms-tire" title="Vorne links">
                     <circle cx="20" cy="35" r="8" />
                     <text x="20" y="35">--</text>


### PR DESCRIPTION
## Summary
- add text for the sunroof percentage inside the openings indicator
- style the percentage label
- update JavaScript to display the percentage when the roof is open

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684eb4bc108083219714fd2ec5b4b363