### PR TITLE
Adjust APRS transmit interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This is a simple Flask application that displays real-time data from a Tesla veh
     ```
 
 4. Open `http://localhost:8013` in your browser (the server listens on `0.0.0.0:8013`).
-5. On the configuration page (`/config`) you can set your APRS call sign, passcode and an optional comment to transmit position packets via an EU APRS-IS server. The outside temperature is appended to the APRS comment in Fahrenheit using the `/tXXX` format (e.g. `/t068`). Positions are sent at most every 10 seconds while driving and at least every 10 minutes even without changes.
+5. On the configuration page (`/config`) you can set your APRS call sign, passcode and an optional comment to transmit position packets via an EU APRS-IS server. The outside temperature is appended to the APRS comment in Fahrenheit using the `/tXXX` format (e.g. `/t068`). Positions are sent at most every 30 seconds while driving and at least every 10 minutes even without changes.
 
 API responses are logged to `data/api.log`. The log file uses rotation and will grow to at most 1&nbsp;MB.
 Vehicle state changes are written to `data/state.log`.

--- a/app.py
+++ b/app.py
@@ -546,7 +546,7 @@ def send_aprs(vehicle_data):
             changed = True
         if now - last.get("time", 0) >= 600:
             changed = True
-        if now - last.get("time", 0) < 10:
+        if now - last.get("time", 0) < 30:
             return
     if not changed:
         return


### PR DESCRIPTION
## Summary
- send APRS packets no more than every 30 seconds
- document new APRS timing

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6855333a23288321b05c27a451fb37b0