### PR TITLE
Add info text in history slider and auto zoom

### DIFF
--- a/static/js/history.js
+++ b/static/js/history.js
@@ -63,8 +63,28 @@ if (Array.isArray(tripPath) && tripPath.length) {
     var slider = document.getElementById('point-slider');
     slider.max = tripPath.length - 1;
     slider.value = tripPath.length - 1;
+
+    var originalZoom = null;
+    var zoomTimeout = null;
+
     slider.addEventListener('input', function() {
         updateMarker(parseInt(this.value, 10));
+
+        if (originalZoom === null) {
+            originalZoom = map.getZoom();
+        }
+        var maxZoom = typeof map.getMaxZoom === 'function' ? map.getMaxZoom() : 18;
+        map.setZoom(maxZoom);
+
+        if (zoomTimeout) {
+            clearTimeout(zoomTimeout);
+        }
+        zoomTimeout = setTimeout(function() {
+            if (originalZoom !== null) {
+                map.setZoom(originalZoom);
+                originalZoom = null;
+            }
+        }, 3000);
     });
 
     updateMarker(tripPath.length - 1);

--- a/templates/history.html
+++ b/templates/history.html
@@ -28,8 +28,8 @@
     <div id="map"></div>
     <div id="slider-container">
         <input type="range" id="point-slider" min="0" max="0" value="0" step="1">
+        <div id="point-info"></div>
     </div>
-    <div id="point-info"></div>
     <script>
         var tripPath = {{ path|tojson }};
         var tripHeading = {{ heading|tojson }};


### PR DESCRIPTION
## Summary
- show point info inside the slider container on `/history`
- when moving the slider, zoom the map to max level
- restore the previous zoom after 3 seconds of inactivity

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684ed0c8e44c8321accec95f540bc3e0