### PR TITLE
Add basic accessibility improvements

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -16,6 +16,26 @@ body {
   padding: 0;
 }
 
+.skip-link {
+  position: absolute;
+  left: -10000px;
+  top: auto;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+}
+
+.skip-link:focus {
+  left: 10px;
+  top: 10px;
+  width: auto;
+  height: auto;
+  padding: 8px 16px;
+  background: var(--surface-color);
+  color: var(--text-color);
+  z-index: 1000;
+}
+
 h2 {
   background: var(--surface-color);
   margin: 0;

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -384,9 +384,15 @@ function updateLockStatus(locked) {
         isLocked = !!locked;
     }
     if (isLocked) {
-        $('#lock-status').text('\uD83D\uDD12').attr('title', 'Verriegelt');
+        $('#lock-status')
+            .text('\uD83D\uDD12')
+            .attr('title', 'Verriegelt')
+            .attr('aria-label', 'Verriegelt');
     } else {
-        $('#lock-status').text('\uD83D\uDD13').attr('title', 'Offen');
+        $('#lock-status')
+            .text('\uD83D\uDD13')
+            .attr('title', 'Offen')
+            .attr('aria-label', 'Offen');
     }
 }
 
@@ -409,15 +415,21 @@ function updateUserPresence(present) {
                '</svg>';
     $('#user-presence').html(icon);
     if (isPresent) {
-        $('#user-presence').css('color', '#4caf50').attr('title', 'Person im Fahrzeug');
+        $('#user-presence')
+            .css('color', '#4caf50')
+            .attr('title', 'Person im Fahrzeug')
+            .attr('aria-label', 'Person im Fahrzeug');
     } else {
-        $('#user-presence').css('color', '#d00').attr('title', 'Keine Person im Fahrzeug');
+        $('#user-presence')
+            .css('color', '#d00')
+            .attr('title', 'Keine Person im Fahrzeug')
+            .attr('aria-label', 'Keine Person im Fahrzeug');
     }
 }
 
 function updateClimateStatus(on) {
     if (on == null) {
-        $('#climate-status').text('').attr('title', '');
+        $('#climate-status').text('').attr('title', '').attr('aria-label', '');
         return;
     }
     var active = false;
@@ -428,25 +440,34 @@ function updateClimateStatus(on) {
         active = !!on;
     }
     if (active) {
-        $('#climate-status').text('\u2744\uFE0F').attr('title', 'Klimaanlage an');
+        $('#climate-status')
+            .text('\u2744\uFE0F')
+            .attr('title', 'Klimaanlage an')
+            .attr('aria-label', 'Klimaanlage an');
     } else {
-        $('#climate-status').text('\uD83D\uDEAB').attr('title', 'Klimaanlage aus');
+        $('#climate-status')
+            .text('\uD83D\uDEAB')
+            .attr('title', 'Klimaanlage aus')
+            .attr('aria-label', 'Klimaanlage aus');
     }
 }
 
 function updateFanStatus(speed) {
     if (speed == null || isNaN(speed)) {
-        $('#fan-status').text('').attr('title', '');
+        $('#fan-status').text('').attr('title', '').attr('aria-label', '');
         return;
     }
     var val = Math.max(0, Math.min(11, Number(speed)));
-    $('#fan-status').text('\uD83C\uDF00 ' + val).attr('title', 'L\u00FCfterstufe ' + val);
+    $('#fan-status')
+        .text('\uD83C\uDF00 ' + val)
+        .attr('title', 'L\u00FCfterstufe ' + val)
+        .attr('aria-label', 'L\u00FCfterstufe ' + val);
 }
 
 function updateClimateMode(mode) {
     var $el = $('#climate-mode');
     if (!mode || mode === 'off') {
-        $el.text('').attr('title', '').hide();
+        $el.text('').attr('title', '').attr('aria-label', '').hide();
         return;
     }
     var icon = '';
@@ -461,25 +482,39 @@ function updateClimateMode(mode) {
         $el.text('').attr('title', '').hide();
         return;
     }
-    $el.text(icon).attr('title', title).show();
+    $el.text(icon)
+        .attr('title', title)
+        .attr('aria-label', title)
+        .show();
 }
 
 function updateCabinProtection(value) {
     var $el = $('#cabin-protection');
     if (value === 'On') {
-        $el.text('\u2600\uFE0F').attr('title', 'Kabinenschutz aktiv').show();
+        $el.text('\u2600\uFE0F')
+            .attr('title', 'Kabinenschutz aktiv')
+            .attr('aria-label', 'Kabinenschutz aktiv')
+            .show();
     } else {
-        $el.text('').attr('title', '').hide();
+        $el.text('')
+            .attr('title', '')
+            .attr('aria-label', '')
+            .hide();
     }
 }
 
 function updateDesiredTemp(temp) {
     if (temp == null || isNaN(temp)) {
-        $('#desired-temp').text('Wunsch: -- \u00B0C').attr('title', 'Wunschtemperatur');
+        $('#desired-temp')
+            .text('Wunsch: -- \u00B0C')
+            .attr('title', 'Wunschtemperatur')
+            .attr('aria-label', 'Wunschtemperatur -- \u00B0C');
         return;
     }
-    $('#desired-temp').text('Wunsch: ' + temp.toFixed(1) + ' \u00B0C')
-        .attr('title', 'Wunschtemperatur');
+    $('#desired-temp')
+        .text('Wunsch: ' + temp.toFixed(1) + ' \u00B0C')
+        .attr('title', 'Wunschtemperatur')
+        .attr('aria-label', 'Wunschtemperatur ' + temp.toFixed(1) + ' \u00B0C');
 }
 
 function updateHeaterIndicator(front, rear, steering, wiper,
@@ -487,8 +522,10 @@ function updateHeaterIndicator(front, rear, steering, wiper,
                                seatL, seatR, seatRL, seatRC, seatRR) {
     function set(id, val, name) {
         if (val == null) {
-            $('#' + id).html(name + ': \uD83D\uDEAB')
-                .attr('title', name + ' unbekannt');
+            $('#' + id)
+                .html(name + ': \uD83D\uDEAB')
+                .attr('title', name + ' unbekannt')
+                .attr('aria-label', name + ' unbekannt');
             return;
         }
         var active = false;
@@ -498,22 +535,30 @@ function updateHeaterIndicator(front, rear, steering, wiper,
         } else {
             active = !!val;
         }
-        $('#' + id).html(name + ': ' + (active ? '\uD83D\uDD25' : '\uD83D\uDEAB'))
-            .attr('title', name + (active ? ' an' : ' aus'));
+        $('#' + id)
+            .html(name + ': ' + (active ? '\uD83D\uDD25' : '\uD83D\uDEAB'))
+            .attr('title', name + (active ? ' an' : ' aus'))
+            .attr('aria-label', name + (active ? ' an' : ' aus'));
     }
     function setLevel(id, val, name) {
         if (val == null || isNaN(val)) {
-            $('#' + id).html(name + ': \uD83D\uDEAB')
-                .attr('title', name + ' unbekannt');
+            $('#' + id)
+                .html(name + ': \uD83D\uDEAB')
+                .attr('title', name + ' unbekannt')
+                .attr('aria-label', name + ' unbekannt');
             return;
         }
         var level = Number(val);
         if (level <= 0) {
-            $('#' + id).html(name + ': \uD83D\uDEAB')
-                .attr('title', name + ' aus');
+            $('#' + id)
+                .html(name + ': \uD83D\uDEAB')
+                .attr('title', name + ' aus')
+                .attr('aria-label', name + ' aus');
         } else {
-            $('#' + id).html(name + ': \uD83D\uDD25' + level)
-                .attr('title', name + ' Stufe ' + level);
+            $('#' + id)
+                .html(name + ': \uD83D\uDD25' + level)
+                .attr('title', name + ' Stufe ' + level)
+                .attr('aria-label', name + ' Stufe ' + level);
         }
     }
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -15,6 +15,7 @@
     <script src="/static/js/Leaflet.Marker.SlideTo.js"></script>
 </head>
 <body>
+    <a href="#dashboard-content" class="skip-link">Zum Inhalt springen</a>
     <h2>Tesla-Dashboard V{{ version }}
         <span id="header-right">
             <span id="vehicle-info"></span>&nbsp;&nbsp;&nbsp;<span id="vehicle-status"></span>
@@ -35,7 +36,7 @@
         <select id="vehicle-select"></select>
         <div id="map-container">
             <div id="map">
-                <div id="location-address"><div id="address-text"></div></div>
+                <div id="location-address"><div id="address-text" aria-live="polite"></div></div>
                 <div id="zoom-level"></div>
             </div>
             <div id="sidebar-right">
@@ -54,14 +55,14 @@
                     <div id="seat-rear-right" title="Sitzheizung hinten rechts"></div>
                     <hr />
                 </div>
-                <div id="announcement-box"></div>
+                <div id="announcement-box" aria-live="polite"></div>
             </div>
         </div>
     <hr />
     <div id="status-bar">
         <div id="lock-container">
-            <div id="lock-status" title="Verriegelt">🔒</div>
-            <div id="user-presence" title="Niemand im Fahrzeug"></div>
+            <div id="lock-status" title="Verriegelt" role="img" aria-label="Verriegelt">🔒</div>
+            <div id="user-presence" title="Niemand im Fahrzeug" role="img" aria-label="Niemand im Fahrzeug"></div>
         </div>
         <div id="gear-shift">
             <div data-gear="P">P</div>
@@ -89,9 +90,9 @@
                     </g>
                     <line id="speedometer-needle" x1="60" y1="50" x2="60" y2="-5" stroke="#d00" stroke-width="3" transform="rotate(-90 60 50)" />
                 </svg>
-                <div id="speed-value">0 km/h</div>
-                <div id="power-value" class="power">0 kW</div>
-                <div id="odometer-value" class="odometer">0 km</div>
+                <div id="speed-value" aria-live="polite">0 km/h</div>
+                <div id="power-value" class="power" aria-live="polite">0 kW</div>
+                <div id="odometer-value" class="odometer" aria-live="polite">0 km</div>
             </div>
         <div id="thermometers">
             <div class="thermometer">
@@ -100,8 +101,8 @@
                     <rect id="inside-level" x="11" y="45" width="8" height="0" class="level" />
                     <circle id="inside-bulb" cx="15" cy="50" r="9" class="bulb" />
                 </svg>
-                <div id="inside-temp-value" class="label">Innen: -- °C</div>
-                <div id="desired-temp" class="label" title="Wunschtemperatur">Wunsch: -- °C</div>
+                <div id="inside-temp-value" class="label" aria-live="polite">Innen: -- °C</div>
+                <div id="desired-temp" class="label" title="Wunschtemperatur" aria-live="polite">Wunsch: -- °C</div>
             </div>
             <div class="thermometer">
                 <svg width="30" height="70" viewBox="0 0 30 60">
@@ -109,16 +110,16 @@
                     <rect id="outside-level" x="11" y="45" width="8" height="0" class="level" />
                     <circle id="outside-bulb" cx="15" cy="50" r="9" class="bulb" />
                 </svg>
-                <div id="outside-temp-value" class="label">Außen: -- °C</div>
+                <div id="outside-temp-value" class="label" aria-live="polite">Außen: -- °C</div>
             </div>
         </div>
         <div id="climate-indicator">
-            <div id="climate-status" title="Klimaanlage aus">🚫</div>
+            <div id="climate-status" title="Klimaanlage aus" role="img" aria-label="Klimaanlage aus">🚫</div>
             <div id="climate-row">
-                <div id="climate-mode" title=""></div>
-                <div id="cabin-protection" title=""></div>
+                <div id="climate-mode" title="" role="img" aria-label=""></div>
+                <div id="cabin-protection" title="" role="img" aria-label=""></div>
             </div>
-            <div id="fan-status" title="Lüfterstufe">🌀 0</div>
+            <div id="fan-status" title="Lüfterstufe" role="img" aria-label="Lüfterstufe">🌀 0</div>
         </div>
         <div id="openings-indicator">
             <svg viewBox="0 0 100 200">


### PR DESCRIPTION
## Summary
- add keyboard skip link to jump to dashboard content
- mark dynamic values with aria-live and label icons for screen readers
- style the skip link

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68637eb980ec8321b2ae9d229a24d426