### PR TITLE
Improve playback restart logic

### DIFF
--- a/static/js/history.js
+++ b/static/js/history.js
@@ -144,8 +144,14 @@ function stepPlayback(idx) {
 if (playBtn) {
     playBtn.addEventListener('click', function() {
         speed = parseFloat(speedSel.value) || 1;
+        var startIdx = parseInt(slider.value, 10);
+        if (startIdx >= tripPath.length - 1) {
+            startIdx = 0;
+            slider.value = 0;
+            updateMarker(0, true);
+        }
         if (!playTimeout) {
-            stepPlayback(parseInt(slider.value, 10));
+            stepPlayback(startIdx);
         }
     });
 }


### PR DESCRIPTION
## Summary
- reset history playback when play is pressed at the end of a trip

## Testing
- `python -m py_compile app.py version.py`


------
https://chatgpt.com/codex/tasks/task_e_6859aaa575388321b47fcf1c82ab9153