### PR TITLE
Fix client count display while offline

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -1049,9 +1049,7 @@ function startStreamIfOnline() {
         var st = resp.state;
         updateVehicleState(st);
         updateOfflineInfo(st);
-        if (st === 'online') {
-            startStream();
-        }
+        startStream();
         $.getJSON('/api/data/' + currentVehicle, function(data) {
             if (data && !data.error) {
                 handleData(data);


### PR DESCRIPTION
## Summary
- ensure the streaming connection is started even when the vehicle is asleep/offline

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685422c4ac9c83219cf0d0337033c207