### PR TITLE
Improve trip playback speed and UI

### DIFF
--- a/static/js/history.js
+++ b/static/js/history.js
@@ -150,6 +150,11 @@ function stepPlayback(idx) {
     updateMarker(idx, true);
     if (idx < tripPath.length - 1) {
         var diff = 1000 / speed;
+        var t1 = tripPath[idx][4];
+        var t2 = tripPath[idx + 1][4];
+        if (t1 && t2 && t2 > t1) {
+            diff = (t2 - t1) / speed;
+        }
         playTimeout = setTimeout(function() { stepPlayback(idx + 1); }, diff);
     }
 }

--- a/templates/history.html
+++ b/templates/history.html
@@ -47,19 +47,20 @@
             {% endif %}
         </select>
     </form>
-    <div id="map"></div>
-    <div id="slider-container">
-        <div id="slider-row">
-            <button id="play-btn" type="button">Play</button>
-            <button id="stop-btn" type="button">Stop</button>
-            <select id="speed-select">
-                <option value="1">1x</option>
-                <option value="2">2x</option>
-                <option value="4">4x</option>
-            </select>
-            <input type="range" id="point-slider" min="0" max="0" value="0" step="1">
+    <div id="map">
+        <div id="slider-container">
+            <div id="slider-row">
+                <button id="play-btn" type="button">Play</button>
+                <button id="stop-btn" type="button">Stop</button>
+                <select id="speed-select">
+                    <option value="1">1x</option>
+                    <option value="2">2x</option>
+                    <option value="4">4x</option>
+                </select>
+                <input type="range" id="point-slider" min="0" max="0" value="0" step="1">
+            </div>
+            <div id="point-info"></div>
         </div>
-        <div id="point-info"></div>
     </div>
     {% if weekly %}
     <h2>Wöchentliche Zusammenfassung</h2>


### PR DESCRIPTION
## Summary
- display playback slider inside the map
- adjust playback timing based on timestamps so speed-select controls playback rate correctly

## Testing
- `python -m py_compile app.py version.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b20d952c083219ec59aba36424136