### PR TITLE
Implement manual vehicle list refresh

### DIFF
--- a/app.py
+++ b/app.py
@@ -879,7 +879,7 @@ def sanitize(data):
     return data
 
 
-def _cached_vehicle_list(tesla, ttl=300):
+def _cached_vehicle_list(tesla, ttl=86400):
     """Return vehicle list with basic time-based caching."""
     global _vehicle_list_cache, _vehicle_list_cache_ts, _default_vehicle_id
     now = time.time()
@@ -1333,6 +1333,10 @@ def config_page():
         announcement = request.form.get("announcement", "").strip()
         api_interval = request.form.get("api_interval", "").strip()
         api_interval_idle = request.form.get("api_interval_idle", "").strip()
+        if "refresh_vehicle_list" in request.form:
+            tesla = get_tesla()
+            if tesla is not None:
+                _cached_vehicle_list(tesla, ttl=0)
         if callsign:
             cfg["aprs_callsign"] = callsign
         elif "aprs_callsign" in cfg:

--- a/templates/config.html
+++ b/templates/config.html
@@ -69,6 +69,7 @@
             </label>
         </div>
         <button type="submit">Speichern</button>
+        <button type="submit" name="refresh_vehicle_list" value="1">Fahrzeugliste aktualisieren</button>
     </form>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- refresh vehicle list only once per day
- allow manual refresh from the config page

## Testing
- `python -m py_compile app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685905d35f888321b14730c8506b472d