### PR TITLE
Show previous charge energy when idle

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -581,6 +581,9 @@ function updateChargingInfo(charge) {
         if (charge.minutes_to_full_charge != null) {
             rows.push('<tr><th>Minuten bis voll:</th><td>' + Math.round(charge.minutes_to_full_charge) + ' min</td></tr>');
         }
+        if (state !== 'Charging' && lastChargeInfo && lastChargeInfo.charge_energy_added != null) {
+            rows.push('<tr><th>Beim letzten Stopp hinzugefügte Energie:</th><td>' + Number(lastChargeInfo.charge_energy_added).toFixed(2) + ' kWh</td></tr>');
+        }
     } else if (lastChargeInfo && lastChargeInfo.charge_energy_added != null) {
         rows.push('<tr><th>Beim letzten Stopp hinzugefügte Energie:</th><td>' + Number(lastChargeInfo.charge_energy_added).toFixed(2) + ' kWh</td></tr>');
     }


### PR DESCRIPTION
## Summary
- always show the previously added energy in the charging info area when not charging

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6851ff73fb308321b89ad40a467f5449