### PR TITLE
Send temperature as APRS telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This is a simple Flask application that displays real-time data from a Tesla veh
     ```
 
 4. Open `http://localhost:8013` in your browser (the server listens on `0.0.0.0:8013`).
-5. On the configuration page (`/config`) you can set your APRS call sign, passcode and an optional comment to transmit position packets via an EU APRS-IS server.
+5. On the configuration page (`/config`) you can set your APRS call sign, passcode and an optional comment to transmit position packets via an EU APRS-IS server. The outside temperature is also sent as APRS telemetry.
 
 API responses are logged to `data/api.log`. The log file uses rotation and will
 grow to at most 1&nbsp;MB.

--- a/app.py
+++ b/app.py
@@ -329,6 +329,7 @@ last_vehicle_state = _load_last_state()
 occupant_present = False
 _default_vehicle_id = None
 _last_aprs_info = {}
+_aprs_seq = {}
 
 
 def track_park_time(vehicle_data):
@@ -563,6 +564,16 @@ def send_aprs(vehicle_data):
             body += f" {comment}"
         packet = f"{callsign}>APRS:{body}"
         aprs.sendall(packet)
+        if temp is not None:
+            seq = (_aprs_seq.get(vid, -1) + 1) % 1000
+            _aprs_seq[vid] = seq
+            tval = int(round(temp))
+            if tval < 0:
+                tval = 0
+            elif tval > 255:
+                tval = 255
+            telem = f"T#{seq:03d},{tval:03d},000,000,000,000,00000000"
+            aprs.sendall(f"{callsign}>APRS:{telem}")
         aprs.close()
         _last_aprs_info[vid] = {
             "lat": lat,


### PR DESCRIPTION
## Summary
- support APRS telemetry by sending temperature as `T#` frame
- mention APRS telemetry in README

## Testing
- `python -m py_compile app.py version.py`

------
https://chatgpt.com/codex/tasks/task_e_685358fa5acc83218df1435aabde056a