### PR TITLE
Display service appointments

### DIFF
--- a/app.py
+++ b/app.py
@@ -629,6 +629,22 @@ def _save_last_energy(vehicle_id, value):
         pass
 
 
+def get_service_appointments():
+    """Return upcoming service appointments from the Tesla API."""
+    tesla = get_tesla()
+    if tesla is None:
+        return []
+    try:
+        data = tesla.api("SERVICE_GET_SERVICE_APPOINTMENTS")
+        log_api_data("SERVICE_GET_SERVICE_APPOINTMENTS", data)
+        if isinstance(data, dict) and "serviceAppointments" in data:
+            return data.get("serviceAppointments")
+        return data
+    except Exception as exc:
+        _log_api_error(exc)
+        return []
+
+
 
 def send_aprs(vehicle_data):
     """Transmit a position packet via APRS-IS using aprslib."""
@@ -1561,6 +1577,13 @@ def api_reverse_geocode():
 def api_config():
     """Return visibility configuration as JSON."""
     return jsonify(load_config())
+
+
+@app.route("/api/service_appointments")
+def api_service_appointments():
+    """Return upcoming service appointments."""
+    visits = get_service_appointments()
+    return jsonify(visits)
 
 
 @app.route("/api/announcement")

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -374,6 +374,37 @@ select {
   margin-right: 4px;
 }
 
+/* Service appointments below the media player */
+#service-appointments {
+  margin: 10px 0;
+  padding: 10px;
+  background: var(--surface-color);
+  color: var(--text-color);
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.4);
+}
+
+#service-appointments table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+#service-appointments th,
+#service-appointments td {
+  border: 1px solid #444;
+  padding: 6px 8px;
+  text-align: left;
+}
+
+#service-appointments th {
+  white-space: nowrap;
+  font-weight: normal;
+}
+
+#service-appointments span.icon {
+  margin-right: 4px;
+}
+
 /* Progress bar for media position */
 #media-progress {
   width: 100%;

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -901,6 +901,42 @@ function updateMediaPlayer(media) {
     $player.html('<table>' + rows.join('') + '</table>');
 }
 
+function updateServiceAppointments(list) {
+    var $box = $('#service-appointments');
+    if (!list || !list.length) {
+        $box.html('<table><tr><td colspan="2"><span class="icon">🛠️</span>Keine Servicetermine</td></tr></table>');
+        return;
+    }
+    var rows = [];
+    list.forEach(function(item) {
+        var date = item.date || item.start_time || item.startTime || '';
+        var loc = item.location || item.service_center || '';
+        var status = item.status || '';
+        var text = '';
+        if (date) {
+            try {
+                text += new Date(date).toLocaleString('de-DE');
+            } catch (e) {
+                text += date;
+            }
+        }
+        if (loc) {
+            text += (text ? ' - ' : '') + loc;
+        }
+        if (status) {
+            text += (text ? ' - ' : '') + status;
+        }
+        rows.push('<tr><td>' + escapeHtml(text) + '</td></tr>');
+    });
+    $box.html('<table>' + rows.join('') + '</table>');
+}
+
+function fetchServiceAppointments() {
+    $.getJSON('/api/service_appointments', function(resp) {
+        updateServiceAppointments(resp);
+    });
+}
+
 function getStatus(data) {
     var drive = data.drive_state || {};
     var charge = data.charge_state || {};
@@ -1224,8 +1260,10 @@ setInterval(updateClientCount, 5000);
 setInterval(fetchAnnouncement, 15000);
 setInterval(fetchConfig, 15000);
 setInterval(displayParkTime, 60000);
+setInterval(fetchServiceAppointments, 900000);
 updateClientCount();
 fetchAnnouncement();
+fetchServiceAppointments();
 updateSmsForm();
 
 $('#sms-send').on('click', function() {

--- a/templates/index.html
+++ b/templates/index.html
@@ -202,6 +202,7 @@
     <div id="charging-info"></div>
     <div id="nav-bar"></div>
     <div id="media-player"></div>
+    <div id="service-appointments"></div>
     <div id="park-since"></div>
     </div>
 


### PR DESCRIPTION
## Summary
- add new /api/service_appointments endpoint
- fetch service appointments on the frontend
- render them below the music player
- style service appointments panel

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861d558bd148321bc6d482f9a638711