### PR TITLE
Improve mobile SMS form layout

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -661,6 +661,19 @@ select {
   #map {
     height: 50vh !important;
   }
+  #sms-form {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  #sms-name,
+  #sms-text,
+  #sms-form button {
+    width: 100%;
+  }
+  #sms-status {
+    margin-left: 0;
+    margin-top: 4px;
+  }
 }
 
 #openings-indicator {


### PR DESCRIPTION
## Summary
- adjust the SMS form styling for small screens

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686190472dd88321a6d0fee93d5577e3