### PR TITLE
Hide energy row while charging

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -638,7 +638,7 @@ function updateChargingInfo(charge) {
         if (state !== 'Charging' && lastEnergyAdded != null) {
             rows.push('<tr><th>Zuletzt hinzugefügte Energie:</th><td>' + lastEnergyAdded.toFixed(2) + ' kWh</td></tr>');
         }
-    } else if (lastEnergyAdded != null) {
+    } else if (state !== 'Charging' && lastEnergyAdded != null) {
         rows.push('<tr><th>Zuletzt hinzugefügte Energie:</th><td>' + lastEnergyAdded.toFixed(2) + ' kWh</td></tr>');
     }
 


### PR DESCRIPTION
## Summary
- suppress the "Zuletzt hinzugefügte Energie" row while the vehicle is actively charging

## Testing
- `pytest -q`
- `npm test` *(fails: package.json missing)*
- `flake8`


------
https://chatgpt.com/codex/tasks/task_e_6853d6a05b088321be811fd5c31b308e