### PR TITLE
Revert marker slide option and maintain center on resize

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -23,6 +23,17 @@ L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
 $(window).on('resize', function() {
     map.invalidateSize();
 });
+// Keep marker centered if the map container size changes (e.g., side panels)
+var mapEl = document.getElementById('map');
+if (window.ResizeObserver && mapEl) {
+    var mapResizeObserver = new ResizeObserver(function() {
+        map.invalidateSize();
+        if (typeof marker !== 'undefined' && marker.getLatLng) {
+            map.setView(marker.getLatLng(), map.getZoom(), {animate: false});
+        }
+    });
+    mapResizeObserver.observe(mapEl);
+}
 // Track when the user last changed the zoom level
 var lastUserZoom = 0;
 var $zoomLevel = $('#zoom-level');
@@ -215,7 +226,7 @@ function handleData(data) {
     var slide = false;
     if (lat && lng) {
         if (typeof marker.slideTo === 'function') {
-            marker.slideTo([lat, lng], {duration: 1000, keepAtCenter: true});
+            marker.slideTo([lat, lng], {duration: 1000});
             slide = true;
         } else {
             marker.setLatLng([lat, lng]);


### PR DESCRIPTION
## Summary
- revert the marker slideTo `keepAtCenter` option
- keep the marker centered by observing map container resize

## Testing
- `python -m py_compile app.py`
- `python -m py_compile version.py`
- `node --check static/js/main.js`
- `node --check static/js/Leaflet.Marker.SlideTo.js`
- `node --check static/js/jquery.min.js 2>/dev/null`

------
https://chatgpt.com/codex/tasks/task_e_6856011dae3883219518f3023f0ccac3