### PR TITLE
Fix window outline when open

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -526,8 +526,11 @@ select {
 #window-fr.window-open,
 #window-rl.window-open,
 #window-rr.window-open {
-  /* only change the color when open */
+  /* keep a visible outline when open */
   fill: #4caf50;
+  stroke: black;
+  stroke-opacity: 1;
+  stroke-width: 0.5px;
 }
 
 /*
@@ -547,6 +550,9 @@ select {
 #window-rl.window-open.window-highlight,
 #window-rr.window-open.window-highlight {
   fill: #4caf50;
+  stroke: black;
+  stroke-opacity: 1;
+  stroke-width: 0.5px;
 }
 
 .app-version {


### PR DESCRIPTION
## Summary
- keep black outlines visible on open windows

## Testing
- `python -m py_compile app.py version.py`

------
https://chatgpt.com/codex/tasks/task_e_684ee4269d308321a27637eedb51851e