### PR TITLE
Add charge port indicator

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -159,7 +159,7 @@ function handleData(data) {
                vehicle.tpms_pressure_fr,
                vehicle.tpms_pressure_rl,
                vehicle.tpms_pressure_rr);
-    updateOpenings(vehicle);
+    updateOpenings(vehicle, charge);
     updateMediaPlayer(vehicle.media_info);
     var lat = drive.latitude;
     var lng = drive.longitude;
@@ -359,7 +359,7 @@ function updateTPMS(fl, fr, rl, rr) {
     set('HR', rr);
 }
 
-function updateOpenings(vehicle) {
+function updateOpenings(vehicle, charge) {
     var parts = [
         {key: 'df', id: 'door-fl'},
         {key: 'dr', id: 'door-rl'},
@@ -370,14 +370,16 @@ function updateOpenings(vehicle) {
         {key: 'fp_window', id: 'window-fr'},
         {key: 'rp_window', id: 'window-rr'},
         {key: 'ft', id: 'frunk'},
-        {key: 'rt', id: 'trunk'}
+        {key: 'rt', id: 'trunk'},
+        {key: 'charge_port_door_open', id: 'charge-port', src: charge}
     ];
 
     parts.forEach(function(p) {
-        if (vehicle[p.key] == null) return;
+        var obj = p.src || vehicle;
+        if (!obj || obj[p.key] == null) return;
         // Values are 0 when the part is closed and non-zero when open.
         // Use loose inequality to handle any non-zero value as "open".
-        var open = Number(vehicle[p.key]) !== 0;
+        var open = Number(obj[p.key]) !== 0;
         var $el = $('#' + p.id);
         $el.attr('class', open ? 'part-open' : 'part-closed');
         if (p.id.startsWith('window-')) {

--- a/templates/index.html
+++ b/templates/index.html
@@ -114,6 +114,7 @@
                     <circle cx="80" cy="170" r="8" />
                     <text x="80" y="170">--</text>
                 </g>
+                <rect id="charge-port" class="part-closed" x="15" y="150" width="8" height="8" rx="1" ry="1"/>
             </svg>
         </div>
         <div id="supercharger-list"></div>


### PR DESCRIPTION
## Summary
- extend car openings graphic with a charge port
- handle charge port status in frontend

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68512dc438f4832186218929e7ca4522