### PR TITLE
Fix heater indicator text alignment

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -407,10 +407,11 @@ select {
 #heater-indicator {
   display: flex;
   flex-direction: column;
-  align-items: center;
+  align-items: flex-end;
   justify-content: center;
   gap: 2px 4px;
   margin-top: 0;
+  text-align: right;
 }
 #heater-indicator div {
   font-size: 20px;


### PR DESCRIPTION
## Summary
- align heater indicator text to the right via CSS

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6853e7d5d12c8321ae6904e94e169723