### PR TITLE
Store state log timestamps in local time

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ This is a simple Flask application that displays real-time data from a Tesla veh
 API responses are logged to `data/api.log`. The log file uses rotation and will
 grow to at most 1&nbsp;MB.
 Vehicle state changes are written to `data/state.log`.
+Timestamps in this file are recorded in local time.
 The latest successful API response is stored in `data/cache_<vehicle_id>.json`.
 This cache is always updated with the current vehicle state so the dashboard
 knows whether the car is online, asleep or offline even when no fresh data is

--- a/app.py
+++ b/app.py
@@ -63,6 +63,7 @@ if not state_logger.handlers:
         os.path.join(DATA_DIR, "state.log"), maxBytes=100_000, backupCount=1
     )
     formatter = logging.Formatter("%(asctime)s %(message)s")
+    formatter.converter = time.localtime  # store timestamps in local time
     handler.setFormatter(formatter)
     state_logger.addHandler(handler)
     state_logger.setLevel(logging.INFO)


### PR DESCRIPTION
## Summary
- ensure state.log entries use local time
- document that state.log keeps timestamps in local time

## Testing
- `python -m py_compile app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854182bd0188321b8f7479ad4ccb4d7