### PR TITLE
Improve WhatsApp error handling

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -1253,8 +1253,15 @@ $('#sms-send').on('click', function() {
                 $('#sms-status').text('Fehler: ' + (resp.error || 'unbekannt'));
             }
         },
-        error: function() {
-            $('#sms-status').text('Fehler beim Senden');
+        error: function(xhr) {
+            var msg = 'unbekannt';
+            try {
+                var resp = JSON.parse(xhr.responseText);
+                if (resp && resp.error) {
+                    msg = resp.error;
+                }
+            } catch (e) {}
+            $('#sms-status').text('Fehler: ' + msg);
         }
     });
 });


### PR DESCRIPTION
## Summary
- show backend error message when WhatsApp sending fails

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68630fa600e883218a15e51966052858