### PR TITLE
Improve idle interval logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ Additional toggles allow hiding the heater indicators and the list of nearby Sup
 You can also enable or disable the announcement text and adjust the API polling interval without restarting the server.
 Clients reload automatically when the polling interval changes so the new setting takes effect immediately.
 
+When the vehicle remains parked for more than ten minutes the backend
+automatically switches to the idle polling interval so the car can go to
+sleep even if clients stay connected.
+
 Data is streamed to the frontend via `/stream/<vehicle_id>` using Server-Sent Events so the dashboard updates instantly when new information arrives.
 The endpoint `/apiliste` exposes a text file listing all seen API variables and their latest values.
 

--- a/app.py
+++ b/app.py
@@ -1202,13 +1202,17 @@ def _fetch_loop(vehicle_id, interval=3):
                 send_aprs(data)
             except Exception:
                 pass
-        # Increase the delay to reduce API usage when no clients are
-        # connected. Once a client connects the shorter interval is used
-        # again on the next loop iteration.
-        if subscribers.get(vehicle_id):
-            time.sleep(interval)
-        else:
+        # Increase the delay to reduce API usage when the car is parked or
+        # no clients are connected. Once a client connects while driving the
+        # shorter interval is used again on the next loop iteration.
+        now_ms = int(time.time() * 1000)
+        parked_long = False
+        if park_start_ms is not None and now_ms - park_start_ms >= 600000:
+            parked_long = True
+        if parked_long or not subscribers.get(vehicle_id):
             time.sleep(idle_interval)
+        else:
+            time.sleep(interval)
 
 
 def _start_thread(vehicle_id):


### PR DESCRIPTION
## Summary
- drop to idle polling when the car has been parked for ten minutes
- document the automatic idle interval

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_685ae65f59a88321a5d8fd2e28e253c1