### PR TITLE
Fix map centering on history page

### DIFF
--- a/static/js/history.js
+++ b/static/js/history.js
@@ -70,13 +70,13 @@ if (Array.isArray(tripPath) && tripPath.length) {
     slider.addEventListener('input', function() {
         var idx = parseInt(this.value, 10);
         updateMarker(idx);
-        map.panTo(marker.getLatLng());
+        var latlng = marker.getLatLng();
 
         if (originalZoom === null) {
             originalZoom = map.getZoom();
         }
         var maxZoom = typeof map.getMaxZoom === 'function' ? map.getMaxZoom() : 18;
-        map.setZoom(maxZoom);
+        map.setView(latlng, maxZoom);
 
         if (zoomTimeout) {
             clearTimeout(zoomTimeout);
@@ -90,4 +90,5 @@ if (Array.isArray(tripPath) && tripPath.length) {
     });
 
     updateMarker(tripPath.length - 1);
+    map.setView(marker.getLatLng(), map.getZoom());
 }


### PR DESCRIPTION
## Summary
- ensure the history map is centered on the marker position while scrubbing

## Testing
- `python -m py_compile $(find . -name '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684ed3d042888321a682156e5e0b6852