### PR TITLE
Fix mobile map display

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -576,15 +576,15 @@ select {
     flex-wrap: wrap;
     gap: 10px;
   }
+  /* Break layout and stack map and heater indicator */
   #map-container {
-    flex-direction: column;
+    display: block;
   }
-  /* Ensure map appears above the heater indicator on small screens */
-  #map-container #map {
-    order: 1;
+  #map-container #map,
+  #map-container #heater-indicator {
+    width: 100%;
   }
   #map-container #heater-indicator {
-    order: 2;
     margin-left: 0;
     margin-right: 0;
   }


### PR DESCRIPTION
## Summary
- adjust mobile CSS to stack map and heater indicator blocks

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6853ee036d4c8321a42c81b352d0f2df