### PR TITLE
Add hover tooltips for openings indicator

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -80,25 +80,25 @@
         </div>
         <div id="openings-indicator">
             <svg viewBox="0 0 100 200">
-                <path id="car-body" class="car-body"
+                <path id="car-body" class="car-body" title="Fahrzeug"
                       d="M20 20 Q30 10 50 10 Q70 10 80 20 V180 Q70 190 50 190 Q30 190 20 180 Z"/>
-                <path id="frunk" class="part-closed"
+                <path id="frunk" class="part-closed" title="Frunk"
                       d="M30 25 L50 15 L70 25 V40 H30 Z"/>
-                <path id="trunk" class="part-closed"
+                <path id="trunk" class="part-closed" title="Kofferraum"
                       d="M30 165 H70 V175 L50 185 L30 175 Z"/>
-                <rect id="door-fl" class="part-closed" x="20" y="40" width="10" height="45"/>
-                <rect id="door-fr" class="part-closed" x="70" y="40" width="10" height="45"/>
-                <rect id="door-rl" class="part-closed" x="20" y="95" width="10" height="45"/>
-                <rect id="door-rr" class="part-closed" x="70" y="95" width="10" height="45"/>
-                <path id="window-fl" class="part-closed"
+                <rect id="door-fl" class="part-closed" x="20" y="40" width="10" height="45" title="T&#252;r vorne links"/>
+                <rect id="door-fr" class="part-closed" x="70" y="40" width="10" height="45" title="T&#252;r vorne rechts"/>
+                <rect id="door-rl" class="part-closed" x="20" y="95" width="10" height="45" title="T&#252;r hinten links"/>
+                <rect id="door-rr" class="part-closed" x="70" y="95" width="10" height="45" title="T&#252;r hinten rechts"/>
+                <path id="window-fl" class="part-closed" title="Fenster vorne links"
                       d="M30 60 V45 L45 35 H50 V60 Z"/>
-                <path id="window-fr" class="part-closed"
+                <path id="window-fr" class="part-closed" title="Fenster vorne rechts"
                       d="M50 60 V35 H55 L70 45 V60 Z"/>
-                <path id="window-rl" class="part-closed"
+                <path id="window-rl" class="part-closed" title="Fenster hinten links"
                       d="M30 115 V100 L45 90 H50 V115 Z"/>
-                <path id="window-rr" class="part-closed"
+                <path id="window-rr" class="part-closed" title="Fenster hinten rechts"
                       d="M50 115 V90 H55 L70 100 V115 Z"/>
-                <rect id="sunroof" class="part-closed" x="30" y="50" width="40" height="30"/>
+                <rect id="sunroof" class="part-closed" x="30" y="50" width="40" height="30" title="Schiebedach"/>
                 <text id="sunroof-percent" x="50" y="65" text-anchor="middle" dominant-baseline="central"></text>
                 <g id="tpms-VL" class="tpms-tire" title="Vorne links">
                     <circle cx="20" cy="35" r="8" />
@@ -116,7 +116,7 @@
                     <circle cx="80" cy="170" r="8" />
                     <text x="80" y="170">--</text>
                 </g>
-                <rect id="charge-port" class="part-closed" x="15" y="150" width="8" height="8" rx="1" ry="1"/>
+                <rect id="charge-port" class="part-closed" x="15" y="150" width="8" height="8" rx="1" ry="1" title="Ladeanschluss"/>
             </svg>
         </div>
         <div id="supercharger-list"></div>


### PR DESCRIPTION
## Summary
- show tooltips on the openings indicator

## Testing
- `python -m py_compile app.py version.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6851fae3e9808321ad7692a4b985471a