### PR TITLE
Implement state check before data fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ The same information is also stored as hierarchical JSON in `data/api-liste.json
 * `/state` – display the vehicle state log
 * `/debug` – display environment info and recent log lines
 * `/api/vehicles` – list available vehicles as JSON
+* `/api/state` – return the current vehicle state as JSON
 * `/api/version` – return the current dashboard version as JSON
 * `/api/clients` – number of connected clients as JSON
 * `/stream/<vehicle_id>` – Server-Sent Events endpoint used by the frontend


### PR DESCRIPTION
## Summary
- add new `/api/state` endpoint for vehicle state retrieval
- expose helper `get_vehicle_state` and update docs
- rework data fetching loop to poll state every 3 seconds and only call Tesla when online
- allow `get_vehicle_data` to reuse known state

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68500a6271908321848c1da95d9e0df1