### PR TITLE
Document backend-only API usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ can be started from any location while still accessing existing trips and logs.
 
 All required JavaScript and CSS libraries are bundled under `static/` so the dashboard works even without Internet access.
 
-The backend continuously polls the Tesla API and pushes new data to clients using Server-Sent Events (SSE).
+The backend continuously polls the Tesla API and pushes new data to clients using Server-Sent Events (SSE). The frontend never talks to the Tesla API directly. It only requests data from the backend using the `/api/...` endpoints so tokens remain secure on the server.
 The frontend first checks `/api/state` to make sure the car is online before
 opening the streaming connection.  When the vehicle is reported as `offline` or
 `asleep` no further API requests are made, preventing the car from waking up


### PR DESCRIPTION
## Summary
- clarify that the frontend never talks to the Tesla API directly and only uses backend endpoints

## Testing
- `pytest -q`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b3a605ffc8321aa3e5ea4336f0f62