### PR TITLE
Fix state log timezone

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,9 @@ This is a simple Flask application that displays real-time data from a Tesla veh
 4. Open `http://localhost:8013` in your browser (the server listens on `0.0.0.0:8013`).
 5. On the configuration page (`/config`) you can set your APRS call sign, passcode and an optional comment to transmit position packets via an EU APRS-IS server. The outside temperature is appended to the APRS comment in Fahrenheit using the `/tXXX` format (e.g. `/t068`). Positions are sent at most every 10 seconds while driving and at least every 10 minutes even without changes.
 
-API responses are logged to `data/api.log`. The log file uses rotation and will
-grow to at most 1&nbsp;MB.
+API responses are logged to `data/api.log`. The log file uses rotation and will grow to at most 1&nbsp;MB.
 Vehicle state changes are written to `data/state.log`.
-Timestamps in this file are recorded in local time.
+Timestamps in this file are recorded in the Europe/Berlin timezone.
 The latest successful API response is stored in `data/cache_<vehicle_id>.json`.
 This cache is always updated with the current vehicle state so the dashboard
 knows whether the car is online, asleep or offline even when no fresh data is


### PR DESCRIPTION
## Summary
- ensure state log timestamps use the Europe/Berlin timezone
- document timezone behavior in README

## Testing
- `python -m py_compile app.py`
- `flake8 app.py` *(fails: E501, F824 and other style errors)*

------
https://chatgpt.com/codex/tasks/task_e_68542bb3ad8c8321b7fb3ba6286e109d