### PR TITLE
Add energy column in statistics

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This is a simple Flask application that displays real-time data from a Tesla veh
 
 API responses are logged to `data/api.log`. The log file uses rotation and will grow to at most 1&nbsp;MB.
 Vehicle state changes are written to `data/state.log`.
-Timestamps in this file are recorded in the Europe/Berlin timezone.
+Added charging energy is appended to `data/energy.log` whenever the value changes while charging. Timestamps in this file are recorded in the Europe/Berlin timezone.
 The latest successful API response is stored in `data/cache_<vehicle_id>.json`.
 This cache is always updated with the current vehicle state so the dashboard
 knows whether the car is online, asleep or offline even when no fresh data is

--- a/templates/statistik.html
+++ b/templates/statistik.html
@@ -15,7 +15,7 @@
 <body>
     <h1>Statistik</h1>
     <table>
-        <tr><th>Datum</th><th>Online %</th><th>Offline %</th><th>Asleep %</th><th>Gefahrene km</th></tr>
+        <tr><th>Datum</th><th>Online %</th><th>Offline %</th><th>Asleep %</th><th>Gefahrene km</th><th>Hinzugefügte Energie (kWh)</th></tr>
         {% for row in rows %}
         <tr>
             <td>{{ row.date }}</td>
@@ -23,6 +23,7 @@
             <td>{{ row.offline }}</td>
             <td>{{ row.asleep }}</td>
             <td>{{ row.km }}</td>
+            <td>{{ row.energy }}</td>
         </tr>
         {% endfor %}
     </table>


### PR DESCRIPTION
## Summary
- compute per-day energy added from `api.log`
- include energy stats when generating statistics
- show energy column on statistics page

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68590899b4ec8321874d256f053613e4