### PR TITLE
Enable 8x and 16x history playback speeds

### DIFF
--- a/templates/history.html
+++ b/templates/history.html
@@ -67,6 +67,8 @@
                     <option value="1">1x</option>
                     <option value="2">2x</option>
                     <option value="4">4x</option>
+                    <option value="8">8x</option>
+                    <option value="16">16x</option>
                 </select>
                 <input type="range" id="point-slider" min="0" max="0" value="0" step="1">
             </div>


### PR DESCRIPTION
## Summary
- update history speed selector with additional speed options

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685b29b56ec08321a061b6f7e4e7bd82