### PR TITLE
Add progress bar to media player

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -358,6 +358,22 @@ select {
   margin-right: 4px;
 }
 
+/* Progress bar for media position */
+#media-progress {
+  width: 100%;
+  background: #444;
+  height: 6px;
+  border-radius: 3px;
+  overflow: hidden;
+  margin-top: 2px;
+}
+
+#media-progress-bar {
+  height: 100%;
+  background: var(--accent-color);
+  width: 0;
+}
+
 /* Simple automatic gear shift display */
 #gear-shift {
   display: inline-block;

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -851,7 +851,8 @@ function updateMediaPlayer(media) {
         var pct = Math.min(Math.max(elapsed / duration * 100, 0), 100);
         var pos = Math.round(elapsed / 1000);
         var dur = Math.round(duration / 1000);
-        rows.push('<tr><th>Position:</th><td>' + pos + 's / ' + dur + 's (' + Math.round(pct) + '%)</td></tr>');
+        var bar = '<div id="media-progress"><div id="media-progress-bar" style="width:' + pct.toFixed(1) + '%"></div></div>';
+        rows.push('<tr><th>Position:</th><td>' + bar + ' ' + pos + 's / ' + dur + 's</td></tr>');
     }
     $player.html('<table>' + rows.join('') + '</table>');
 }


### PR DESCRIPTION
## Summary
- show song position with a progress bar in the media player

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68586e3755988321b59e424375939bab