### PR TITLE
Add SMS configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This is a simple Flask application that displays real-time data from a Tesla veh
 
 4. Open `http://localhost:8013` in your browser (the server listens on `0.0.0.0:8013`).
 5. On the configuration page (`/config`) you can set your APRS call sign, passcode and an optional comment to transmit position packets via an EU APRS-IS server. You may also enable an additional WX packet using a separate call sign. Temperatures are included in Celsius within the comment. Positions are sent at most every 30 seconds while driving and at least every 10 minutes even without changes. WX packets obey the same limits and are only transmitted when the outside temperature changes or after ten minutes without an update. The page also lets you adjust the Tesla API polling interval and disable the announcement text.
-6. You can also enter the driver's phone number and your Infobip API key here. This allows sending an SMS from the main page while the vehicle is driving.
+6. You can also enter the driver's phone number and your Infobip API key here. SMS messages to the driver can be enabled or disabled and you may choose whether they are only allowed while driving or at any time.
 
 All API calls are logged to `data/api.log` without storing request details. The log file uses rotation and will grow to at most 1&nbsp;MB.
 Vehicle state changes are written to `data/state.log`.

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -115,9 +115,11 @@ function showConfigured() {
 
 function updateSmsForm() {
     if (!smsForm.length) return;
-    var hasNumber = CONFIG && CONFIG.phone_number && CONFIG.infobip_api_key;
+    var cfg = CONFIG || {};
+    var hasNumber = cfg.phone_number && cfg.infobip_api_key && cfg.sms_enabled !== false;
     smsForm.toggle(!!hasNumber);
-    var enabled = hasNumber && currentGear && currentGear !== 'P';
+    var driveOnly = cfg.sms_drive_only !== false;
+    var enabled = hasNumber && (!driveOnly || (currentGear && currentGear !== 'P'));
     smsInput.prop('disabled', !enabled);
     smsButton.prop('disabled', !enabled);
     if (!enabled) {

--- a/templates/config.html
+++ b/templates/config.html
@@ -81,6 +81,18 @@
                 <input type="text" name="infobip_api_key" value="{{ config.get('infobip_api_key','') }}">
             </label>
         </div>
+        <div>
+            <label>
+                <input type="checkbox" name="sms_enabled" value="1" {% if config.get('sms_enabled', True) %}checked{% endif %}>
+                SMS-Versand erlauben
+            </label>
+        </div>
+        <div>
+            <label>
+                <input type="checkbox" name="sms_drive_only" value="1" {% if config.get('sms_drive_only', True) %}checked{% endif %}>
+                SMS nur während der Fahrt
+            </label>
+        </div>
         <button type="submit">Speichern</button>
         <button type="submit" name="refresh_vehicle_list" value="1">Fahrzeugliste aktualisieren</button>
     </form>

--- a/templates/index.html
+++ b/templates/index.html
@@ -189,10 +189,10 @@
         </div>
     </div>
     <div id="offline-msg"></div>
-    {% if config.get('phone_number') %}
+    {% if config.get('phone_number') and config.get('sms_enabled', True) %}
     <div id="sms-form" style="display:none;">
         <input id="sms-text" type="text" maxlength="160" placeholder="Nachricht">
-        <button id="sms-send" type="button">SMS senden</button>
+        <button id="sms-send" type="button">Nachricht an Fahrer senden</button>
         <span id="sms-status"></span>
     </div>
     {% endif %}


### PR DESCRIPTION
## Summary
- allow disabling SMS and restricting to driving only
- show new checkboxes on the config page
- hide SMS form when disabled and rename button
- document feature in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686157fde7148321988327412fb6fcc3