### PR TITLE
Update window open style

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -526,7 +526,7 @@ select {
 #window-fr.window-open,
 #window-rl.window-open,
 #window-rr.window-open {
-  transform: translateY(20px);
+  /* only change the color when open */
   fill: #4caf50;
 }
 
@@ -540,7 +540,7 @@ select {
  * Example:
  *   <path id="window-fl" class="part-open window-open window-highlight">
  * Without this rule the fill from ".window-highlight" would override
- * the green color. With it, open windows remain green while sliding down.
+ * the green color. With it, open windows remain green.
  */
 #window-fl.window-open.window-highlight,
 #window-fr.window-open.window-highlight,


### PR DESCRIPTION
## Summary
- stop translating window paths when open
- update CSS comment accordingly

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `for f in static/js/*.js; do node -c "$f"; done`

------
https://chatgpt.com/codex/tasks/task_e_684ede1ae2a88321ac060e046a81c3a9