### PR TITLE
Add APRS WX packet configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This is a simple Flask application that displays real-time data from a Tesla veh
     ```
 
 4. Open `http://localhost:8013` in your browser (the server listens on `0.0.0.0:8013`).
-5. On the configuration page (`/config`) you can set your APRS call sign, passcode and an optional comment to transmit position packets via an EU APRS-IS server. The outside temperature is appended to the APRS comment in Fahrenheit using the `/tXXX` format (e.g. `/t068`). Positions are sent at most every 30 seconds while driving and at least every 10 minutes even without changes.
+5. On the configuration page (`/config`) you can set your APRS call sign, passcode and an optional comment to transmit position packets via an EU APRS-IS server. You may also enable an additional WX packet using a separate call sign. Temperatures are included in Celsius within the comment. Positions are sent at most every 30 seconds while driving and at least every 10 minutes even without changes.
 
 API responses are logged to `data/api.log`. The log file uses rotation and will grow to at most 1&nbsp;MB.
 Vehicle state changes are written to `data/state.log`.

--- a/templates/config.html
+++ b/templates/config.html
@@ -34,6 +34,18 @@
         </div>
         <div>
             <label>
+                <input type="checkbox" name="aprs_wx_enabled" value="1" {% if config.get('aprs_wx_enabled', True) %}checked{% endif %}>
+                APRS WX-Paket senden
+            </label>
+        </div>
+        <div>
+            <label>
+                APRS WX Rufzeichen
+                <input type="text" name="aprs_wx_callsign" value="{{ config.get('aprs_wx_callsign','') }}">
+            </label>
+        </div>
+        <div>
+            <label>
                 APRS Kommentar
                 <input type="text" name="aprs_comment" value="{{ config.get('aprs_comment','') }}">
             </label>


### PR DESCRIPTION
## Summary
- support WX packets in `send_aprs`
- handle new APRS settings on the config page
- expose new inputs for WX packets in template
- update README with updated APRS instructions

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6855f47dfdf4832199af57aa49c2c9f2