### PR TITLE
Add request logging to api.log

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This is a simple Flask application that displays real-time data from a Tesla veh
 4. Open `http://localhost:8013` in your browser (the server listens on `0.0.0.0:8013`).
 5. On the configuration page (`/config`) you can set your APRS call sign, passcode and an optional comment to transmit position packets via an EU APRS-IS server. You may also enable an additional WX packet using a separate call sign. Temperatures are included in Celsius within the comment. Positions are sent at most every 30 seconds while driving and at least every 10 minutes even without changes. WX packets obey the same limits and are only transmitted when the outside temperature changes or after ten minutes without an update. The page also lets you adjust the Tesla API polling interval and disable the announcement text.
 
-All API requests and responses are logged to `data/api.log`. The log file uses rotation and will grow to at most 1&nbsp;MB.
+All API calls are logged to `data/api.log` without storing request details. The log file uses rotation and will grow to at most 1&nbsp;MB.
 Vehicle state changes are written to `data/state.log`.
 Added charging energy is appended to `data/energy.log` whenever the value changes while charging. Timestamps in this file are recorded in the Europe/Berlin timezone.
 The latest successful API response is stored in `data/cache_<vehicle_id>.json`.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This is a simple Flask application that displays real-time data from a Tesla veh
 4. Open `http://localhost:8013` in your browser (the server listens on `0.0.0.0:8013`).
 5. On the configuration page (`/config`) you can set your APRS call sign, passcode and an optional comment to transmit position packets via an EU APRS-IS server. You may also enable an additional WX packet using a separate call sign. Temperatures are included in Celsius within the comment. Positions are sent at most every 30 seconds while driving and at least every 10 minutes even without changes. WX packets obey the same limits and are only transmitted when the outside temperature changes or after ten minutes without an update. The page also lets you adjust the Tesla API polling interval and disable the announcement text.
 
-API responses are logged to `data/api.log`. The log file uses rotation and will grow to at most 1&nbsp;MB.
+All API requests and responses are logged to `data/api.log`. The log file uses rotation and will grow to at most 1&nbsp;MB.
 Vehicle state changes are written to `data/state.log`.
 Added charging energy is appended to `data/energy.log` whenever the value changes while charging. Timestamps in this file are recorded in the Europe/Berlin timezone.
 The latest successful API response is stored in `data/cache_<vehicle_id>.json`.

--- a/app.py
+++ b/app.py
@@ -242,8 +242,8 @@ def update_api_list(data, filename=os.path.join(DATA_DIR, "api-liste.txt")):
 
 
 # Communication with the Tesla API is logged via ``log_api_data`` and the
-# ``teslapy``/``urllib3`` loggers.  Requests to this web application are
-# now also recorded in ``api.log``.
+# ``teslapy``/``urllib3`` loggers.  Requests to this web application only
+# record the called endpoint in ``api.log``.
 
 
 def log_api_data(endpoint, data):
@@ -257,17 +257,9 @@ def log_api_data(endpoint, data):
 
 @app.before_request
 def log_request():
-    """Record every incoming request in ``api.log``."""
+    """Record the endpoint path for every request in ``api.log``."""
     try:
-        api_logger.info(
-            json.dumps(
-                {
-                    "request": request.path,
-                    "method": request.method,
-                    "args": request.args.to_dict(flat=True),
-                }
-            )
-        )
+        api_logger.info(json.dumps({"request": request.path}))
     except Exception:
         pass
 

--- a/app.py
+++ b/app.py
@@ -242,8 +242,8 @@ def update_api_list(data, filename=os.path.join(DATA_DIR, "api-liste.txt")):
 
 
 # Communication with the Tesla API is logged via ``log_api_data`` and the
-# ``teslapy``/``urllib3`` loggers. Requests to this web application are no longer
-# recorded in ``api.log``.
+# ``teslapy``/``urllib3`` loggers.  Requests to this web application are
+# now also recorded in ``api.log``.
 
 
 def log_api_data(endpoint, data):
@@ -251,6 +251,23 @@ def log_api_data(endpoint, data):
     try:
         api_logger.info(json.dumps({"endpoint": endpoint, "data": data}))
         update_api_list(data)
+    except Exception:
+        pass
+
+
+@app.before_request
+def log_request():
+    """Record every incoming request in ``api.log``."""
+    try:
+        api_logger.info(
+            json.dumps(
+                {
+                    "request": request.path,
+                    "method": request.method,
+                    "args": request.args.to_dict(flat=True),
+                }
+            )
+        )
     except Exception:
         pass
 


### PR DESCRIPTION
## Summary
- log incoming requests in `api.log`
- document new logging behaviour in README

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6859128684f8832187ae6abbeb12472b