### PR TITLE
Adjust thermometer graphics

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -450,7 +450,7 @@ select {
 #thermometers svg {
   display: block;
   height: 70px;
-  width: 40px;
+  width: auto;
 }
 
 #thermometers .label {

--- a/templates/index.html
+++ b/templates/index.html
@@ -56,18 +56,18 @@
         <div id="thermometers">
             <div class="thermometer">
                 <svg width="30" height="70" viewBox="0 0 30 60">
-                    <rect x="13" y="5" width="4" height="40" class="tube" />
-                    <rect id="inside-level" x="13" y="45" width="4" height="0" class="level" />
-                    <circle id="inside-bulb" cx="15" cy="50" r="7" class="bulb" />
+                    <rect x="11" y="5" width="8" height="40" class="tube" />
+                    <rect id="inside-level" x="11" y="45" width="8" height="0" class="level" />
+                    <circle id="inside-bulb" cx="15" cy="50" r="9" class="bulb" />
                 </svg>
                 <div id="inside-temp-value" class="label">Innen: -- °C</div>
                 <div id="desired-temp" class="label" title="Wunschtemperatur">Wunsch: -- °C</div>
             </div>
             <div class="thermometer">
                 <svg width="30" height="70" viewBox="0 0 30 60">
-                    <rect x="13" y="5" width="4" height="40" class="tube" />
-                    <rect id="outside-level" x="13" y="45" width="4" height="0" class="level" />
-                    <circle id="outside-bulb" cx="15" cy="50" r="7" class="bulb" />
+                    <rect x="11" y="5" width="8" height="40" class="tube" />
+                    <rect id="outside-level" x="11" y="45" width="8" height="0" class="level" />
+                    <circle id="outside-bulb" cx="15" cy="50" r="9" class="bulb" />
                 </svg>
                 <div id="outside-temp-value" class="label">Außen: -- °C</div>
             </div>


### PR DESCRIPTION
## Summary
- widen the inner shapes of thermometer SVGs
- revert overall width so layout stays the same

## Testing
- `pytest -q`
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68533de4aa7483219456ab4fab0853cd