### PR TITLE
Update park time display

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -9,6 +9,7 @@ var lastConfigJSON = null;
 var lastApiInterval = null;
 var lastApiIntervalIdle = null;
 var parkStartTime = null;
+var currentGear = null;
 // Default view if no coordinates are available
 var DEFAULT_POS = [51.4556, 7.0116];
 var DEFAULT_ZOOM = 18;
@@ -325,8 +326,10 @@ function handleData(data) {
 
 function updateGearShift(state) {
     var gear = state || 'P';
+    currentGear = gear;
     $('#gear-shift div').removeClass('active');
     $('#gear-shift div[data-gear="' + gear + '"]').addClass('active');
+    displayParkTime();
 }
 
 function updateLockStatus(locked) {
@@ -925,8 +928,12 @@ function updateParkTime(ts) {
 
 function displayParkTime() {
     var $el = $('#park-since');
+    if (currentGear && currentGear !== 'P') {
+        $el.hide();
+        return;
+    }
     if (!parkStartTime) {
-        $el.text('');
+        $el.hide();
         return;
     }
     var diff = Math.max(0, Date.now() - parkStartTime);
@@ -938,7 +945,7 @@ function displayParkTime() {
         parts.push(hours + ' ' + (hours === 1 ? 'Stunde' : 'Stunden'));
     }
     parts.push(minutes + ' ' + (minutes === 1 ? 'Minute' : 'Minuten'));
-    $el.text('Geparkt seit ' + parts.join(' '));
+    $el.text('Geparkt seit ' + parts.join(' ')).show();
 }
 
 function updateVehicleState(state) {

--- a/templates/index.html
+++ b/templates/index.html
@@ -182,9 +182,9 @@
     <div id="loading-msg">Daten werden geladen...</div>
     <div id="v2l-infos"></div>
     <div id="charging-info"></div>
-    <div id="park-since"></div>
     <div id="nav-bar"></div>
     <div id="media-player"></div>
+    <div id="park-since"></div>
     </div>
 
     <footer class="app-version">


### PR DESCRIPTION
## Summary
- move `park-since` element to the bottom of dashboard content
- track current gear in the frontend
- hide the 'Geparkt seit' text while in gear R, N or D

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_685aefeb90b48321a57ba0ca64ee4a74