### PR TITLE
Fix dynamic announcement info

### DIFF
--- a/app.py
+++ b/app.py
@@ -362,7 +362,7 @@ def get_news_events_info():
     """Return the current state of the news/events toggles via the API."""
     tesla = get_tesla()
     if tesla is None:
-        return "NOTIFICATIONS_GET_NEWS_AND_EVENTS_TOGGLES"
+        return ""
 
     try:
         data = tesla.api("NOTIFICATIONS_GET_NEWS_AND_EVENTS_TOGGLES")
@@ -372,7 +372,7 @@ def get_news_events_info():
             return "Toggles: " + ", ".join(pairs)
     except Exception as exc:
         _log_api_error(exc)
-    return "NOTIFICATIONS_GET_NEWS_AND_EVENTS_TOGGLES"
+    return ""
 
 
 def check_auth(username, password):
@@ -1569,7 +1569,7 @@ def api_announcement():
     cfg = load_config()
     text = cfg.get("announcement", "")
     info = get_news_events_info()
-    if info and info not in text:
+    if info:
         text = text + ("\n" if text else "") + info
     return jsonify({"announcement": text})
 


### PR DESCRIPTION
## Summary
- return empty string when news/events info unavailable
- include current news/events info in announcements every time

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6861d3b630188321ba0bc1518147ddc7