### PR TITLE
Fix announcement line breaks

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -914,6 +914,7 @@ function formatAnnouncement(text) {
     if (!/<[a-z][\s\S]*>/i.test(text)) {
         html = escapeHtml(text);
     }
+    html = html.replace(/\n/g, '<br>');
     return html.replace(/(https?:\/\/[^\s]+)/g, function(url) {
         return '<a href="' + url + '" target="_blank">' + url + '</a>';
     });

--- a/templates/config.html
+++ b/templates/config.html
@@ -53,7 +53,7 @@
         <div>
             <label>
                 Hinweistext
-                <input type="text" name="announcement" value="{{ config.get('announcement','') }}">
+                <textarea name="announcement" rows="3">{{ config.get('announcement','') }}</textarea>
             </label>
         </div>
         <button type="submit">Speichern</button>


### PR DESCRIPTION
## Summary
- support multi-line announcement text on the config page
- render announcement newlines as `<br>` in the dashboard

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68571a2e2cc88321a971b7e5f8a5bcf6