### PR TITLE
Add black outline for sunroof

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -522,6 +522,19 @@ select {
   stroke-width: 0.5px;
 }
 
+#sunroof {
+  stroke: black;
+  stroke-opacity: 0.3;
+  stroke-width: 0.5px;
+}
+
+#sunroof.part-open {
+  /* keep a visible outline when open */
+  stroke: black;
+  stroke-opacity: 1;
+  stroke-width: 0.5px;
+}
+
 #window-fl.window-open,
 #window-fr.window-open,
 #window-rl.window-open,


### PR DESCRIPTION
## Summary
- style the sunroof like the windows
- keep stroke visible when the sunroof is open

## Testing
- `python -m py_compile app.py version.py`


------
https://chatgpt.com/codex/tasks/task_e_684ee55245c4832192dadf71fadd25ae