### PR TITLE
Show road type below address

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -76,9 +76,14 @@ select {
   color: #fff;
   padding: 2px 6px;
   border-radius: 4px;
-  font-size: 0.9em;
+  font-size: 1.1em;
   pointer-events: none;
   z-index: 900;
+}
+
+#location-address #road-type {
+  display: block;
+  font-size: 0.9em;
 }
 
 #vehicle-info,

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -179,7 +179,8 @@ function handleData(data) {
     } else {
         // Fall back to Essen if no coordinates are available
         map.setView(DEFAULT_POS, DEFAULT_ZOOM);
-        $('#location-address').text('');
+        $('#address-text').text('');
+        $('#road-type').text('');
     }
 
     // Show destination flag and route line if navigation is active
@@ -806,6 +807,7 @@ function fetchAddress(lat, lon) {
     lastAddressLng = lon;
     $.getJSON('/api/reverse_geocode', {lat: lat, lon: lon}, function(resp) {
         var addr = null;
+        var roadType = null;
         if (resp.raw && resp.raw.address) {
             var a = resp.raw.address;
             var line1 = '';
@@ -829,6 +831,30 @@ function fetchAddress(lat, lon) {
                     addr += (addr ? ', ' : '') + line2;
                 }
             }
+            if (resp.raw.category === 'highway' && resp.raw.type) {
+                var t = resp.raw.type;
+                var map = {
+                    motorway: 'Autobahn',
+                    motorway_link: 'Autobahnauffahrt',
+                    trunk: 'Schnellstraße',
+                    trunk_link: 'Schnellstraßenauffahrt',
+                    primary: 'Hauptstraße',
+                    primary_link: 'Zubringer',
+                    secondary: 'Nebenstraße',
+                    secondary_link: 'Zubringer',
+                    tertiary: 'Nebenstraße',
+                    residential: 'Wohnstraße',
+                    service: 'Zufahrtsstraße',
+                    living_street: 'Spielstraße',
+                    pedestrian: 'Fußgängerzone',
+                    track: 'Feldweg',
+                    road: 'Straße',
+                    footway: 'Gehweg',
+                    cycleway: 'Radweg',
+                    path: 'Pfad'
+                };
+                roadType = map[t] || t;
+            }
         }
         if (!addr) {
             addr = resp.address || resp.display_name;
@@ -836,7 +862,8 @@ function fetchAddress(lat, lon) {
                 addr = resp.raw.display_name;
             }
         }
-        $('#location-address').text(addr || '');
+        $('#address-text').text(addr || '');
+        $('#road-type').text(roadType ? '(' + roadType + ')' : '');
     });
 }
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -16,7 +16,7 @@
         <label for="vehicle-select">Fahrzeug auswählen:</label>
         <select id="vehicle-select"></select>
         <div id="map">
-            <div id="location-address"></div>
+            <div id="location-address"><div id="address-text"></div><div id="road-type"></div></div>
         </div>
     <div id="status-bar">
         <div id="lock-container">

--- a/templates/map.html
+++ b/templates/map.html
@@ -18,7 +18,7 @@
 </head>
 <body>
     <div id="map">
-        <div id="location-address"></div>
+        <div id="location-address"><div id="address-text"></div><div id="road-type"></div></div>
     </div>
     <script>
         window.APP_VERSION = "{{ version }}";


### PR DESCRIPTION
## Summary
- tweak location address container to show two lines
- increase font size for the address overlay
- display road type (translated to German) below the address

## Testing
- `python -m py_compile app.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_6851f36001b48321b0b7adde25603d64