### PR TITLE
Fix battery indicator scaling

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -136,6 +136,7 @@ select {
   display: inline-block;
   margin-right: 5px;
   position: relative;
+  overflow: hidden;
 }
 
 .battery-block {
@@ -152,7 +153,7 @@ select {
   position: absolute;
   bottom: 0;
   width: 100%;
-  height: 0;
+  height: 100%;
   background: linear-gradient(
     to top,
     #f44336 0%,

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -619,8 +619,9 @@ function updateBatteryIndicator(level, rangeMiles, chargingState, heaterOn) {
     var range = rangeMiles != null ? Math.round(rangeMiles * MILES_TO_KM) : '?';
     var charging = chargingState === 'Charging';
     var heating = !!heaterOn;
+    var clip = 'clip-path: inset(' + (100 - pct) + '% 0 0 0)';
     var html = '<div class="battery">';
-    html += '<div class="level" style="height:' + pct + '%;"></div>';
+    html += '<div class="level" style="' + clip + '"></div>';
     if (charging) {
         html += '<div class="bolt">\u26A1</div>';
     }
@@ -635,7 +636,8 @@ function updateBatteryIndicator(level, rangeMiles, chargingState, heaterOn) {
 
 function batteryBar(level) {
     var pct = level != null ? level : 0;
-    return '<div class="battery-block"><div class="battery"><div class="level" style="height:' + pct + '%;"></div></div><div class="battery-value">' + pct + '%</div></div>';
+    var clip = 'clip-path: inset(' + (100 - pct) + '% 0 0 0)';
+    return '<div class="battery-block"><div class="battery"><div class="level" style="' + clip + '"></div></div><div class="battery-value">' + pct + '%</div></div>';
 }
 
 var lastChargeInfo = null;


### PR DESCRIPTION
## Summary
- keep battery color bands at fixed size
- use clip-path to show current level without shrinking gradient

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6856c925f2808321858955b51f107c6d