### PR TITLE
Reload dashboard on API interval change

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Below the navigation bar a small media player section shows details of the curre
 The configuration page also offers an option to highlight doors and windows in blue.
 Additional toggles allow hiding the heater indicators and the list of nearby Superchargers on the main page.
 You can also enable or disable the announcement text and adjust the API polling interval without restarting the server.
+Clients reload automatically when the polling interval changes so the new setting takes effect immediately.
 
 Data is streamed to the frontend via `/stream/<vehicle_id>` using Server-Sent Events so the dashboard updates instantly when new information arrives.
 The endpoint `/apiliste` exposes a text file listing all seen API variables and their latest values.

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -6,6 +6,8 @@ var announcementList = [];
 var announcementIndex = 0;
 var announcementTimer = null;
 var lastConfigJSON = null;
+var lastApiInterval = null;
+var lastApiIntervalIdle = null;
 // Default view if no coordinates are available
 var DEFAULT_POS = [51.4556, 7.0116];
 var DEFAULT_ZOOM = 18;
@@ -1104,6 +1106,10 @@ function startStreamIfOnline() {
 $.getJSON('/api/config', function(cfg) {
     applyConfig(cfg);
     lastConfigJSON = JSON.stringify(cfg || {});
+    if (cfg) {
+        lastApiInterval = cfg.api_interval;
+        lastApiIntervalIdle = cfg.api_interval_idle;
+    }
     fetchVehicles();
 });
 
@@ -1111,7 +1117,16 @@ function fetchConfig() {
     $.getJSON('/api/config', function(cfg) {
         var json = JSON.stringify(cfg || {});
         if (json !== lastConfigJSON) {
+            if (cfg && (cfg.api_interval !== lastApiInterval ||
+                        cfg.api_interval_idle !== lastApiIntervalIdle)) {
+                location.reload(true);
+                return;
+            }
             lastConfigJSON = json;
+            if (cfg) {
+                lastApiInterval = cfg.api_interval;
+                lastApiIntervalIdle = cfg.api_interval_idle;
+            }
             applyConfig(cfg);
         }
     });


### PR DESCRIPTION
## Summary
- track API interval settings in frontend
- automatically reload page when API polling interval changes
- document this behaviour in the README

## Testing
- `flake8`
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6858aef2e1f8832192cfda312f8b400f