### PR TITLE
Revert map width change & adjust announcement box

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -78,8 +78,7 @@ select {
 }
 
 #map-container #map {
-  flex: 0 0 66.666%;
-  max-width: 66.666%;
+  flex: 3;
 }
 
 #map-container #sidebar-right {
@@ -236,7 +235,8 @@ select {
 
 #announcement-box {
   align-self: flex-end;
-  max-width: 100%;
+  display: inline-block;
+  max-width: 25ch;
   margin: 10px 0 0;
   text-align: right;
   font-size: 0.9em;
@@ -244,6 +244,7 @@ select {
   font-weight: bold;
   overflow-wrap: break-word;
   word-break: break-word;
+  white-space: normal;
 }
 
 #v2l-infos,


### PR DESCRIPTION
## Summary
- revert map width changes from PR #280
- keep the announcement area small and wrap lines

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6857200881348321a9fea16a99c8fa14