### PR TITLE
Implement announcement box line wrapping

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -233,12 +233,15 @@ select {
 }
 
 #announcement-box {
-  width: auto;
+  align-self: flex-end;
+  max-width: 100%;
   margin: 10px 0 0;
-  text-align: left;
+  text-align: right;
   font-size: 0.9em;
   color: yellow;
   font-weight: bold;
+  overflow-wrap: break-word;
+  word-break: break-word;
 }
 
 #v2l-infos,

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -905,10 +905,24 @@ function updateClientCount() {
     });
 }
 
+function escapeHtml(text) {
+    return $('<div>').text(text).html();
+}
+
+function formatAnnouncement(text) {
+    var html = text;
+    if (!/<[a-z][\s\S]*>/i.test(text)) {
+        html = escapeHtml(text);
+    }
+    return html.replace(/(https?:\/\/[^\s]+)/g, function(url) {
+        return '<a href="' + url + '" target="_blank">' + url + '</a>';
+    });
+}
+
 function updateAnnouncement() {
     var $box = $('#announcement-box');
     if (announcementText) {
-        $box.text(announcementText);
+        $box.html(formatAnnouncement(announcementText));
     } else {
         $box.empty();
     }


### PR DESCRIPTION
## Summary
- wrap long texts inside the announcement box
- align the announcement box with the heater indicators
- support HTML and clickable links in announcements

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6857145c06f08321b9af9d8025c60c71