### PR TITLE
Fix trip selector position

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -263,7 +263,7 @@ select {
 #trip-form {
   position: absolute;
   top: 10px;
-  left: 10px;
+  right: 10px;
   z-index: 1000;
   background: var(--surface-color);
   padding: 10px;


### PR DESCRIPTION
## Summary
- move trip selector on /history to the top-right so it doesn't conflict with the Leaflet zoom controls

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68599e0ea1a88321b02e6f5c81e1ae50