### PR TITLE
Integrate Infobip SMS service

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This is a simple Flask application that displays real-time data from a Tesla veh
 
 4. Open `http://localhost:8013` in your browser (the server listens on `0.0.0.0:8013`).
 5. On the configuration page (`/config`) you can set your APRS call sign, passcode and an optional comment to transmit position packets via an EU APRS-IS server. You may also enable an additional WX packet using a separate call sign. Temperatures are included in Celsius within the comment. Positions are sent at most every 30 seconds while driving and at least every 10 minutes even without changes. WX packets obey the same limits and are only transmitted when the outside temperature changes or after ten minutes without an update. The page also lets you adjust the Tesla API polling interval and disable the announcement text.
-6. You can also enter the driver's phone number here to send a free message from the main page. The form only appears when a number is set and is usable only while the vehicle is driving.
+6. You can also enter the driver's phone number and your Infobip API key here. This allows sending an SMS from the main page while the vehicle is driving.
 
 All API calls are logged to `data/api.log` without storing request details. The log file uses rotation and will grow to at most 1&nbsp;MB.
 Vehicle state changes are written to `data/state.log`.

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -115,7 +115,7 @@ function showConfigured() {
 
 function updateSmsForm() {
     if (!smsForm.length) return;
-    var hasNumber = CONFIG && CONFIG.phone_number;
+    var hasNumber = CONFIG && CONFIG.phone_number && CONFIG.infobip_api_key;
     smsForm.toggle(!!hasNumber);
     var enabled = hasNumber && currentGear && currentGear !== 'P';
     smsInput.prop('disabled', !enabled);

--- a/templates/config.html
+++ b/templates/config.html
@@ -75,6 +75,12 @@
                 <input type="text" name="phone_number" value="{{ config.get('phone_number','') }}">
             </label>
         </div>
+        <div>
+            <label>
+                Infobip API Key
+                <input type="text" name="infobip_api_key" value="{{ config.get('infobip_api_key','') }}">
+            </label>
+        </div>
         <button type="submit">Speichern</button>
         <button type="submit" name="refresh_vehicle_list" value="1">Fahrzeugliste aktualisieren</button>
     </form>


### PR DESCRIPTION
## Summary
- switch SMS service from Textbelt to Infobip
- store Infobip API key in configuration
- hide SMS form when API key is missing
- document Infobip usage in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861533a5f388321bbe92a9ca0255c62