### PR TITLE
Add service data endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,13 @@ The same information is also stored as hierarchical JSON in `data/api-liste.json
 * `/history` – select and display recorded trips
 * `/error` – show recent API errors (JSON via `/api/errors`)
 * `/state` – display the vehicle state log
+* `/service` – show vehicle service data (JSON via `/api/service`)
 * `/debug` – display environment info and recent log lines
 * `/api/vehicles` – list available vehicles as JSON
 * `/api/state` – return the current vehicle state as JSON
 * `/api/version` – return the current dashboard version as JSON
 * `/api/clients` – number of connected clients as JSON
+* `/api/service` – return vehicle service data as JSON
 * `/stream/<vehicle_id>` – Server-Sent Events endpoint used by the frontend
 
 ## Version

--- a/templates/service.html
+++ b/templates/service.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="de">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Service Daten</title>
+    <link rel="stylesheet" href="/static/css/style.css" />
+    <style>
+        pre { background:#1f1f1f; padding:10px; overflow-x:auto; color: var(--text-color); }
+    </style>
+</head>
+<body>
+    <h1>Service Daten</h1>
+    <pre>{{ data|tojson(indent=2) }}</pre>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- query Tesla service data using `VEHICLE_SERVICE_DATA`
- expose `/service` page and `/api/service` endpoint
- document new endpoints

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_685120608e208321aeb316fb33a1ab38