### PR TITLE
Remove WhatsApp integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,8 @@ This is a simple Flask application that displays real-time data from a Tesla veh
 
 4. Open `http://localhost:8013` in your browser (the server listens on `0.0.0.0:8013`).
 5. On the configuration page (`/config`) you can set your APRS call sign, passcode and an optional comment to transmit position packets via an EU APRS-IS server. You may also enable an additional WX packet using a separate call sign. Temperatures are included in Celsius within the comment. Positions are sent at most every 30 seconds while driving and at least every 10 minutes even without changes. WX packets obey the same limits and are only transmitted when the outside temperature changes or after ten minutes without an update. The page also lets you adjust the Tesla API polling interval and disable the announcement text.
-6. You can also enter the driver's phone number and your Infobip API key here. SMS messages to the driver can be enabled or disabled and you may choose whether they are only allowed while driving or at any time. If you restrict SMS to driving mode, the dashboard switches to WhatsApp delivery as soon as the vehicle is parked.
+6. You can also enter the driver's phone number and your Infobip API key here. SMS messages to the driver can be enabled or disabled and you may choose whether they are only allowed while driving or at any time. When restricted to driving mode, messages are still allowed for five minutes after parking.
 7. When sending a text message the sender's name is requested as well. The entire message including the name must not exceed 160 characters.
-8. You can optionally provide a base URL for Infobip, the WhatsApp sender number and a template name. Leaving the template empty sends a regular WhatsApp text message. If omitted, `https://api.infobip.com` is used. The field is also available on the `/config` page.
 
 All API calls are logged to `data/api.log` without storing request details. The log file uses rotation and will grow to at most 1&nbsp;MB.
 Vehicle state changes are written to `data/state.log`.

--- a/templates/config.html
+++ b/templates/config.html
@@ -89,18 +89,6 @@
         </div>
         <div>
             <label>
-                WhatsApp Absender
-                <input type="text" name="whatsapp_from" value="{{ config.get('whatsapp_from','') }}">
-            </label>
-        </div>
-        <div>
-            <label>
-                WhatsApp-Template (optional)
-                <input type="text" name="whatsapp_template" value="{{ config.get('whatsapp_template','') }}">
-            </label>
-        </div>
-        <div>
-            <label>
                 <input type="checkbox" name="sms_enabled" value="1" {% if config.get('sms_enabled', True) %}checked{% endif %}>
                 SMS-Versand erlauben
             </label>


### PR DESCRIPTION
## Summary
- remove WhatsApp support from backend and configuration
- add five‑minute grace period for SMS sending after parking
- update configuration page and documentation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863175ed72c83219724ff7231b4f92d