### PR TITLE
Fix map marker centering

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -215,7 +215,7 @@ function handleData(data) {
     var slide = false;
     if (lat && lng) {
         if (typeof marker.slideTo === 'function') {
-            marker.slideTo([lat, lng], {duration: 1000});
+            marker.slideTo([lat, lng], {duration: 1000, keepAtCenter: true});
             slide = true;
         } else {
             marker.setLatLng([lat, lng]);


### PR DESCRIPTION
## Summary
- keep the map marker centered during sliding animations

## Testing
- `python -m py_compile app.py version.py`

------
https://chatgpt.com/codex/tasks/task_e_6855fee651b883218a4da3b022da7f67