### PR TITLE
Undo previous highlight and tweak SMS color

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -879,8 +879,8 @@ select {
 #sms-form {
   margin: 10px 0;
   padding: 8px;
-  background: var(--surface-color);
-  border: 1px solid #444;
+  background: rgba(255, 235, 59, 0.2);
+  border: 1px solid #ffeb3b;
   border-radius: 8px;
   display: flex;
   align-items: center;
@@ -916,12 +916,4 @@ select {
 
 #sms-status {
   margin-left: 10px;
-}
-
-#sms-section {
-  background: rgba(211, 47, 47, 0.2);
-  border: 1px solid var(--accent-color);
-  padding: 8px;
-  border-radius: 8px;
-  margin: 10px 0;
 }

--- a/templates/config.html
+++ b/templates/config.html
@@ -69,37 +69,35 @@
                 <textarea name="announcement" rows="6" style="width:100%">{{ config.get('announcement','') }}</textarea>
             </label>
         </div>
-        <div id="sms-section">
-            <div>
-                <label>
-                    Handynummer des Fahrers
-                    <input type="text" name="phone_number" value="{{ config.get('phone_number','') }}">
-                </label>
-            </div>
-            <div>
-                <label>
-                    Infobip API Key
-                    <input type="text" name="infobip_api_key" value="{{ config.get('infobip_api_key','') }}">
-                </label>
-            </div>
-            <div>
-                <label>
-                    Infobip Basis-URL
-                    <input type="text" name="infobip_base_url" value="{{ config.get('infobip_base_url','https://api.infobip.com') }}">
-                </label>
-            </div>
-            <div>
-                <label>
-                    <input type="checkbox" name="sms_enabled" value="1" {% if config.get('sms_enabled', True) %}checked{% endif %}>
-                    SMS-Versand erlauben
-                </label>
-            </div>
-            <div>
-                <label>
-                    <input type="checkbox" name="sms_drive_only" value="1" {% if config.get('sms_drive_only', True) %}checked{% endif %}>
-                    SMS nur während der Fahrt
-                </label>
-            </div>
+        <div>
+            <label>
+                Handynummer des Fahrers
+                <input type="text" name="phone_number" value="{{ config.get('phone_number','') }}">
+            </label>
+        </div>
+        <div>
+            <label>
+                Infobip API Key
+                <input type="text" name="infobip_api_key" value="{{ config.get('infobip_api_key','') }}">
+            </label>
+        </div>
+        <div>
+            <label>
+                Infobip Basis-URL
+                <input type="text" name="infobip_base_url" value="{{ config.get('infobip_base_url','https://api.infobip.com') }}">
+            </label>
+        </div>
+        <div>
+            <label>
+                <input type="checkbox" name="sms_enabled" value="1" {% if config.get('sms_enabled', True) %}checked{% endif %}>
+                SMS-Versand erlauben
+            </label>
+        </div>
+        <div>
+            <label>
+                <input type="checkbox" name="sms_drive_only" value="1" {% if config.get('sms_drive_only', True) %}checked{% endif %}>
+                SMS nur während der Fahrt
+            </label>
         </div>
         <button type="submit">Speichern</button>
         <button type="submit" name="refresh_vehicle_list" value="1">Fahrzeugliste aktualisieren</button>


### PR DESCRIPTION
## Summary
- revert the previous merge that highlighted the config SMS section
- brighten the SMS form on the main page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68631cd703148321a63600a9ff61c671