### PR TITLE
Fetch Superchargers with main vehicle data

### DIFF
--- a/app.py
+++ b/app.py
@@ -760,6 +760,12 @@ def _fetch_data_once(vehicle_id='default'):
         else:
             data = {'state': state}
 
+    if isinstance(data, dict):
+        try:
+            data['superchargers'] = get_superchargers(vid)
+        except Exception:
+            pass
+
     latest_data[cache_id] = data
     if isinstance(data, dict):
         try:

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -214,8 +214,10 @@ function handleData(data) {
         map.removeLayer(polyline);
         polyline = null;
     }
+    if (Array.isArray(data.superchargers)) {
+        superchargerData = data.superchargers;
+    }
     updateSuperchargerList();
-    fetchSuperchargers();
 }
 
 
@@ -816,9 +818,7 @@ function startStream() {
     superchargerMarkers.forEach(function(m) { map.removeLayer(m); });
     superchargerMarkers = [];
     updateSuperchargerList();
-    lastSuperchargerFetch = 0;
     eventSource = new EventSource('/stream/' + currentVehicle);
-    fetchSuperchargers();
     eventSource.onmessage = function(e) {
         var data = JSON.parse(e.data);
         if (!data.error) {


### PR DESCRIPTION
## Summary
- fetch nearby Superchargers whenever vehicle data is updated
- deliver Supercharger data via the SSE/data endpoints
- update frontend to use the integrated Supercharger list

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6851ad3448588321ad3a3b428a45d435