### PR TITLE
Add Google Analytics support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,6 @@ TESLA_PASSWORD=your_password
 # Alternatively use access and refresh tokens
 TESLA_ACCESS_TOKEN=
 TESLA_REFRESH_TOKEN=
+
+# Google Analytics Tracking ID (optional)
+GA_TRACKING_ID=

--- a/app.py
+++ b/app.py
@@ -27,6 +27,13 @@ load_dotenv()
 app = Flask(__name__)
 __version__ = get_version()
 CURRENT_YEAR = datetime.now().year
+GA_TRACKING_ID = os.getenv("GA_TRACKING_ID")
+
+
+@app.context_processor
+def inject_ga_id():
+    """Add Google Analytics tracking ID to all templates."""
+    return {"ga_id": GA_TRACKING_ID}
 
 # Ensure data paths are relative to this file regardless of the
 # current working directory.  This allows running the application

--- a/templates/analytics.html
+++ b/templates/analytics.html
@@ -1,0 +1,10 @@
+{% if ga_id %}
+<!-- Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id={{ ga_id }}"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', '{{ ga_id }}');
+</script>
+{% endif %}

--- a/templates/apilog.html
+++ b/templates/apilog.html
@@ -6,6 +6,7 @@
     <meta name="keywords" content="Tesla, Dashboard, Fahrzeugdaten, Statistik, Karte, Elektroauto, Ladung, Stromverbrauch, Standort, Routenplanung, Fahrzeugstatus, Kilometerstand, Trip, Tesla Model S, Model 3, Model X, Model Y">
     <title>API Log</title>
     <link rel="stylesheet" href="/static/css/style.css" />
+    {% include 'analytics.html' %}
     <style>
         pre { background:#1f1f1f; padding:10px; overflow-x:auto; color: var(--text-color); }
     </style>

--- a/templates/config.html
+++ b/templates/config.html
@@ -7,6 +7,7 @@
     <meta name="keywords" content="Tesla, Dashboard, Fahrzeugdaten, Statistik, Karte, Elektroauto, Ladung, Stromverbrauch, Standort, Routenplanung, Fahrzeugstatus, Kilometerstand, Trip, Tesla Model S, Model 3, Model X, Model Y">
     <title>Dashboard Konfiguration</title>
     <link rel="stylesheet" href="/static/css/style.css" />
+    {% include 'analytics.html' %}
 </head>
 <body>
     <h1>Dashboard Konfiguration</h1>

--- a/templates/data.html
+++ b/templates/data.html
@@ -7,6 +7,7 @@
     <meta name="keywords" content="Tesla, Dashboard, Fahrzeugdaten, Statistik, Karte, Elektroauto, Ladung, Stromverbrauch, Standort, Routenplanung, Fahrzeugstatus, Kilometerstand, Trip, Tesla Model S, Model 3, Model X, Model Y">
     <title>Tesla Daten</title>
     <link rel="stylesheet" href="/static/css/style.css" />
+    {% include 'analytics.html' %}
     <style>
         pre { background:#1f1f1f; padding:10px; overflow-x:auto; color: var(--text-color); }
     </style>

--- a/templates/debug.html
+++ b/templates/debug.html
@@ -7,6 +7,7 @@
     <meta name="keywords" content="Tesla, Dashboard, Fahrzeugdaten, Statistik, Karte, Elektroauto, Ladung, Stromverbrauch, Standort, Routenplanung, Fahrzeugstatus, Kilometerstand, Trip, Tesla Model S, Model 3, Model X, Model Y">
     <title>Debug Info</title>
     <link rel="stylesheet" href="/static/css/style.css" />
+    {% include 'analytics.html' %}
     <style>
         pre { background:#1f1f1f; padding:10px; overflow-x:auto; color: var(--text-color); }
     </style>

--- a/templates/errors.html
+++ b/templates/errors.html
@@ -7,6 +7,7 @@
     <meta name="keywords" content="Tesla, Dashboard, Fahrzeugdaten, Statistik, Karte, Elektroauto, Ladung, Stromverbrauch, Standort, Routenplanung, Fahrzeugstatus, Kilometerstand, Trip, Tesla Model S, Model 3, Model X, Model Y">
     <title>API Fehler</title>
     <link rel="stylesheet" href="/static/css/style.css" />
+    {% include 'analytics.html' %}
 </head>
 <body>
     <h1>API Fehler</h1>

--- a/templates/history.html
+++ b/templates/history.html
@@ -9,6 +9,7 @@
     <script src="/static/js/jquery.min.js"></script>
     <link rel="stylesheet" href="/static/css/leaflet.css" />
     <link rel="stylesheet" href="/static/css/style.css" />
+    {% include 'analytics.html' %}
     <script src="/static/js/leaflet.js"></script>
     <script src="/static/js/leaflet.rotatedMarker.js"></script>
     <style>

--- a/templates/index.html
+++ b/templates/index.html
@@ -9,6 +9,7 @@
     <script src="/static/js/jquery.min.js"></script>
     <link rel="stylesheet" href="/static/css/leaflet.css" />
     <link rel="stylesheet" href="/static/css/style.css" />
+    {% include 'analytics.html' %}
     <script src="/static/js/leaflet.js"></script>
     <script src="/static/js/leaflet.rotatedMarker.js"></script>
     <script src="/static/js/Leaflet.Marker.SlideTo.js"></script>

--- a/templates/map.html
+++ b/templates/map.html
@@ -9,6 +9,7 @@
     <script src="/static/js/jquery.min.js"></script>
     <link rel="stylesheet" href="/static/css/leaflet.css" />
     <link rel="stylesheet" href="/static/css/style.css" />
+    {% include 'analytics.html' %}
     <script src="/static/js/leaflet.js"></script>
     <script src="/static/js/leaflet.rotatedMarker.js"></script>
     <script src="/static/js/Leaflet.Marker.SlideTo.js"></script>

--- a/templates/state.html
+++ b/templates/state.html
@@ -7,6 +7,7 @@
     <meta name="keywords" content="Tesla, Dashboard, Fahrzeugdaten, Statistik, Karte, Elektroauto, Ladung, Stromverbrauch, Standort, Routenplanung, Fahrzeugstatus, Kilometerstand, Trip, Tesla Model S, Model 3, Model X, Model Y">
     <title>State Log</title>
     <link rel="stylesheet" href="/static/css/style.css" />
+    {% include 'analytics.html' %}
     <style>
         pre { background:#1f1f1f; padding:10px; overflow-x:auto; color: var(--text-color); }
     </style>

--- a/templates/statistik.html
+++ b/templates/statistik.html
@@ -7,6 +7,7 @@
     <meta name="keywords" content="Tesla, Dashboard, Fahrzeugdaten, Statistik, Karte, Elektroauto, Ladung, Stromverbrauch, Standort, Routenplanung, Fahrzeugstatus, Kilometerstand, Trip, Tesla Model S, Model 3, Model X, Model Y">
     <title>Statistik</title>
     <link rel="stylesheet" href="/static/css/style.css" />
+    {% include 'analytics.html' %}
     <style>
         table { border-collapse: collapse; }
         th, td { padding: 4px 8px; border: 1px solid #444; }


### PR DESCRIPTION
## Summary
- add Google Analytics tracking ID example in `.env.example`
- provide `ga_id` to templates via a context processor
- include new `analytics.html` snippet in all pages

## Testing
- `python -m compileall -q .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859952a3b748321954bd4649e08ef61