### PR TITLE
Respect occupant presence while parked

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ Clients reload automatically when the polling interval changes so the new settin
 
 When the vehicle remains parked for more than ten minutes the backend
 automatically switches to the idle polling interval so the car can go to
-sleep even if clients stay connected.
+sleep even if clients stay connected. If occupant presence is reported via
+`/api/occupant` the normal interval is used even while parked.
 
 Data is streamed to the frontend via `/stream/<vehicle_id>` using Server-Sent Events so the dashboard updates instantly when new information arrives.
 The endpoint `/apiliste` exposes a text file listing all seen API variables and their latest values.

--- a/app.py
+++ b/app.py
@@ -1265,7 +1265,7 @@ def _fetch_loop(vehicle_id, interval=3):
         parked_long = False
         if park_start_ms is not None and now_ms - park_start_ms >= 600000:
             parked_long = True
-        if parked_long or not subscribers.get(vehicle_id):
+        if (parked_long and not occupant_present) or not subscribers.get(vehicle_id):
             time.sleep(idle_interval)
         else:
             time.sleep(interval)


### PR DESCRIPTION
## Summary
- allow normal polling interval when occupant is present
- document occupant behaviour in README

## Testing
- `pip install -q -r requirements.txt`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_685bb1395d408321aa57645374684fec