### PR TITLE
Enforce integer API intervals

### DIFF
--- a/templates/config.html
+++ b/templates/config.html
@@ -53,13 +53,13 @@
         <div>
             <label>
                 API Intervall (Sekunden)
-                <input type="number" name="api_interval" min="1" value="{{ config.get('api_interval', 3) }}">
+                <input type="number" name="api_interval" min="1" step="1" value="{{ config.get('api_interval', 3) }}">
             </label>
         </div>
         <div>
             <label>
                 API Intervall ohne Client (Sekunden)
-                <input type="number" name="api_interval_idle" min="1" value="{{ config.get('api_interval_idle', 30) }}">
+                <input type="number" name="api_interval_idle" min="1" step="1" value="{{ config.get('api_interval_idle', 30) }}">
             </label>
         </div>
         <div>


### PR DESCRIPTION
## Summary
- require integer polling intervals on the config page
- enforce integer values in backend when reading/writing config

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6858a2718e50832198e65bd6d2413086