### PR TITLE
Improve climate controls layout

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -367,6 +367,12 @@ select {
   font-size: 34px;
 }
 
+#climate-row {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
 #fan-status,
 #desired-temp {
   display: block;
@@ -674,7 +680,7 @@ select {
 #charge-cable {
   display: none;
   stroke: #4caf50;
-  stroke-width: 2px;
+  stroke-width: 3px;
   fill: none;
   stroke-dasharray: 5 3;
   animation: cable-flow 1s linear infinite;

--- a/templates/index.html
+++ b/templates/index.html
@@ -74,8 +74,10 @@
         </div>
         <div id="climate-indicator">
             <div id="climate-status" title="Klimaanlage aus">🚫</div>
-            <div id="climate-mode" title=""></div>
-            <div id="cabin-protection" title=""></div>
+            <div id="climate-row">
+                <div id="climate-mode" title=""></div>
+                <div id="cabin-protection" title=""></div>
+            </div>
             <div id="fan-status" title="Lüfterstufe">🌀 0</div>
         </div>
         <div id="openings-indicator">
@@ -142,7 +144,7 @@
                 <rect id="charge-port" class="part-closed" x="15" y="150" width="8" height="8" rx="1" ry="1">
                     <title>Ladeanschluss</title>
                 </rect>
-                <path id="charge-cable" d="M15 154 h -12 v -20" />
+                <path id="charge-cable" d="M15 154 q -5 5 -10 10 q 5 5 10 10 q -5 5 -10 10 q 5 5 10 10" />
             </svg>
         </div>
         <div id="supercharger-list"></div>


### PR DESCRIPTION
## Summary
- keep `climate-mode` and `cabin-protection` together on one row
- curve and extend the `charge-cable` path with multiple waves
- make the cable slightly thicker

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6853d12af2f48321a29bcd31fd38a196