### PR TITLE
Improve history slider layout

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -169,12 +169,18 @@ select {
   border-radius: 8px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.4);
   display: flex;
+  flex-direction: column;
   gap: 10px;
   align-items: center;
 }
 
 #slider-container input[type="range"] {
-  width: 200px;
+  width: 75vw;
+}
+
+#point-info {
+  text-align: center;
+  color: var(--text-color);
 }
 
 #charging-info table,

--- a/templates/history.html
+++ b/templates/history.html
@@ -28,8 +28,8 @@
     <div id="map"></div>
     <div id="slider-container">
         <input type="range" id="point-slider" min="0" max="0" value="0" step="1">
-        <span id="point-info"></span>
     </div>
+    <div id="point-info"></div>
     <script>
         var tripPath = {{ path|tojson }};
         var tripHeading = {{ heading|tojson }};


### PR DESCRIPTION
## Summary
- separate slider from point info on `/history`
- stack slider elements vertically and widen the slider to cover 75% of the page

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684ecf283a0883218d98c9e5c8d6517a