### PR TITLE
Adjust thermometer SVG sizing

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -373,7 +373,8 @@ select {
 }
 
 #inside-temp-value,
-#desired-temp {
+#desired-temp,
+#outside-temp-value {
   width: 9em;
   text-align: right;
 }
@@ -449,7 +450,7 @@ select {
 #thermometers svg {
   display: block;
   height: 70px;
-  width: auto;
+  width: 40px;
 }
 
 #thermometers .label {


### PR DESCRIPTION
## Summary
- keep thermometer container height as before
- expand thermometer width via CSS
- align outside temperature label to the right

## Testing
- `python -m py_compile app.py version.py`


------
https://chatgpt.com/codex/tasks/task_e_68533bf6d93083219f1c613f556e42ff