### PR TITLE
Dynamically adjust Tesla API polling interval

### DIFF
--- a/app.py
+++ b/app.py
@@ -1055,7 +1055,13 @@ def _fetch_loop(vehicle_id, interval=3):
                 pass
         for q in subscribers.get(vehicle_id, []):
             q.put(data)
-        time.sleep(interval)
+        # Increase the delay to reduce API usage when no clients are
+        # connected. Once a client connects the shorter interval is used
+        # again on the next loop iteration.
+        if subscribers.get(vehicle_id):
+            time.sleep(interval)
+        else:
+            time.sleep(30)
 
 
 def _start_thread(vehicle_id):


### PR DESCRIPTION
## Summary
- poll at 30s intervals when no streaming clients are connected
- revert to 3s intervals as soon as a client connects

## Testing
- `python -m py_compile app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68589c8e0e708321a29cfcb8f46fd5d9