### PR TITLE
Reconnect SSE after background timeout

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -921,6 +921,7 @@ function startStream() {
     eventSource.onerror = function() {
         if (eventSource) {
             eventSource.close();
+            eventSource = null;
         }
         var url = '/api/data';
         if (currentVehicle) {
@@ -933,6 +934,10 @@ function startStream() {
         });
         // Ensure the map shows Essen if no cached data was found
         map.setView(DEFAULT_POS, DEFAULT_ZOOM);
+        // Attempt to reconnect after a short delay in case the
+        // browser has suspended the connection while running in the
+        // background.
+        setTimeout(startStream, 5000);
     };
 }
 


### PR DESCRIPTION
## Summary
- attempt to reconnect the SSE stream after it errors

## Testing
- `python -m py_compile app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685264a31b248321a2c0e7c6c028b998