### PR TITLE
Implement chat room join

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,10 @@ This is a simple Flask application that displays real-time data from a Tesla veh
 
 4. Open `http://localhost:8013` in your browser (the server listens on `0.0.0.0:8013`).
 5. On the configuration page (`/config`) you can set your APRS call sign, passcode and an optional comment to transmit position packets via an EU APRS-IS server. You may also enable an additional WX packet using a separate call sign. Temperatures are included in Celsius within the comment. Positions are sent at most every 30 seconds while driving and at least every 10 minutes even without changes. WX packets obey the same limits and are only transmitted when the outside temperature changes or after ten minutes without an update. The page also lets you adjust the Tesla API polling interval and disable the announcement text.
-6. You can also enter the driver's phone number and your Infobip API key here. SMS messages to the driver can be enabled or disabled and you may choose whether they are only allowed while driving or at any time. If you restrict SMS to driving mode, messages remain possible for ten minutes after parking and are then disabled.
-7. When sending an SMS the sender's name is requested as well. The entire message including the name must not exceed 160 characters.
-8. You can optionally provide a base URL for Infobip. If omitted, `https://api.infobip.com` is used. The field is also available on the `/config` page.
+6. You can also enter the driver's phone number and your Infobip API key here. SMS messages to the driver can be enabled or disabled and you may choose whether they are only allowed while driving or at any time. If you restrict SMS to driving mode, the dashboard switches to WhatsApp delivery as soon as the vehicle is parked.
+7. When sending a text message the sender's name is requested as well. The entire message including the name must not exceed 160 characters.
+8. You can optionally provide a base URL for Infobip, the WhatsApp sender number and the template name. If omitted, `https://api.infobip.com` is used. The field is also available on the `/config` page.
+9. Set a chat room name to allow users to join via a generated link. The join button appears above the SMS form when a room is configured.
 
 All API calls are logged to `data/api.log` without storing request details. The log file uses rotation and will grow to at most 1&nbsp;MB.
 Vehicle state changes are written to `data/state.log`.

--- a/templates/config.html
+++ b/templates/config.html
@@ -89,6 +89,24 @@
         </div>
         <div>
             <label>
+                WhatsApp Absender
+                <input type="text" name="whatsapp_from" value="{{ config.get('whatsapp_from','') }}">
+            </label>
+        </div>
+        <div>
+            <label>
+                WhatsApp Template
+                <input type="text" name="whatsapp_template" value="{{ config.get('whatsapp_template','') }}">
+            </label>
+        </div>
+        <div>
+            <label>
+                Chatraum Name
+                <input type="text" name="chat_room" value="{{ config.get('chat_room','TeslaDashboard') }}">
+            </label>
+        </div>
+        <div>
+            <label>
                 <input type="checkbox" name="sms_enabled" value="1" {% if config.get('sms_enabled', True) %}checked{% endif %}>
                 SMS-Versand erlauben
             </label>

--- a/templates/index.html
+++ b/templates/index.html
@@ -189,6 +189,12 @@
         </div>
     </div>
     <div id="offline-msg"></div>
+    {% if config.get('chat_room') and config.get('infobip_api_key') %}
+    <div id="chat-link" style="display:none;">
+        <button id="chat-join" type="button">Chat beitreten</button>
+        <span id="chat-status"></span>
+    </div>
+    {% endif %}
     {% if config.get('phone_number') and config.get('sms_enabled', True) %}
     <div id="sms-form" style="display:none;">
         <input id="sms-name" type="text" placeholder="Ihr Name">


### PR DESCRIPTION
## Summary
- add chat room field on config page
- generate call link via new `/api/chatlink` endpoint
- add chat join button above SMS form
- document chat feature in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6863025e9cb48321957a2ab8ae427a7a