### PR TITLE
Improve configurable page menu

### DIFF
--- a/app.py
+++ b/app.py
@@ -283,6 +283,10 @@ CONFIG_ITEMS = [
     {"id": "charging-info", "desc": "Ladeinformationen"},
     {"id": "v2l-infos", "desc": "V2L-Hinweis"},
     {"id": "announcement-box", "desc": "Hinweistext"},
+    {"id": "page-menu", "desc": "Seitenmenü"},
+    {"id": "menu-dashboard", "desc": "Dashboard im Seitenmenü"},
+    {"id": "menu-statistik", "desc": "Statistik im Seitenmenü"},
+    {"id": "menu-history", "desc": "History im Seitenmenü"},
     {"id": "nav-bar", "desc": "Navigationsleiste"},
     {"id": "media-player", "desc": "Medienwiedergabe"},
 ]
@@ -1273,7 +1277,13 @@ def _start_thread(vehicle_id):
 
 @app.route("/")
 def index():
-    return render_template("index.html", version=__version__, year=CURRENT_YEAR)
+    cfg = load_config()
+    return render_template(
+        "index.html",
+        version=__version__,
+        year=CURRENT_YEAR,
+        config=cfg,
+    )
 
 
 @app.route("/map")
@@ -1305,6 +1315,7 @@ def trip_history():
     if len(path) >= 2:
         heading = _bearing(path[0][:2], path[1][:2])
     weekly, monthly = compute_trip_summaries()
+    cfg = load_config()
     return render_template(
         "history.html",
         path=path,
@@ -1315,6 +1326,7 @@ def trip_history():
         selected=selected,
         weekly=weekly,
         monthly=monthly,
+        config=cfg,
     )
 
 
@@ -1531,7 +1543,8 @@ def statistics_page():
                 "energy": round(entry.get("energy", 0.0), 2),
             }
         )
-    return render_template("statistik.html", rows=rows)
+    cfg = load_config()
+    return render_template("statistik.html", rows=rows, config=cfg)
 
 
 @app.route("/api/errors")

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -390,6 +390,29 @@ select {
   width: 0;
 }
 
+/* Navigation menu linking to other pages */
+#page-menu {
+  margin: 10px 0;
+  text-align: center;
+}
+
+#page-menu a {
+  display: inline-block;
+  padding: 4px 8px;
+  background: var(--surface-color);
+  color: var(--text-color);
+  border: 1px solid #444;
+  border-radius: 4px;
+  margin: 0 5px;
+  text-decoration: none;
+}
+
+#page-menu a:hover {
+  background: var(--accent-color);
+  color: var(--bg-color);
+  text-decoration: none;
+}
+
 /* Simple automatic gear shift display */
 #gear-shift {
   display: inline-block;

--- a/templates/history.html
+++ b/templates/history.html
@@ -23,6 +23,17 @@
     </style>
 </head>
 <body>
+    <h1>Fahrtverlauf</h1>
+    {% set show_dash = config.get('menu-dashboard', True) %}
+    {% set show_stat = config.get('menu-statistik', True) %}
+    {% set show_hist = config.get('menu-history', True) %}
+    {% if config.get('page-menu', True) and (show_dash or show_stat or show_hist) %}
+    <nav id="page-menu">
+        {% if show_dash %}<a class="menu-button" href="/">Dashboard</a>{% endif %}
+        {% if show_stat %}<a class="menu-button" href="/statistik">Statistik</a>{% endif %}
+        {% if show_hist %}<a class="menu-button" href="/history">History</a>{% endif %}
+    </nav>
+    {% endif %}
     <form id="trip-form" method="get" action="/history">
         <label for="file">Fahrt auswählen:</label>
         <select id="file" name="file" onchange="document.getElementById('trip-form').submit();">

--- a/templates/index.html
+++ b/templates/index.html
@@ -20,6 +20,16 @@
             <span id="vehicle-info"></span>&nbsp;&nbsp;&nbsp;<span id="vehicle-status"></span>
         </span>
     </h2>
+    {% set show_dash = config.get('menu-dashboard', True) %}
+    {% set show_stat = config.get('menu-statistik', True) %}
+    {% set show_hist = config.get('menu-history', True) %}
+    {% if config.get('page-menu', True) and (show_dash or show_stat or show_hist) %}
+    <nav id="page-menu">
+        {% if show_dash %}<a class="menu-button" href="/">Dashboard</a>{% endif %}
+        {% if show_stat %}<a class="menu-button" href="/statistik">Statistik</a>{% endif %}
+        {% if show_hist %}<a class="menu-button" href="/history">History</a>{% endif %}
+    </nav>
+    {% endif %}
     <div id="dashboard-content">
         <label for="vehicle-select">Fahrzeug auswählen:</label>
         <select id="vehicle-select"></select>

--- a/templates/statistik.html
+++ b/templates/statistik.html
@@ -15,6 +15,16 @@
 </head>
 <body>
     <h1>Statistik</h1>
+    {% set show_dash = config.get('menu-dashboard', True) %}
+    {% set show_stat = config.get('menu-statistik', True) %}
+    {% set show_hist = config.get('menu-history', True) %}
+    {% if config.get('page-menu', True) and (show_dash or show_stat or show_hist) %}
+    <nav id="page-menu">
+        {% if show_dash %}<a class="menu-button" href="/">Dashboard</a>{% endif %}
+        {% if show_stat %}<a class="menu-button" href="/statistik">Statistik</a>{% endif %}
+        {% if show_hist %}<a class="menu-button" href="/history">History</a>{% endif %}
+    </nav>
+    {% endif %}
     <table>
         <tr><th>Datum</th><th>Online %</th><th>Offline %</th><th>Asleep %</th><th>Gefahrene km</th><th>Höchste Geschwindigkeit (km/h)</th><th>Hinzugefügte Energie (kWh)</th></tr>
         {% for row in rows %}


### PR DESCRIPTION
## Summary
- add per-page toggles for the navigation menu
- show menu buttons only for enabled pages
- style menu entries as buttons for better visibility

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_685b2518e46883219eee41e312a5a868