### PR TITLE
Fix history playback buttons

### DIFF
--- a/templates/history.html
+++ b/templates/history.html
@@ -47,8 +47,8 @@
     <div id="map"></div>
     <div id="slider-container">
         <div id="slider-row">
-            <button id="play-btn">Play</button>
-            <button id="stop-btn">Stop</button>
+            <button id="play-btn" type="button">Play</button>
+            <button id="stop-btn" type="button">Stop</button>
             <select id="speed-select">
                 <option value="1">1x</option>
                 <option value="2">2x</option>


### PR DESCRIPTION
## Summary
- make history page `Play` and `Stop` buttons have explicit type

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6859a845003c8321996c56692cccd572