### PR TITLE
Fix supercharger list position

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -74,6 +74,7 @@ select {
   gap: 10px;
   width: 100%;
   margin-top: 10px;
+  flex-wrap: wrap;
 }
 
 #map-container #map {
@@ -229,7 +230,8 @@ select {
 }
 
 #supercharger-list {
-  margin-left: auto;
+  width: 100%;
+  margin: 10px 0 0;
   text-align: left;
   font-size: 0.9em;
 }


### PR DESCRIPTION
## Summary
- ensure `#map-container` wraps its children
- give `#supercharger-list` full width and margin

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6855f9dd454483219868a62a15dc4d7c