### PR TITLE
Update layout to move Supercharger list

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -81,7 +81,9 @@ select {
   flex: 3;
 }
 
-#map-container #heater-indicator {
+#map-container #sidebar-right {
+  display: flex;
+  flex-direction: column;
   flex: 0 0 auto;
   margin-left: auto;
   margin-right: 20px;
@@ -230,7 +232,7 @@ select {
 }
 
 #supercharger-list {
-  width: 100%;
+  width: auto;
   margin: 10px 0 0;
   text-align: left;
   font-size: 0.9em;
@@ -589,15 +591,15 @@ select {
     flex-wrap: wrap;
     gap: 10px;
   }
-  /* Break layout and stack map and heater indicator */
+  /* Break layout and stack map and sidebar */
   #map-container {
     display: block;
   }
   #map-container #map,
-  #map-container #heater-indicator {
+  #map-container #sidebar-right {
     width: 100%;
   }
-  #map-container #heater-indicator {
+  #map-container #sidebar-right {
     margin-left: 0;
     margin-right: 0;
   }

--- a/templates/index.html
+++ b/templates/index.html
@@ -27,21 +27,23 @@
                 <div id="location-address"><div id="address-text"></div></div>
                 <div id="zoom-level"></div>
             </div>
-            <div id="heater-indicator">
-                <div id="front-defrost" title="Frontscheibenheizung"></div>
-                <div id="rear-defrost" title="Heckscheibenheizung"></div>
-                <div id="steering-heater" title="Lenkradheizung"></div>
-                <div id="wiper-heater" title="Scheibenwischerheizung"></div>
-                <div id="mirror-heater" title="Seitenspiegelheizung"></div>
-                <div id="battery-heater" title="Batterieheizung"></div>
-                <hr />
-                <div id="seat-left" title="Sitzheizung Fahrer"></div>
-                <div id="seat-right" title="Sitzheizung Beifahrer"></div>
-                <div id="seat-rear-left" title="Sitzheizung hinten links"></div>
-                <div id="seat-rear-center" title="Sitzheizung hinten Mitte"></div>
-                <div id="seat-rear-right" title="Sitzheizung hinten rechts"></div>
+            <div id="sidebar-right">
+                <div id="heater-indicator">
+                    <div id="front-defrost" title="Frontscheibenheizung"></div>
+                    <div id="rear-defrost" title="Heckscheibenheizung"></div>
+                    <div id="steering-heater" title="Lenkradheizung"></div>
+                    <div id="wiper-heater" title="Scheibenwischerheizung"></div>
+                    <div id="mirror-heater" title="Seitenspiegelheizung"></div>
+                    <div id="battery-heater" title="Batterieheizung"></div>
+                    <hr />
+                    <div id="seat-left" title="Sitzheizung Fahrer"></div>
+                    <div id="seat-right" title="Sitzheizung Beifahrer"></div>
+                    <div id="seat-rear-left" title="Sitzheizung hinten links"></div>
+                    <div id="seat-rear-center" title="Sitzheizung hinten Mitte"></div>
+                    <div id="seat-rear-right" title="Sitzheizung hinten rechts"></div>
+                </div>
+                <div id="supercharger-list"></div>
             </div>
-            <div id="supercharger-list"></div>
         </div>
     <div id="status-bar">
         <div id="lock-container">


### PR DESCRIPTION
## Summary
- adjust HTML layout to place Supercharger list beside the map
- add sidebar-right styles and responsive rules
- tweak Supercharger list width

## Testing
- `python -m py_compile app.py version.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68564e35388c83218d93f91663d6dbb0