### PR TITLE
Fix location address by using OSM fallback

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 flask
 teslapy
 python-dotenv
+requests


### PR DESCRIPTION
## Summary
- add dependency on `requests`
- fall back to OpenStreetMap's reverse geocoding when Tesla API fails

## Testing
- `python -m py_compile app.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_6851e9afb0c08321a5e9ebb045882e87