### PR TITLE
Fix dynamic map zoom for string speed values

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -171,7 +171,8 @@ function handleData(data) {
     var lng = drive.longitude;
     if (lat && lng) {
         marker.setLatLng([lat, lng]);
-        var speedKmh = typeof drive.speed === 'number' ? drive.speed * MILES_TO_KM : 0;
+        var speedVal = Number(drive.speed);
+        var speedKmh = isNaN(speedVal) ? 0 : speedVal * MILES_TO_KM;
         var zoom = computeZoomForSpeed(speedKmh);
         map.setView([lat, lng], zoom);
         if (typeof drive.heading === 'number') {


### PR DESCRIPTION
## Summary
- fix speed-dependent map zoom when `drive.speed` comes as a string

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `node -e "require('fs').readFileSync('static/js/main.js')"`

------
https://chatgpt.com/codex/tasks/task_e_6852db53b898832182cf6abff9b8c6ed