### PR TITLE
Fix map starting location

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -142,7 +142,7 @@ var arrowIcon = L.divIcon({
     iconAnchor: [15, 15]
 });
 
-var marker = L.marker([0, 0], {
+var marker = L.marker(DEFAULT_POS, {
     icon: arrowIcon,
     rotationAngle: 0,
     rotationOrigin: 'center center'


### PR DESCRIPTION
## Summary
- ensure the initial map marker uses the Essen fallback position

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685ac9acb0348321b85a04a53800ca3a