### PR TITLE
Add statistics page

### DIFF
--- a/templates/statistik.html
+++ b/templates/statistik.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="de">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Statistik</title>
+    <link rel="stylesheet" href="/static/css/style.css" />
+    <style>
+        table { border-collapse: collapse; }
+        th, td { padding: 4px 8px; border: 1px solid #444; }
+    </style>
+</head>
+<body>
+    <h1>Statistik</h1>
+    <table>
+        <tr><th>Datum</th><th>Online %</th><th>Offline %</th><th>Asleep %</th><th>Gefahrene km</th></tr>
+        {% for row in rows %}
+        <tr>
+            <td>{{ row.date }}</td>
+            <td>{{ row.online }}</td>
+            <td>{{ row.offline }}</td>
+            <td>{{ row.asleep }}</td>
+            <td>{{ row.km }}</td>
+        </tr>
+        {% endfor %}
+    </table>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- record daily vehicle usage stats in a JSON file
- compute offline/online/asleep percentages and kilometers driven
- display results on new `/statistik` page

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_685292ba0de08321a9699d9cd612ee5e