### PR TITLE
Add nearby supercharger list

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -136,6 +136,20 @@ select {
   margin: 0;
 }
 
+#supercharger-list {
+  margin-left: auto;
+  text-align: left;
+  font-size: 0.9em;
+}
+#supercharger-list ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+#supercharger-list li {
+  white-space: nowrap;
+}
+
 #v2l-infos,
 #charging-info,
 /* Navigation bar below the status bar */

--- a/templates/index.html
+++ b/templates/index.html
@@ -116,6 +116,7 @@
                 </g>
             </svg>
         </div>
+        <div id="supercharger-list"></div>
     </div>
     <div id="v2l-infos"></div>
     <div id="charging-info"></div>


### PR DESCRIPTION
## Summary
- add endpoint to request nearby Superchargers
- display fetched Superchargers in the dashboard status bar
- style and fetch supercharger list using JavaScript

## Testing
- `python -m py_compile app.py`
- `node --check static/js/main.js`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850a79a594883218e2bf379f86d4d52