### PR TITLE
Fix map location overlay

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -78,6 +78,7 @@ select {
   border-radius: 4px;
   font-size: 0.9em;
   pointer-events: none;
+  z-index: 900;
 }
 
 #vehicle-info,


### PR DESCRIPTION
## Summary
- ensure location-address overlay is visible on top of map tiles

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6851ed86e3908321949d79eda9b8f6c1