### PR TITLE
Fix address overlay

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -70,7 +70,7 @@ select {
 #location-address {
   position: absolute;
   left: 50%;
-  bottom: 4px;
+  bottom: 24px;
   transform: translateX(-50%);
   background: rgba(0, 0, 0, 0.6);
   color: #fff;


### PR DESCRIPTION
## Summary
- move location address up so it isn't hidden behind map edge

## Testing
- `python -m py_compile app.py`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6851eb885f348321a28afc4fcbf67d34