### PR TITLE
Display resolved address on map

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -59,11 +59,25 @@ select {
 }
 
 #map {
+  position: relative;
   height: 400px;
   margin-top: 10px;
   border-radius: 8px;
   overflow: hidden;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.4);
+}
+
+#location-address {
+  position: absolute;
+  left: 50%;
+  bottom: 4px;
+  transform: translateX(-50%);
+  background: rgba(0, 0, 0, 0.6);
+  color: #fff;
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 0.9em;
+  pointer-events: none;
 }
 
 #vehicle-info,

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -21,6 +21,8 @@ L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
 }).addTo(map);
 var polyline = null;
 var lastDataTimestamp = null;
+var lastAddressLat = null;
+var lastAddressLng = null;
 var CONFIG = {};
 var HIGHLIGHT_BLUE = false;
 var ASLEEP = false;
@@ -173,9 +175,11 @@ function handleData(data) {
         if (typeof drive.heading === 'number') {
             marker.setRotationAngle(drive.heading);
         }
+        fetchAddress(lat, lng);
     } else {
         // Fall back to Essen if no coordinates are available
         map.setView(DEFAULT_POS, DEFAULT_ZOOM);
+        $('#location-address').text('');
     }
 
     // Show destination flag and route line if navigation is active
@@ -792,6 +796,20 @@ function fetchSuperchargers() {
             superchargerData = resp;
             updateSuperchargerList();
         }
+    });
+}
+
+function fetchAddress(lat, lon) {
+    if (lat == null || lon == null) return;
+    if (lastAddressLat === lat && lastAddressLng === lon) return;
+    lastAddressLat = lat;
+    lastAddressLng = lon;
+    $.getJSON('/api/reverse_geocode', {lat: lat, lon: lon}, function(resp) {
+        var addr = resp.address || resp.display_name;
+        if (!addr && resp.raw && resp.raw.display_name) {
+            addr = resp.raw.display_name;
+        }
+        $('#location-address').text(addr || '');
     });
 }
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -15,7 +15,9 @@
     <div id="dashboard-content">
         <label for="vehicle-select">Fahrzeug auswählen:</label>
         <select id="vehicle-select"></select>
-        <div id="map"></div>
+        <div id="map">
+            <div id="location-address"></div>
+        </div>
     <div id="status-bar">
         <div id="lock-container">
             <div id="lock-status" title="Verriegelt">🔒</div>

--- a/templates/map.html
+++ b/templates/map.html
@@ -17,7 +17,9 @@
     </style>
 </head>
 <body>
-    <div id="map"></div>
+    <div id="map">
+        <div id="location-address"></div>
+    </div>
     <script>
         window.APP_VERSION = "{{ version }}";
     </script>


### PR DESCRIPTION
## Summary
- add helper and route for REVERSE_GEOCODING API
- overlay resolved address at bottom of map
- request address from frontend when location changes

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6851e3a33e7c8321a8c7df6c1d7223b2