### PR TITLE
Fix service appointment parsing

### DIFF
--- a/app.py
+++ b/app.py
@@ -642,15 +642,21 @@ def get_service_appointments():
                 result = result["data"]
             if "response" in result and isinstance(result["response"], dict):
                 result = result["response"]
-            for key in (
+            keys = (
                 "serviceAppointments",
                 "appointments",
                 "serviceVisits",
                 "upcomingServiceVisits",
                 "scheduledVisits",
-            ):
+            )
+            for key in keys:
                 if key in result:
                     return result.get(key) or []
+                snake = "".join(
+                    "_" + c.lower() if c.isupper() else c for c in key
+                ).lstrip("_")
+                if snake in result:
+                    return result.get(snake) or []
         return result if isinstance(result, list) else []
 
     try:


### PR DESCRIPTION
## Summary
- handle snake_case service appointment keys in API responses

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861e0240d8483218bcedc1e298152ef