### PR TITLE
Fix zoom overlay

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -24,6 +24,7 @@
         <div id="map-container">
             <div id="map">
                 <div id="location-address"><div id="address-text"></div></div>
+                <div id="zoom-level"></div>
             </div>
             <div id="heater-indicator">
                 <div id="front-defrost" title="Frontscheibenheizung"></div>


### PR DESCRIPTION
## Summary
- show map zoom overlay on dashboard page

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685424857b808321924bfcdd9b0a2c4d