### PR TITLE
Fix immediate zoom update when speed changes

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -208,10 +208,10 @@ function handleData(data) {
         var mph = !units || units.indexOf('km') === -1;
         var speedKmh = isNaN(speedVal) ? 0 : (mph ? speedVal * MILES_TO_KM : speedVal);
         var zoom = computeZoomForSpeed(speedKmh);
-        if (Date.now() - lastUserZoom < 60000) {
-            zoom = map.getZoom();
+        if (map.getZoom() !== zoom) {
+            map.setZoom(zoom);
         }
-        map.setView([lat, lng], zoom);
+        map.panTo([lat, lng]);
         if (typeof drive.heading === 'number') {
             marker.setRotationAngle(drive.heading);
         }


### PR DESCRIPTION
## Summary
- adjust zoom as soon as speed-based threshold is reached by updating the map's zoom each update

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685447d89c90832186cf0dc186fb5381