### PR TITLE
Fix tooltips for openings indicator

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -80,43 +80,66 @@
         </div>
         <div id="openings-indicator">
             <svg viewBox="0 0 100 200">
-                <path id="car-body" class="car-body" title="Fahrzeug"
-                      d="M20 20 Q30 10 50 10 Q70 10 80 20 V180 Q70 190 50 190 Q30 190 20 180 Z"/>
-                <path id="frunk" class="part-closed" title="Frunk"
-                      d="M30 25 L50 15 L70 25 V40 H30 Z"/>
-                <path id="trunk" class="part-closed" title="Kofferraum"
-                      d="M30 165 H70 V175 L50 185 L30 175 Z"/>
-                <rect id="door-fl" class="part-closed" x="20" y="40" width="10" height="45" title="T&#252;r vorne links"/>
-                <rect id="door-fr" class="part-closed" x="70" y="40" width="10" height="45" title="T&#252;r vorne rechts"/>
-                <rect id="door-rl" class="part-closed" x="20" y="95" width="10" height="45" title="T&#252;r hinten links"/>
-                <rect id="door-rr" class="part-closed" x="70" y="95" width="10" height="45" title="T&#252;r hinten rechts"/>
-                <path id="window-fl" class="part-closed" title="Fenster vorne links"
-                      d="M30 60 V45 L45 35 H50 V60 Z"/>
-                <path id="window-fr" class="part-closed" title="Fenster vorne rechts"
-                      d="M50 60 V35 H55 L70 45 V60 Z"/>
-                <path id="window-rl" class="part-closed" title="Fenster hinten links"
-                      d="M30 115 V100 L45 90 H50 V115 Z"/>
-                <path id="window-rr" class="part-closed" title="Fenster hinten rechts"
-                      d="M50 115 V90 H55 L70 100 V115 Z"/>
-                <rect id="sunroof" class="part-closed" x="30" y="50" width="40" height="30" title="Schiebedach"/>
+                <path id="car-body" class="car-body" d="M20 20 Q30 10 50 10 Q70 10 80 20 V180 Q70 190 50 190 Q30 190 20 180 Z">
+                    <title>Fahrzeug</title>
+                </path>
+                <path id="frunk" class="part-closed" d="M30 25 L50 15 L70 25 V40 H30 Z">
+                    <title>Frunk</title>
+                </path>
+                <path id="trunk" class="part-closed" d="M30 165 H70 V175 L50 185 L30 175 Z">
+                    <title>Kofferraum</title>
+                </path>
+                <rect id="door-fl" class="part-closed" x="20" y="40" width="10" height="45">
+                    <title>T&#252;r vorne links</title>
+                </rect>
+                <rect id="door-fr" class="part-closed" x="70" y="40" width="10" height="45">
+                    <title>T&#252;r vorne rechts</title>
+                </rect>
+                <rect id="door-rl" class="part-closed" x="20" y="95" width="10" height="45">
+                    <title>T&#252;r hinten links</title>
+                </rect>
+                <rect id="door-rr" class="part-closed" x="70" y="95" width="10" height="45">
+                    <title>T&#252;r hinten rechts</title>
+                </rect>
+                <path id="window-fl" class="part-closed" d="M30 60 V45 L45 35 H50 V60 Z">
+                    <title>Fenster vorne links</title>
+                </path>
+                <path id="window-fr" class="part-closed" d="M50 60 V35 H55 L70 45 V60 Z">
+                    <title>Fenster vorne rechts</title>
+                </path>
+                <path id="window-rl" class="part-closed" d="M30 115 V100 L45 90 H50 V115 Z">
+                    <title>Fenster hinten links</title>
+                </path>
+                <path id="window-rr" class="part-closed" d="M50 115 V90 H55 L70 100 V115 Z">
+                    <title>Fenster hinten rechts</title>
+                </path>
+                <rect id="sunroof" class="part-closed" x="30" y="50" width="40" height="30">
+                    <title>Schiebedach</title>
+                </rect>
                 <text id="sunroof-percent" x="50" y="65" text-anchor="middle" dominant-baseline="central"></text>
-                <g id="tpms-VL" class="tpms-tire" title="Vorne links">
+                <g id="tpms-VL" class="tpms-tire">
+                    <title>Vorne links</title>
                     <circle cx="20" cy="35" r="8" />
                     <text x="20" y="35">--</text>
                 </g>
-                <g id="tpms-VR" class="tpms-tire" title="Vorne rechts">
+                <g id="tpms-VR" class="tpms-tire">
+                    <title>Vorne rechts</title>
                     <circle cx="80" cy="35" r="8" />
                     <text x="80" y="35">--</text>
                 </g>
-                <g id="tpms-HL" class="tpms-tire" title="Hinten links">
+                <g id="tpms-HL" class="tpms-tire">
+                    <title>Hinten links</title>
                     <circle cx="20" cy="170" r="8" />
                     <text x="20" y="170">--</text>
                 </g>
-                <g id="tpms-HR" class="tpms-tire" title="Hinten rechts">
+                <g id="tpms-HR" class="tpms-tire">
+                    <title>Hinten rechts</title>
                     <circle cx="80" cy="170" r="8" />
                     <text x="80" y="170">--</text>
                 </g>
-                <rect id="charge-port" class="part-closed" x="15" y="150" width="8" height="8" rx="1" ry="1" title="Ladeanschluss"/>
+                <rect id="charge-port" class="part-closed" x="15" y="150" width="8" height="8" rx="1" ry="1">
+                    <title>Ladeanschluss</title>
+                </rect>
             </svg>
         </div>
         <div id="supercharger-list"></div>


### PR DESCRIPTION
## Summary
- show tooltips for car parts by embedding <title> elements inside the SVG

## Testing
- `python -m py_compile app.py`
- `flake8 app.py` *(fails: E303, E501, E305, E128)*

------
https://chatgpt.com/codex/tasks/task_e_6851fcfbe52c83219cf638f16d8c08a7