### PR TITLE
Add periodic announcement fetching

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ The same information is also stored as hierarchical JSON in `data/api-liste.json
 * `/api/version` – return the current dashboard version as JSON
 * `/api/clients` – number of connected clients as JSON
 * `/api/occupant` – get or set occupant presence flag
+* `/api/announcement` – return the current announcement text as JSON
     * Use `POST` with a JSON body like `{ "present": true }` or `{ "present": false }`
       to keep the vehicle awake only when someone is inside.
 * `/stream/<vehicle_id>` – Server-Sent Events endpoint used by the frontend

--- a/app.py
+++ b/app.py
@@ -1191,6 +1191,13 @@ def api_config():
     return jsonify(load_config())
 
 
+@app.route("/api/announcement")
+def api_announcement():
+    """Return the current announcement text."""
+    cfg = load_config()
+    return jsonify({"announcement": cfg.get("announcement", "")})
+
+
 @app.route("/api/occupant", methods=["GET", "POST"])
 def api_occupant():
     """Return or update occupant presence status."""

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -914,6 +914,17 @@ function updateAnnouncement() {
     }
 }
 
+function fetchAnnouncement() {
+    $.getJSON('/api/announcement', function(resp) {
+        if (typeof resp.announcement !== 'undefined') {
+            if (resp.announcement !== announcementText) {
+                announcementText = resp.announcement;
+                updateAnnouncement();
+            }
+        }
+    });
+}
+
 function fetchAddress(lat, lon) {
     if (lat == null || lon == null) return;
     if (lastAddressLat === lat && lastAddressLng === lon) return;
@@ -1049,4 +1060,6 @@ function checkAppVersion() {
 setInterval(checkAppVersion, 60000);
 setInterval(function() { updateDataAge(); }, 1000);
 setInterval(updateClientCount, 5000);
+setInterval(fetchAnnouncement, 15000);
 updateClientCount();
+fetchAnnouncement();


### PR DESCRIPTION
## Summary
- provide a new `/api/announcement` endpoint that returns the announcement text
- auto refresh announcement box in the frontend by polling the new endpoint
- document the endpoint in the README

## Testing
- `python -m py_compile app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685711ef32408321b56647b368527dc4