### PR TITLE
Add heater status graphics

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -386,6 +386,18 @@ select {
   display: block;
 }
 
+#heater-indicator {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 2px 4px;
+  margin-top: 4px;
+}
+#heater-indicator div {
+  font-size: 20px;
+}
+
 #climate-status,
 #climate-mode,
 #cabin-protection {

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -176,6 +176,19 @@ function handleData(data) {
     updateCabinProtection(climate.cabin_overheat_protection);
     updateFanStatus(climate.fan_status);
     updateDesiredTemp(climate.driver_temp_setting);
+    updateHeaterIndicator(
+        climate.is_front_defroster_on,
+        climate.is_rear_defroster_on,
+        climate.steering_wheel_heater,
+        climate.wiper_blade_heater,
+        climate.side_mirror_heaters,
+        charge.battery_heater_on,
+        climate.seat_heater_left,
+        climate.seat_heater_right,
+        climate.seat_heater_rear_left,
+        climate.seat_heater_rear_center,
+        climate.seat_heater_rear_right
+    );
     updateTPMS(vehicle.tpms_pressure_fl,
                vehicle.tpms_pressure_fr,
                vehicle.tpms_pressure_rl,
@@ -367,6 +380,51 @@ function updateDesiredTemp(temp) {
     }
     $('#desired-temp').text('Wunsch: ' + temp.toFixed(1) + ' \u00B0C')
         .attr('title', 'Wunschtemperatur');
+}
+
+function updateHeaterIndicator(front, rear, steering, wiper,
+                               mirror, battery,
+                               seatL, seatR, seatRL, seatRC, seatRR) {
+    function set(id, val, name) {
+        if (val == null) {
+            $('#' + id).text('\uD83D\uDEAB').attr('title', name + ' unbekannt');
+            return;
+        }
+        var active = false;
+        if (typeof val === 'string') {
+            var norm = val.toLowerCase();
+            active = norm === 'true' || norm === '1';
+        } else {
+            active = !!val;
+        }
+        $('#' + id).text(active ? '\uD83D\uDD25' : '\uD83D\uDEAB')
+            .attr('title', name + (active ? ' an' : ' aus'));
+    }
+    function setLevel(id, val, name) {
+        if (val == null || isNaN(val)) {
+            $('#' + id).text('\uD83D\uDEAB').attr('title', name + ' unbekannt');
+            return;
+        }
+        var level = Number(val);
+        if (level <= 0) {
+            $('#' + id).text('\uD83D\uDEAB').attr('title', name + ' aus');
+        } else {
+            $('#' + id).text('\uD83D\uDD25' + level)
+                .attr('title', name + ' Stufe ' + level);
+        }
+    }
+
+    set('front-defrost', front, 'Frontscheibenheizung');
+    set('rear-defrost', rear, 'Heckscheibenheizung');
+    set('steering-heater', steering, 'Lenkradheizung');
+    set('wiper-heater', wiper, 'Scheibenwischerheizung');
+    set('mirror-heater', mirror, 'Seitenspiegelheizung');
+    set('battery-heater', battery, 'Batterieheizung');
+    setLevel('seat-left', seatL, 'Sitzheizung Fahrer');
+    setLevel('seat-right', seatR, 'Sitzheizung Beifahrer');
+    setLevel('seat-rear-left', seatRL, 'Sitzheizung hinten links');
+    setLevel('seat-rear-center', seatRC, 'Sitzheizung hinten Mitte');
+    setLevel('seat-rear-right', seatRR, 'Sitzheizung hinten rechts');
 }
 
 function updateTPMS(fl, fr, rl, rr) {

--- a/templates/index.html
+++ b/templates/index.html
@@ -79,6 +79,19 @@
                 <div id="cabin-protection" title=""></div>
             </div>
             <div id="fan-status" title="Lüfterstufe">🌀 0</div>
+            <div id="heater-indicator">
+                <div id="front-defrost" title="Frontscheibenheizung"></div>
+                <div id="rear-defrost" title="Heckscheibenheizung"></div>
+                <div id="steering-heater" title="Lenkradheizung"></div>
+                <div id="wiper-heater" title="Scheibenwischerheizung"></div>
+                <div id="mirror-heater" title="Seitenspiegelheizung"></div>
+                <div id="battery-heater" title="Batterieheizung"></div>
+                <div id="seat-left" title="Sitzheizung Fahrer"></div>
+                <div id="seat-right" title="Sitzheizung Beifahrer"></div>
+                <div id="seat-rear-left" title="Sitzheizung hinten links"></div>
+                <div id="seat-rear-center" title="Sitzheizung hinten Mitte"></div>
+                <div id="seat-rear-right" title="Sitzheizung hinten rechts"></div>
+            </div>
         </div>
         <div id="openings-indicator">
             <svg viewBox="0 0 100 200">


### PR DESCRIPTION
## Summary
- add battery, mirror and seat heating status to indicator
- allow wrapping icons and smaller font
- track seat heater levels

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6853dabca59c83219755468ae037dff4