### PR TITLE
Honor user zoom preference on map

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -19,6 +19,11 @@ var map = L.map('map').setView(DEFAULT_POS, DEFAULT_ZOOM);
 L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
     attribution: 'Kartendaten © OpenStreetMap-Mitwirkende'
 }).addTo(map);
+// Track when the user last changed the zoom level
+var lastUserZoom = 0;
+map.on('zoomend', function() {
+    lastUserZoom = Date.now();
+});
 var polyline = null;
 var lastDataTimestamp = null;
 var lastAddressLat = null;
@@ -176,6 +181,9 @@ function handleData(data) {
         var mph = !units || units.indexOf('km') === -1;
         var speedKmh = isNaN(speedVal) ? 0 : (mph ? speedVal * MILES_TO_KM : speedVal);
         var zoom = computeZoomForSpeed(speedKmh);
+        if (Date.now() - lastUserZoom < 60000) {
+            zoom = map.getZoom();
+        }
         map.setView([lat, lng], zoom);
         if (typeof drive.heading === 'number') {
             marker.setRotationAngle(drive.heading);


### PR DESCRIPTION
## Summary
- track when the user zooms the Leaflet map
- avoid changing zoom automatically for 60 seconds after manual zoom

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6853cc81bd4483218742f0625abf6ca5