### PR TITLE
Add Infobip base URL setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ This is a simple Flask application that displays real-time data from a Tesla veh
 4. Open `http://localhost:8013` in your browser (the server listens on `0.0.0.0:8013`).
 5. On the configuration page (`/config`) you can set your APRS call sign, passcode and an optional comment to transmit position packets via an EU APRS-IS server. You may also enable an additional WX packet using a separate call sign. Temperatures are included in Celsius within the comment. Positions are sent at most every 30 seconds while driving and at least every 10 minutes even without changes. WX packets obey the same limits and are only transmitted when the outside temperature changes or after ten minutes without an update. The page also lets you adjust the Tesla API polling interval and disable the announcement text.
 6. You can also enter the driver's phone number and your Infobip API key here. SMS messages to the driver can be enabled or disabled and you may choose whether they are only allowed while driving or at any time.
+7. Optional kann die Basis-URL für Infobip angegeben werden. Ohne Angabe wird
+   `https://api.infobip.com` verwendet. Das Feld befindet sich ebenfalls auf der
+   Seite `/config`.
 
 All API calls are logged to `data/api.log` without storing request details. The log file uses rotation and will grow to at most 1&nbsp;MB.
 Vehicle state changes are written to `data/state.log`.

--- a/app.py
+++ b/app.py
@@ -1575,6 +1575,7 @@ def api_sms():
         return jsonify({"success": False, "error": "SMS disabled"}), 400
     phone = cfg.get("phone_number")
     api_key = cfg.get("infobip_api_key")
+    base_url = cfg.get("infobip_base_url", "https://api.infobip.com")
     if not phone:
         return jsonify({"success": False, "error": "No phone number configured"}), 400
     if not api_key:
@@ -1587,8 +1588,11 @@ def api_sms():
     if not message:
         return jsonify({"success": False, "error": "Missing message"}), 400
     try:
+        if not base_url.startswith("http"):
+            base_url = "https://" + base_url
+        url = base_url.rstrip("/") + "/sms/2/text/advanced"
         resp = requests.post(
-            "https://api.infobip.com/sms/2/text/advanced",
+            url,
             json={
                 "messages": [
                     {
@@ -1631,6 +1635,7 @@ def config_page():
         announcement = request.form.get("announcement", "").strip()
         phone_number = request.form.get("phone_number", "").strip()
         infobip_api_key = request.form.get("infobip_api_key", "").strip()
+        infobip_base_url = request.form.get("infobip_base_url", "").strip()
         sms_enabled = "sms_enabled" in request.form
         sms_drive_only = "sms_drive_only" in request.form
         api_interval = request.form.get("api_interval", "").strip()
@@ -1668,6 +1673,10 @@ def config_page():
             cfg["infobip_api_key"] = infobip_api_key
         elif "infobip_api_key" in cfg:
             cfg.pop("infobip_api_key")
+        if infobip_base_url:
+            cfg["infobip_base_url"] = infobip_base_url
+        elif "infobip_base_url" in cfg:
+            cfg.pop("infobip_base_url")
         cfg["sms_enabled"] = sms_enabled
         cfg["sms_drive_only"] = sms_drive_only
         if api_interval.isdigit():

--- a/templates/config.html
+++ b/templates/config.html
@@ -83,6 +83,12 @@
         </div>
         <div>
             <label>
+                Infobip Basis-URL
+                <input type="text" name="infobip_base_url" value="{{ config.get('infobip_base_url','https://api.infobip.com') }}">
+            </label>
+        </div>
+        <div>
+            <label>
                 <input type="checkbox" name="sms_enabled" value="1" {% if config.get('sms_enabled', True) %}checked{% endif %}>
                 SMS-Versand erlauben
             </label>


### PR DESCRIPTION
## Summary
- allow configuration of Infobip base URL for SMS sending
- document Infobip URL in README
- update config page with new field

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68615c66a5a0832185176fa1de916c2a