### PR TITLE
Add week/month selection to history view

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ The dashboard shows a short overview depending on whether the vehicle is parked,
 
 While driving, a blue path is drawn on the map using the reported GPS positions. All trips of a day are logged to a single CSV file under `data/trips` for later analysis.
 The `/history` page lists these files so previous trips can be selected and displayed on an interactive map.
+Entire weeks or months can also be chosen to display longer time spans at once.
 Using the slider you can inspect each recorded point and see the exact timestamp along with speed and power information.
 When multiple cars are available a drop-down menu lets you switch between vehicles.
 Below the navigation bar a small media player section shows details of the currently playing track if provided by the API.

--- a/templates/history.html
+++ b/templates/history.html
@@ -22,9 +22,25 @@
     <form id="trip-form" method="get" action="/history">
         <label for="file">Fahrt auswählen:</label>
         <select id="file" name="file" onchange="document.getElementById('trip-form').submit();">
+            <optgroup label="Tage">
             {% for f in files %}
             <option value="{{ f }}" {% if f == selected %}selected{% endif %}>{{ f }}</option>
             {% endfor %}
+            </optgroup>
+            {% if weeks %}
+            <optgroup label="Wochen">
+            {% for w in weeks %}
+            <option value="week:{{ w }}" {% if ('week:' ~ w) == selected %}selected{% endif %}>{{ w }}</option>
+            {% endfor %}
+            </optgroup>
+            {% endif %}
+            {% if months %}
+            <optgroup label="Monate">
+            {% for m in months %}
+            <option value="month:{{ m }}" {% if ('month:' ~ m) == selected %}selected{% endif %}>{{ m }}</option>
+            {% endfor %}
+            </optgroup>
+            {% endif %}
         </select>
     </form>
     <div id="map"></div>


### PR DESCRIPTION
## Summary
- allow combining trip data for entire weeks or months
- add week/month options to history dropdown
- document extended history view options

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6858a7c3ddc4832190e0327f1ed1ebb9