### PR TITLE
Align °C units in temperature labels

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -372,6 +372,12 @@ select {
   margin-top: 2px;
 }
 
+#inside-temp-value,
+#desired-temp {
+  width: 9em;
+  text-align: right;
+}
+
 #gear-shift div {
   text-align: center;
   padding: 2px 0;


### PR DESCRIPTION
## Summary
- right-align temperature labels for inside and desired temps so the `°C` units line up

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685339a7e6fc8321a508512555d8f8fe