### PR TITLE
Adjust status bar height and vertical centering

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -122,7 +122,7 @@ select {
 /* Container for lock, gear, battery and temperature icons */
 #status-bar {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   flex-wrap: wrap;
   gap: 20px;
   margin: 20px 0;
@@ -130,10 +130,15 @@ select {
   background: var(--surface-color);
   border-radius: 8px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.4);
+  height: 200px;
 }
 
 #status-bar > div {
   margin: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  height: 100%;
 }
 
 #v2l-infos,


### PR DESCRIPTION
## Summary
- center status bar items vertically and set a fixed height

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684f201f5d9c8321adea557cd1ba240a