### PR TITLE
Enhance charging info display

### DIFF
--- a/app.py
+++ b/app.py
@@ -245,6 +245,7 @@ CONFIG_ITEMS = [
     {'id': 'openings-indicator', 'desc': 'Türen/Fenster'},
     {'id': 'blue-openings', 'desc': 'Türen/Fenster blau einfärben', 'default': False},
     {'id': 'charging-info', 'desc': 'Ladeinformationen'},
+    {'id': 'v2l-infos', 'desc': 'V2L-Hinweis'},
     {'id': 'nav-bar', 'desc': 'Navigationsleiste'},
     {'id': 'media-player', 'desc': 'Medienwiedergabe'},
 ]

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -136,6 +136,7 @@ select {
   margin: 0;
 }
 
+#v2l-infos,
 #charging-info,
 /* Navigation bar below the status bar */
 #nav-bar {
@@ -183,12 +184,15 @@ select {
   color: var(--text-color);
 }
 
+#v2l-infos table,
 #charging-info table,
 #nav-bar table {
   width: 100%;
   border-collapse: collapse;
 }
 
+#v2l-infos th,
+#v2l-infos td,
 #charging-info th,
 #charging-info td,
 #nav-bar th,
@@ -198,12 +202,14 @@ select {
   text-align: left;
 }
 
+#v2l-infos th,
 #charging-info th,
 #nav-bar th {
   white-space: nowrap;
   font-weight: normal;
 }
 
+#v2l-infos span.icon,
 #charging-info span.icon,
 #nav-bar span.icon {
   margin-right: 4px;

--- a/templates/index.html
+++ b/templates/index.html
@@ -117,6 +117,7 @@
             </svg>
         </div>
     </div>
+    <div id="v2l-infos"></div>
     <div id="charging-info"></div>
     <div id="nav-bar"></div>
     <div id="media-player"></div>


### PR DESCRIPTION
## Summary
- persist last charging session info for 10 minutes after unplugging
- only show the last added energy when not recently charging
- show V2L adapter notice with map link when conditions are met
- make V2L info display configurable via the config page
- clarify label for last stop energy

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_684eef85713883219b2a3d0e136d9da1