### PR TITLE
Show cached data when vehicle offline

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -42,13 +42,6 @@ select {
   padding: 0 1rem;
 }
 
-#sleep-msg {
-  display: none;
-  text-align: center;
-  font-size: 1.2em;
-  margin: 20px;
-  color: var(--accent-color);
-}
 
 #offline-msg {
   display: none;

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -42,7 +42,6 @@ var lastAddressLat = null;
 var lastAddressLng = null;
 var CONFIG = {};
 var HIGHLIGHT_BLUE = false;
-var ASLEEP = false;
 var OFFLINE_TEXT = 'Das Fahrzeug ist offline und schläft - Bitte nicht wecken! - Die Daten sind die zuletzt bekannten und somit nicht aktuell!';
 
 function applyConfig(cfg) {
@@ -60,15 +59,6 @@ function showConfigured() {
     $('#dashboard-content').show();
     // Recalculate map dimensions when the content becomes visible.
     map.invalidateSize();
-    $('#sleep-msg').hide();
-    ASLEEP = false;
-}
-
-function hideForSleep() {
-    $('#dashboard-content').hide();
-    $('#sleep-msg').show();
-    $('#loading-msg').hide();
-    ASLEEP = true;
 }
 
 function showLoading() {
@@ -1036,15 +1026,11 @@ function startStream() {
             var st = resp.state;
             updateVehicleState(st);
             updateOfflineInfo(st);
-            if (st === 'online') {
-                $.getJSON('/api/data/' + currentVehicle, function(data) {
-                    if (data && !data.error) {
-                        handleData(data);
-                    }
-                });
-            } else {
-                hideForSleep();
-            }
+            $.getJSON('/api/data/' + currentVehicle, function(data) {
+                if (data && !data.error) {
+                    handleData(data);
+                }
+            });
         });
         // Ensure the map shows Essen if no cached data was found
         map.setView(DEFAULT_POS, DEFAULT_ZOOM);
@@ -1065,9 +1051,12 @@ function startStreamIfOnline() {
         updateOfflineInfo(st);
         if (st === 'online') {
             startStream();
-        } else {
-            hideForSleep();
         }
+        $.getJSON('/api/data/' + currentVehicle, function(data) {
+            if (data && !data.error) {
+                handleData(data);
+            }
+        });
     });
 }
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -178,7 +178,6 @@
     <div id="nav-bar"></div>
     <div id="media-player"></div>
     </div>
-    <div id="sleep-msg">Das Fahrzeug schläft.</div>
 
     <footer class="app-version">
         <span id="vehicle-state"></span>


### PR DESCRIPTION
## Summary
- remove sleep message
- keep dashboard visible when vehicle is asleep
- always fetch cached data if vehicle is not online

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68541f5936ec8321b87b343417bc0a85