### PR TITLE
Fix heater indicator alignment

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -88,8 +88,9 @@ select {
 }
 
 #map-container #heater-indicator {
-  flex: 1;
+  flex: 0 0 auto;
   margin-left: auto;
+  margin-right: 20px;
 }
 
 #location-address {


### PR DESCRIPTION
## Summary
- adjust heater indicator flex settings
- add a right margin for spacing from the edge

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853e61a8ecc8321b4f34269ce52e72c