### PR TITLE
Update zoom level position on map

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -105,8 +105,8 @@ select {
 /* Overlay showing the current map zoom level */
 #zoom-level {
   position: absolute;
-  left: 10px;
-  bottom: 24px;
+  left: 2px;
+  bottom: 2px;
   background: rgba(0, 0, 0, 0.6);
   color: #fff;
   padding: 2px 6px;


### PR DESCRIPTION
## Summary
- move the map zoom level overlay to the bottom-left corner

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685432bca7c88321837bfefa632e00bb