### PR TITLE
Add /apilog endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ The same information is also stored as hierarchical JSON in `data/api-liste.json
 * `/error` – show recent API errors (JSON via `/api/errors`)
 * `/state` – display the vehicle state log
 * `/debug` – display environment info and recent log lines
+* `/apilog` – show the raw API log
 * `/api/vehicles` – list available vehicles as JSON
 * `/api/state` – return the current vehicle state as JSON
 * `/api/version` – return the current dashboard version as JSON

--- a/app.py
+++ b/app.py
@@ -1435,6 +1435,18 @@ def state_log_page():
     return render_template("state.html", log_lines=log_lines)
 
 
+@app.route("/apilog")
+def api_log_page():
+    """Display the API log."""
+    log_lines = []
+    try:
+        with open(os.path.join(DATA_DIR, "api.log"), "r", encoding="utf-8") as f:
+            log_lines = f.readlines()
+    except Exception:
+        pass
+    return render_template("apilog.html", log_lines=log_lines)
+
+
 @app.route("/debug")
 def debug_info():
     """Display diagnostic information about the server."""

--- a/templates/apilog.html
+++ b/templates/apilog.html
@@ -1,0 +1,17 @@
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="Tesla Dashboard zur Anzeige aktueller Fahrzeugdaten">
+    <meta name="keywords" content="Tesla, Dashboard, Fahrzeugdaten, Statistik, Karte, Elektroauto, Ladung, Stromverbrauch, Standort, Routenplanung, Fahrzeugstatus, Kilometerstand, Trip, Tesla Model S, Model 3, Model X, Model Y">
+    <title>API Log</title>
+    <link rel="stylesheet" href="/static/css/style.css" />
+    <style>
+        pre { background:#1f1f1f; padding:10px; overflow-x:auto; color: var(--text-color); }
+    </style>
+</head>
+<body>
+    <h1>API Log</h1>
+    <pre>{{ log_lines|join('') }}</pre>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `/apilog` route for viewing the API log
- document the new endpoint
- include HTML template for the API log

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_685901a6e25c8321b5bc9630a9cd1c59