### PR TITLE
Implement larger announcement input

### DIFF
--- a/templates/config.html
+++ b/templates/config.html
@@ -53,7 +53,7 @@
         <div>
             <label>
                 Hinweistext
-                <textarea name="announcement" rows="3">{{ config.get('announcement','') }}</textarea>
+                <textarea name="announcement" rows="6" style="width:100%">{{ config.get('announcement','') }}</textarea>
             </label>
         </div>
         <button type="submit">Speichern</button>


### PR DESCRIPTION
## Summary
- enlarge the announcement textarea on the config page for easier editing

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68572751c5e883219d92654f9e89ded7