### PR TITLE
Fix energy logging per session

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This is a simple Flask application that displays real-time data from a Tesla veh
 
 All API calls are logged to `data/api.log` without storing request details. The log file uses rotation and will grow to at most 1&nbsp;MB.
 Vehicle state changes are written to `data/state.log`.
-Added charging energy is appended to `data/energy.log` whenever the value changes while charging. Timestamps in this file are recorded in the Europe/Berlin timezone.
+Added charging energy is appended to `data/energy.log` once a charging session finishes. Timestamps in this file are recorded in the Europe/Berlin timezone.
 The latest successful API response is stored in `data/<vehicle_id>/cache.json`.
 This cache is always updated with the current vehicle state so the dashboard
 knows whether the car is online, asleep or offline even when no fresh data is


### PR DESCRIPTION
## Summary
- log charging energy only once a session completes
- document new logging behaviour in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686709c1a8d883218af7066d1d7c6e07