### PR TITLE
Cache vehicle state after every fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,11 @@ This is a simple Flask application that displays real-time data from a Tesla veh
 API responses are logged to `data/api.log`. The log file uses rotation and will
 grow to at most 1&nbsp;MB.
 Vehicle state changes are written to `data/state.log`.
-The latest successful API response is also stored in `data/cache_<vehicle_id>.json`
-so the dashboard can display the most recently fetched data if the Tesla API is
-temporarily unavailable. When the vehicle is asleep or offline the server only
-checks the vehicle state and serves this cached data back to the client.
+The latest successful API response is stored in `data/cache_<vehicle_id>.json`.
+This cache is always updated with the current vehicle state so the dashboard
+knows whether the car is online, asleep or offline even when no fresh data is
+available. When the Tesla API cannot be reached the server serves this cached
+data back to the client.
 All data paths are resolved relative to the application directory, so the server
 can be started from any location while still accessing existing trips and logs.
 

--- a/app.py
+++ b/app.py
@@ -671,7 +671,7 @@ def _fetch_data_once(vehicle_id='default'):
     if state == 'online':
         data = get_vehicle_data(vid, state=state)
         if isinstance(data, dict) and not data.get('error'):
-            _save_cached(cache_id, data)
+            pass
         else:
             cached = _load_cached(cache_id)
             if cached is not None:
@@ -690,6 +690,11 @@ def _fetch_data_once(vehicle_id='default'):
             data = {'state': state}
 
     latest_data[cache_id] = data
+    if isinstance(data, dict):
+        try:
+            _save_cached(cache_id, data)
+        except Exception:
+            pass
     return data
 
 


### PR DESCRIPTION
## Summary
- persist vehicle state in cached data even when not fetching new data
- document cache behaviour in README

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_685098d292f083219341de448bba25da