### PR TITLE
Add persistent last charge energy value

### DIFF
--- a/app.py
+++ b/app.py
@@ -466,6 +466,30 @@ def _save_cached(vehicle_id, data):
         pass
 
 
+def _last_energy_file(vehicle_id):
+    """Return filename for the last added energy of a vehicle."""
+    name = vehicle_id if vehicle_id is not None else "default"
+    return os.path.join(DATA_DIR, f"last_energy_{name}.txt")
+
+
+def _load_last_energy(vehicle_id):
+    """Load the last added energy value from disk."""
+    try:
+        with open(_last_energy_file(vehicle_id), "r", encoding="utf-8") as f:
+            return float(f.read().strip())
+    except Exception:
+        return None
+
+
+def _save_last_energy(vehicle_id, value):
+    """Persist the last added energy value for a vehicle."""
+    try:
+        with open(_last_energy_file(vehicle_id), "w", encoding="utf-8") as f:
+            f.write(str(value))
+    except Exception:
+        pass
+
+
 def _get_trip_files(directory=TRIP_DIR):
     """Return a list of available trip CSV files sorted chronologically."""
     try:
@@ -827,6 +851,9 @@ def _fetch_data_once(vehicle_id="default"):
             and charge.get("charge_energy_added") is not None
         ):
             last_val = charge.get("charge_energy_added")
+            _save_last_energy(cache_id, last_val)
+        elif last_val is None:
+            last_val = _load_last_energy(cache_id)
         if last_val is not None:
             data["last_charge_energy_added"] = last_val
         try:

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -545,9 +545,6 @@ function updateChargingInfo(charge) {
         lastChargeStop = null;
         if (charge.charge_energy_added != null && !isNaN(charge.charge_energy_added)) {
             lastEnergyAdded = Number(charge.charge_energy_added);
-            try {
-                localStorage.setItem('lastEnergyAdded', String(lastEnergyAdded));
-            } catch (e) {}
         }
     } else {
         if (lastChargeInfo && !lastChargeStop) {
@@ -555,14 +552,8 @@ function updateChargingInfo(charge) {
         }
         if (charge.charge_energy_added != null && !isNaN(charge.charge_energy_added)) {
             lastEnergyAdded = Number(charge.charge_energy_added);
-        } else if (lastEnergyAdded == null) {
-            var cached = null;
-            try {
-                cached = localStorage.getItem('lastEnergyAdded');
-            } catch (e) {}
-            if (cached != null && !isNaN(cached)) {
-                lastEnergyAdded = Number(cached);
-            }
+        } else if (lastEnergyAdded == null && charge.last_charge_energy_added != null && !isNaN(charge.last_charge_energy_added)) {
+            lastEnergyAdded = Number(charge.last_charge_energy_added);
         }
     }
 


### PR DESCRIPTION
## Summary
- keep track of the last added charge energy in a new data file
- load that value when the API cache does not contain it
- simplify client logic by relying on server-provided value

## Testing
- `pytest -q`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6852055f2b008321ae57de4f65ea6d3b