### PR TITLE
Fix mobile map display order

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -579,7 +579,12 @@ select {
   #map-container {
     flex-direction: column;
   }
+  /* Ensure map appears above the heater indicator on small screens */
+  #map-container #map {
+    order: 1;
+  }
   #map-container #heater-indicator {
+    order: 2;
     margin-left: 0;
     margin-right: 0;
   }


### PR DESCRIPTION
## Summary
- ensure map shows above heater controls on mobile

## Testing
- `python -m py_compile app.py version.py`

------
https://chatgpt.com/codex/tasks/task_e_6853eae64e808321b1317596a08b5a80