### PR TITLE
Revert last PR and center climate indicator

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -341,10 +341,15 @@ select {
 }
 
 #climate-indicator {
-  display: inline-block;
+  display: inline-flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  align-self: center;
   margin: 0;
   text-align: center;
   vertical-align: top;
+  height: 110px;
 }
 
 #climate-indicator > div {
@@ -375,7 +380,7 @@ select {
 #inside-temp-value,
 #desired-temp,
 #outside-temp-value {
-  width: 7em;
+  width: 9em;
   text-align: right;
 }
 


### PR DESCRIPTION
## Summary
- revert "Fix climate indicator overlap on small screens"
- vertically center the climate indicator

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_685341f2d8b8832188c573ffbb1e096a