### PR TITLE
Fix heater indicator stacking on narrow screens

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -576,6 +576,13 @@ select {
     flex-wrap: wrap;
     gap: 10px;
   }
+  #map-container {
+    flex-direction: column;
+  }
+  #map-container #heater-indicator {
+    margin-left: 0;
+    margin-right: 0;
+  }
   #heater-indicator {
     flex-direction: column;
   }


### PR DESCRIPTION
## Summary
- put the heater indicator below the map on small screens

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6853e948fe908321aff714158a3dab6b