### PR TITLE
Improve heater indicator layout and labeling

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -396,6 +396,10 @@ select {
 }
 #heater-indicator div {
   font-size: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  white-space: nowrap;
 }
 
 #climate-status,
@@ -546,6 +550,9 @@ select {
   #status-bar {
     flex-wrap: wrap;
     gap: 10px;
+  }
+  #heater-indicator {
+    flex-direction: column;
   }
   #map {
     height: 50vh !important;

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -387,7 +387,8 @@ function updateHeaterIndicator(front, rear, steering, wiper,
                                seatL, seatR, seatRL, seatRC, seatRR) {
     function set(id, val, name) {
         if (val == null) {
-            $('#' + id).text('\uD83D\uDEAB').attr('title', name + ' unbekannt');
+            $('#' + id).html(name + ': \uD83D\uDEAB')
+                .attr('title', name + ' unbekannt');
             return;
         }
         var active = false;
@@ -397,19 +398,21 @@ function updateHeaterIndicator(front, rear, steering, wiper,
         } else {
             active = !!val;
         }
-        $('#' + id).text(active ? '\uD83D\uDD25' : '\uD83D\uDEAB')
+        $('#' + id).html(name + ': ' + (active ? '\uD83D\uDD25' : '\uD83D\uDEAB'))
             .attr('title', name + (active ? ' an' : ' aus'));
     }
     function setLevel(id, val, name) {
         if (val == null || isNaN(val)) {
-            $('#' + id).text('\uD83D\uDEAB').attr('title', name + ' unbekannt');
+            $('#' + id).html(name + ': \uD83D\uDEAB')
+                .attr('title', name + ' unbekannt');
             return;
         }
         var level = Number(val);
         if (level <= 0) {
-            $('#' + id).text('\uD83D\uDEAB').attr('title', name + ' aus');
+            $('#' + id).html(name + ': \uD83D\uDEAB')
+                .attr('title', name + ' aus');
         } else {
-            $('#' + id).text('\uD83D\uDD25' + level)
+            $('#' + id).html(name + ': \uD83D\uDD25' + level)
                 .attr('title', name + ' Stufe ' + level);
         }
     }

--- a/templates/index.html
+++ b/templates/index.html
@@ -79,19 +79,19 @@
                 <div id="cabin-protection" title=""></div>
             </div>
             <div id="fan-status" title="Lüfterstufe">🌀 0</div>
-            <div id="heater-indicator">
-                <div id="front-defrost" title="Frontscheibenheizung"></div>
-                <div id="rear-defrost" title="Heckscheibenheizung"></div>
-                <div id="steering-heater" title="Lenkradheizung"></div>
-                <div id="wiper-heater" title="Scheibenwischerheizung"></div>
-                <div id="mirror-heater" title="Seitenspiegelheizung"></div>
-                <div id="battery-heater" title="Batterieheizung"></div>
-                <div id="seat-left" title="Sitzheizung Fahrer"></div>
-                <div id="seat-right" title="Sitzheizung Beifahrer"></div>
-                <div id="seat-rear-left" title="Sitzheizung hinten links"></div>
-                <div id="seat-rear-center" title="Sitzheizung hinten Mitte"></div>
-                <div id="seat-rear-right" title="Sitzheizung hinten rechts"></div>
-            </div>
+        </div>
+        <div id="heater-indicator">
+            <div id="front-defrost" title="Frontscheibenheizung"></div>
+            <div id="rear-defrost" title="Heckscheibenheizung"></div>
+            <div id="steering-heater" title="Lenkradheizung"></div>
+            <div id="wiper-heater" title="Scheibenwischerheizung"></div>
+            <div id="mirror-heater" title="Seitenspiegelheizung"></div>
+            <div id="battery-heater" title="Batterieheizung"></div>
+            <div id="seat-left" title="Sitzheizung Fahrer"></div>
+            <div id="seat-right" title="Sitzheizung Beifahrer"></div>
+            <div id="seat-rear-left" title="Sitzheizung hinten links"></div>
+            <div id="seat-rear-center" title="Sitzheizung hinten Mitte"></div>
+            <div id="seat-rear-right" title="Sitzheizung hinten rechts"></div>
         </div>
         <div id="openings-indicator">
             <svg viewBox="0 0 100 200">


### PR DESCRIPTION
## Summary
- move heater indicator outside of climate block
- add text descriptions before each heater icon
- adjust heater label JS
- improve heater indicator styles
- stack heater icons vertically on small screens

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6853df4686dc8321a98a5eab509b04d7