### PR TITLE
Rearrange heater indicator

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -69,10 +69,26 @@ select {
 #map {
   position: relative;
   height: 400px;
-  margin-top: 10px;
+  margin-top: 0;
   border-radius: 8px;
   overflow: hidden;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.4);
+}
+
+#map-container {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  width: 100%;
+  margin-top: 10px;
+}
+
+#map-container #map {
+  flex: 3;
+}
+
+#map-container #heater-indicator {
+  flex: 1;
 }
 
 #location-address {
@@ -388,11 +404,11 @@ select {
 
 #heater-indicator {
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
-  flex-wrap: wrap;
   gap: 2px 4px;
-  margin-top: 4px;
+  margin-top: 0;
 }
 #heater-indicator div {
   font-size: 20px;

--- a/templates/index.html
+++ b/templates/index.html
@@ -15,8 +15,23 @@
     <div id="dashboard-content">
         <label for="vehicle-select">Fahrzeug auswählen:</label>
         <select id="vehicle-select"></select>
-        <div id="map">
-            <div id="location-address"><div id="address-text"></div><div id="road-type"></div></div>
+        <div id="map-container">
+            <div id="map">
+                <div id="location-address"><div id="address-text"></div><div id="road-type"></div></div>
+            </div>
+            <div id="heater-indicator">
+                <div id="front-defrost" title="Frontscheibenheizung"></div>
+                <div id="rear-defrost" title="Heckscheibenheizung"></div>
+                <div id="steering-heater" title="Lenkradheizung"></div>
+                <div id="wiper-heater" title="Scheibenwischerheizung"></div>
+                <div id="mirror-heater" title="Seitenspiegelheizung"></div>
+                <div id="battery-heater" title="Batterieheizung"></div>
+                <div id="seat-left" title="Sitzheizung Fahrer"></div>
+                <div id="seat-right" title="Sitzheizung Beifahrer"></div>
+                <div id="seat-rear-left" title="Sitzheizung hinten links"></div>
+                <div id="seat-rear-center" title="Sitzheizung hinten Mitte"></div>
+                <div id="seat-rear-right" title="Sitzheizung hinten rechts"></div>
+            </div>
         </div>
     <div id="status-bar">
         <div id="lock-container">
@@ -79,19 +94,6 @@
                 <div id="cabin-protection" title=""></div>
             </div>
             <div id="fan-status" title="Lüfterstufe">🌀 0</div>
-        </div>
-        <div id="heater-indicator">
-            <div id="front-defrost" title="Frontscheibenheizung"></div>
-            <div id="rear-defrost" title="Heckscheibenheizung"></div>
-            <div id="steering-heater" title="Lenkradheizung"></div>
-            <div id="wiper-heater" title="Scheibenwischerheizung"></div>
-            <div id="mirror-heater" title="Seitenspiegelheizung"></div>
-            <div id="battery-heater" title="Batterieheizung"></div>
-            <div id="seat-left" title="Sitzheizung Fahrer"></div>
-            <div id="seat-right" title="Sitzheizung Beifahrer"></div>
-            <div id="seat-rear-left" title="Sitzheizung hinten links"></div>
-            <div id="seat-rear-center" title="Sitzheizung hinten Mitte"></div>
-            <div id="seat-rear-right" title="Sitzheizung hinten rechts"></div>
         </div>
         <div id="openings-indicator">
             <svg viewBox="0 0 100 200">


### PR DESCRIPTION
## Summary
- place heater indicator next to the map
- adjust CSS layout so the map and heater indicator share width
- align heater indicator icons vertically

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6853e2803f408321aa9cf7e225a1f98f