### PR TITLE
Fix door animation hinge

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -485,29 +485,29 @@ select {
 }
 
 #door-fl {
-  transform-origin: 20px 62.5px;
+  transform-origin: 25px 40px;
 }
 
 #door-rl {
-  transform-origin: 20px 117.5px;
+  transform-origin: 25px 95px;
 }
 
 #door-fr {
-  transform-origin: 80px 62.5px;
+  transform-origin: 75px 40px;
 }
 
 #door-rr {
-  transform-origin: 80px 117.5px;
+  transform-origin: 75px 95px;
 }
 
 #door-fl.part-open,
 #door-rl.part-open {
-  transform: rotate(-75deg);
+  transform: perspective(200px) rotateX(-75deg) rotateY(-15deg);
 }
 
 #door-fr.part-open,
 #door-rr.part-open {
-  transform: rotate(75deg);
+  transform: perspective(200px) rotateX(-75deg) rotateY(15deg);
 }
 
 /* animated windows */


### PR DESCRIPTION
## Summary
- adjust door transform origins so hinge is at the top
- animate doors with a perspective rotateX so the bottom swings outward
- swing left doors left and right doors right

## Testing
- `python -m py_compile app.py version.py`


------
https://chatgpt.com/codex/tasks/task_e_684ee72f7ff88321824d7851857c3b77