### PR TITLE
Handle offline vehicle when occupant detected

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ The same information is also stored as hierarchical JSON in `data/api-liste.json
 * `/api/state` – return the current vehicle state as JSON
 * `/api/version` – return the current dashboard version as JSON
 * `/api/clients` – number of connected clients as JSON
+* `/api/occupant` – get or set occupant presence flag
 * `/stream/<vehicle_id>` – Server-Sent Events endpoint used by the frontend
 
 ## Version


### PR DESCRIPTION
## Summary
- track occupant presence via `/api/occupant` endpoint
- wake up the car when occupant is present, even if offline
- always fetch state when occupant is detected
- document new endpoint

## Testing
- `python -m py_compile app.py`
- `python -m py_compile version.py`


------
https://chatgpt.com/codex/tasks/task_e_6851923c72e88321969eb4d5e25dd35a