### PR TITLE
Fix supercharger list retrieval

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -218,6 +218,9 @@ function handleData(data) {
         superchargerData = data.superchargers;
     }
     updateSuperchargerList();
+    if (!superchargerData.length) {
+        fetchSuperchargers();
+    }
 }
 
 
@@ -818,6 +821,8 @@ function startStream() {
     superchargerMarkers.forEach(function(m) { map.removeLayer(m); });
     superchargerMarkers = [];
     updateSuperchargerList();
+    lastSuperchargerFetch = 0;
+    fetchSuperchargers();
     eventSource = new EventSource('/stream/' + currentVehicle);
     eventSource.onmessage = function(e) {
         var data = JSON.parse(e.data);


### PR DESCRIPTION
## Summary
- fallback to API call when superchargers are not included in stream data
- refresh supercharger list when starting the stream

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6851b2c85e54832192f5d5e161a57613