### PR TITLE
Center history map on slider move

### DIFF
--- a/static/js/history.js
+++ b/static/js/history.js
@@ -68,7 +68,9 @@ if (Array.isArray(tripPath) && tripPath.length) {
     var zoomTimeout = null;
 
     slider.addEventListener('input', function() {
-        updateMarker(parseInt(this.value, 10));
+        var idx = parseInt(this.value, 10);
+        updateMarker(idx);
+        map.panTo(marker.getLatLng());
 
         if (originalZoom === null) {
             originalZoom = map.getZoom();


### PR DESCRIPTION
## Summary
- center the map on the currently selected point when moving the slider on `/history`

## Testing
- `python -m py_compile app.py`
- `python -m py_compile version.py`


------
https://chatgpt.com/codex/tasks/task_e_684ed233391483219a3cbc32d6a418d7