### PR TITLE
Fix header span order on desktop

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -112,9 +112,11 @@ select {
   font-size: 0.9em;
 }
 
-#vehicle-info,
-#vehicle-status {
+#header-right {
   float: right;
+}
+
+#header-right span {
   margin-left: 10px;
 }
 
@@ -566,12 +568,14 @@ select {
 
 /* Responsive adjustments */
 @media (max-width: 600px) {
-  #vehicle-info,
-  #vehicle-status {
+  #header-right {
     float: none;
     display: block;
-    margin-left: 0;
     text-align: right;
+  }
+  #header-right span {
+    display: block;
+    margin-left: 0;
   }
   #status-bar {
     flex-wrap: wrap;

--- a/templates/index.html
+++ b/templates/index.html
@@ -11,7 +11,11 @@
     <script src="/static/js/leaflet.rotatedMarker.js"></script>
 </head>
 <body>
-    <h1>Tesla-Dashboard V{{ version }} <span id="vehicle-info"></span>&nbsp;&nbsp;&nbsp;<span id="vehicle-status"></span></h1>
+    <h1>Tesla-Dashboard V{{ version }}
+        <span id="header-right">
+            <span id="vehicle-info"></span>&nbsp;&nbsp;&nbsp;<span id="vehicle-status"></span>
+        </span>
+    </h1>
     <div id="dashboard-content">
         <label for="vehicle-select">Fahrzeug auswählen:</label>
         <select id="vehicle-select"></select>


### PR DESCRIPTION
## Summary
- wrap vehicle info and status spans in a new `header-right` container
- style header spans via container so order is preserved on desktop

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853f202a42c832192a0bcc546901aa5