### PR TITLE
Add persistent park time tracking

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -182,6 +182,7 @@
     <div id="loading-msg">Daten werden geladen...</div>
     <div id="v2l-infos"></div>
     <div id="charging-info"></div>
+    <div id="park-since"></div>
     <div id="nav-bar"></div>
     <div id="media-player"></div>
     </div>


### PR DESCRIPTION
## Summary
- persist park timestamp in `parktime.json`
- expose parking duration in API data
- display parked time on dashboard

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685ae90393bc8321ae252b1acba0398c