### PR TITLE
Fix timezone handling

### DIFF
--- a/app.py
+++ b/app.py
@@ -522,7 +522,7 @@ def track_drive_path(vehicle_data):
         if ts is None:
             ts = int(time.time() * 1000)
         vid = vehicle_data.get("id_s") or vehicle_data.get("vehicle_id")
-        date_str = time.strftime("%Y%m%d", time.localtime(ts / 1000))
+        date_str = datetime.fromtimestamp(ts / 1000, LOCAL_TZ).strftime("%Y%m%d")
         if current_trip_file is None or current_trip_date != date_str:
             current_trip_file = os.path.join(trip_dir(vid), f"trip_{date_str}.csv")
             current_trip_date = date_str
@@ -1626,9 +1626,9 @@ def error_page():
         errors = list(api_errors)
     for e in errors:
         try:
-            e["time_str"] = time.strftime(
-                "%Y-%m-%d %H:%M:%S", time.localtime(e["timestamp"])
-            )
+            e["time_str"] = datetime.fromtimestamp(
+                e["timestamp"], LOCAL_TZ
+            ).strftime("%Y-%m-%d %H:%M:%S")
         except Exception:
             e["time_str"] = str(e["timestamp"])
     return render_template("errors.html", errors=errors)

--- a/static/js/history.js
+++ b/static/js/history.js
@@ -50,7 +50,7 @@ function updateInfo(idx) {
     var text = [];
     if (point[4]) {
         var date = new Date(point[4]);
-        text.push(date.toLocaleString());
+        text.push(date.toLocaleString('de-DE', { timeZone: 'Europe/Berlin' }));
     }
     if (point[2] !== null && point[2] !== undefined && point[2] !== '') {
         var kmh = Math.round(point[2] * MILES_TO_KM);

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -806,7 +806,11 @@ function updateNavBar(drive) {
         var m = mins % 60;
         var timeStr = (h > 0 ? h + 'h ' : '') + m + 'min';
         var arrival = new Date(Date.now() + mins * 60000);
-        var arrivalStr = arrival.toLocaleTimeString([], {hour: '2-digit', minute: '2-digit'});
+        var arrivalStr = arrival.toLocaleTimeString('de-DE', {
+            hour: '2-digit',
+            minute: '2-digit',
+            timeZone: 'Europe/Berlin'
+        });
         rows.push('<tr><th><span class="icon">⏱️</span>Restzeit (Ankunftszeit):</th><td>' + timeStr + ' (' + arrivalStr + ')</td></tr>');
     }
     if (drive.active_route_traffic_minutes_delay != null) {
@@ -912,7 +916,12 @@ function updateDataAge(ts) {
         var s = diff % 60;
         text = h + ' h ' + m + ' min ' + s + ' s';
     }
-    var timeStr = new Date(lastDataTimestamp).toLocaleTimeString([], {hour: '2-digit', minute: '2-digit', second: '2-digit'});
+    var timeStr = new Date(lastDataTimestamp).toLocaleTimeString('de-DE', {
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit',
+        timeZone: 'Europe/Berlin'
+    });
     $el.text('Letztes Update vor ' + text + ' (' + timeStr + ')');
 }
 


### PR DESCRIPTION
## Summary
- ensure trip files use Europe/Berlin timezone
- show API error log times in Berlin time
- display all dates in the dashboard using Berlin timezone

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f7a620f3c832187413e978ed099ce