### PR TITLE
Fix climate indicator overlap on small screens

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -375,7 +375,7 @@ select {
 #inside-temp-value,
 #desired-temp,
 #outside-temp-value {
-  width: 9em;
+  width: 7em;
   text-align: right;
 }
 


### PR DESCRIPTION
## Summary
- adjust thermometer label width to keep climate controls from overlapping on narrow displays

## Testing
- `pytest -q`
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68534050df6c832199c0db1ec44bc9b6