### PR TITLE
Handle drive-only SMS

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,9 @@ This is a simple Flask application that displays real-time data from a Tesla veh
 
 4. Open `http://localhost:8013` in your browser (the server listens on `0.0.0.0:8013`).
 5. On the configuration page (`/config`) you can set your APRS call sign, passcode and an optional comment to transmit position packets via an EU APRS-IS server. You may also enable an additional WX packet using a separate call sign. Temperatures are included in Celsius within the comment. Positions are sent at most every 30 seconds while driving and at least every 10 minutes even without changes. WX packets obey the same limits and are only transmitted when the outside temperature changes or after ten minutes without an update. The page also lets you adjust the Tesla API polling interval and disable the announcement text.
-6. You can also enter the driver's phone number and your Infobip API key here. SMS messages to the driver can be enabled or disabled and you may choose whether they are only allowed while driving or at any time.
-7. Beim Senden einer SMS wird auch der Name des Absenders abgefragt. Die gesamte Nachricht inklusive Name darf maximal 160 Zeichen lang sein.
-8. Optional kann die Basis-URL für Infobip angegeben werden. Ohne Angabe wird
-   `https://api.infobip.com` verwendet. Das Feld befindet sich ebenfalls auf der
-   Seite `/config`.
+6. You can also enter the driver's phone number and your Infobip API key here. SMS messages to the driver can be enabled or disabled and you may choose whether they are only allowed while driving or at any time. If you restrict SMS to driving mode, the dashboard shows a short notice while the vehicle is parked.
+7. When sending an SMS the sender's name is requested as well. The entire message including the name must not exceed 160 characters.
+8. You can optionally provide a base URL for Infobip. If omitted, `https://api.infobip.com` is used. The field is also available on the `/config` page.
 
 All API calls are logged to `data/api.log` without storing request details. The log file uses rotation and will grow to at most 1&nbsp;MB.
 Vehicle state changes are written to `data/state.log`.

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -125,9 +125,15 @@ function updateSmsForm() {
     smsInput.prop('disabled', !enabled);
     smsButton.prop('disabled', !enabled);
     if (!enabled) {
-        smsStatus.text('');
+        if (hasNumber && driveOnly && (!currentGear || currentGear === 'P')) {
+            smsStatus.text('SMS nur während der Fahrt erlaubt');
+        } else {
+            smsStatus.text('');
+        }
         smsNameInput.val('');
         smsInput.val('');
+    } else {
+        smsStatus.text('');
     }
 }
 


### PR DESCRIPTION
## Summary
- translate README SMS section to English
- mention user notice when SMS is allowed only while driving
- show message in UI when SMS is disabled while parked

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6861658a81b08321b7c1029823f0bdb3