### PR TITLE
Fix single announcement line display

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -67,8 +67,10 @@ function startAnnouncementCycle() {
         clearInterval(announcementTimer);
         announcementTimer = null;
     }
+    // Always reset the index when the announcement list changes to avoid
+    // referencing an out-of-range entry when the number of lines decreases.
+    announcementIndex = 0;
     if (announcementList.length > 1) {
-        announcementIndex = 0;
         announcementTimer = setInterval(function() {
             announcementIndex = (announcementIndex + 1) % announcementList.length;
             updateAnnouncement();


### PR DESCRIPTION
## Summary
- reset announcement index whenever the list is updated so a single-line announcement shows correctly

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685728b88f808321895568315da9425b