### PR TITLE
Add playback controls to history

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -291,6 +291,20 @@ select {
   width: 75vw;
 }
 
+#slider-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+#slider-row button {
+  padding: 4px 8px;
+  background: var(--surface-color);
+  color: var(--text-color);
+  border: 1px solid #444;
+  border-radius: 4px;
+}
+
 #point-info {
   text-align: center;
   color: var(--text-color);

--- a/static/js/history.js
+++ b/static/js/history.js
@@ -94,4 +94,47 @@ if (Array.isArray(tripPath) && tripPath.length) {
 
     updateMarker(tripPath.length - 1);
     map.setView(marker.getLatLng(), map.getZoom());
+
+    var playBtn = document.getElementById('play-btn');
+    var stopBtn = document.getElementById('stop-btn');
+    var speedSel = document.getElementById('speed-select');
+    var playTimeout = null;
+    var speed = 1;
+
+    function stopPlayback() {
+        if (playTimeout) {
+            clearTimeout(playTimeout);
+            playTimeout = null;
+        }
+    }
+
+    function stepPlayback(idx) {
+        if (idx >= tripPath.length) {
+            stopPlayback();
+            return;
+        }
+        slider.value = idx;
+        updateMarker(idx);
+        if (idx < tripPath.length - 1) {
+            var cur = tripPath[idx][4];
+            var nxt = tripPath[idx + 1][4];
+            var diff = nxt - cur;
+            if (!diff || diff < 0) {
+                diff = 1000;
+            }
+            diff = diff / speed;
+            playTimeout = setTimeout(function() { stepPlayback(idx + 1); }, diff);
+        }
+    }
+
+    playBtn.addEventListener('click', function() {
+        speed = parseFloat(speedSel.value) || 1;
+        if (!playTimeout) {
+            stepPlayback(parseInt(slider.value, 10));
+        }
+    });
+
+    stopBtn.addEventListener('click', function() {
+        stopPlayback();
+    });
 }

--- a/templates/history.html
+++ b/templates/history.html
@@ -46,7 +46,16 @@
     </form>
     <div id="map"></div>
     <div id="slider-container">
-        <input type="range" id="point-slider" min="0" max="0" value="0" step="1">
+        <div id="slider-row">
+            <button id="play-btn">Play</button>
+            <button id="stop-btn">Stop</button>
+            <select id="speed-select">
+                <option value="1">1x</option>
+                <option value="2">2x</option>
+                <option value="4">4x</option>
+            </select>
+            <input type="range" id="point-slider" min="0" max="0" value="0" step="1">
+        </div>
         <div id="point-info"></div>
     </div>
     {% if weekly %}


### PR DESCRIPTION
## Summary
- add playback buttons & speed dropdown on history page
- style playback controls next to the slider
- implement playback logic using timestamps

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6859a0403fec8321a7adcf0f9b38a5ca