### PR TITLE
Center status bar elements

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -122,11 +122,13 @@ select {
 /* Container for lock, gear, battery and temperature icons */
 #status-bar {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
+  justify-content: center;
   flex-wrap: wrap;
   gap: 20px;
   margin: 20px 0;
   padding: 10px;
+  height: 200px;
   background: var(--surface-color);
   border-radius: 8px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.4);
@@ -134,6 +136,9 @@ select {
 
 #status-bar > div {
   margin: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 #v2l-infos,


### PR DESCRIPTION
## Summary
- vertically and horizontally center contents in the status bar
- make the status bar 200px high

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684f1a3a5b188321876db7f81d0a4269