### PR TITLE
Add vehicle alarm popup

### DIFF
--- a/app.py
+++ b/app.py
@@ -1618,6 +1618,24 @@ def api_announcement():
     return jsonify({"announcement": text})
 
 
+@app.route("/api/alarm_state")
+@app.route("/api/alarm_state/<vehicle_id>")
+def api_alarm_state(vehicle_id=None):
+    """Return the current alarm state."""
+    vid = vehicle_id or "default"
+    _start_thread(vid)
+    data = latest_data.get(vid)
+    if data is None:
+        data = _fetch_data_once(vid)
+    alarm = None
+    if isinstance(data, dict):
+        alarm = data.get("alarm_state")
+        if alarm is None:
+            vs = data.get("vehicle_state", {})
+            alarm = vs.get("alarm_state")
+    return jsonify({"alarm_state": alarm})
+
+
 @app.route("/api/occupant", methods=["GET", "POST"])
 def api_occupant():
     """Return or update occupant presence status."""

--- a/docs/alarm_logger.py
+++ b/docs/alarm_logger.py
@@ -1,0 +1,43 @@
+"""Beispielskript zum Protokollieren des Fahrzeugalarmzustands."""
+
+import datetime
+import os
+import time
+import requests
+
+API_URL = os.getenv("API_URL", "http://localhost:8013/api/alarm_state")
+ACCESS_TOKEN = os.getenv("ACCESS_TOKEN")
+LOG_FILE = "alarm.log"
+INTERVAL = 15
+
+
+def log_event(message: str) -> None:
+    timestamp = datetime.datetime.now().isoformat()
+    with open(LOG_FILE, "a", encoding="utf-8") as f:
+        f.write(f"{timestamp} - {message}\n")
+    print(f"{timestamp} - {message}")
+
+
+def get_alarm_state():
+    headers = {}
+    if ACCESS_TOKEN:
+        headers["Authorization"] = f"Bearer {ACCESS_TOKEN}"
+    try:
+        response = requests.get(API_URL, headers=headers)
+        if response.status_code == 200:
+            data = response.json()
+            return data.get("alarm_state")
+        log_event(f"Fehler bei API-Abfrage: {response.status_code}")
+    except Exception as e:
+        log_event(f"Fehler: {e}")
+    return None
+
+
+log_event("\U0001F697 Tesla Alarm Logger gestartet.")
+while True:
+    state = get_alarm_state()
+    if state == "alarm_triggered":
+        log_event("\u26a0 ALARM ausgelöst!")
+    elif state is not None:
+        log_event(f"Alarmstatus: {state}")
+    time.sleep(INTERVAL)

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -269,6 +269,35 @@ select {
   white-space: normal;
 }
 
+#alarm-popup {
+  display: none;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(255, 0, 0, 0.7);
+  z-index: 2000;
+  color: #fff;
+  font-size: 1.2em;
+  text-align: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+}
+
+#alarm-popup .box {
+  background: rgba(255, 0, 0, 0.9);
+  padding: 20px;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
+}
+
+#alarm-popup button {
+  margin-top: 10px;
+}
+
 #v2l-infos,
 #charging-info,
 /* Navigation bar below the status bar */

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -298,6 +298,11 @@ function handleData(data) {
                vehicle.tpms_pressure_rr);
     updateOpenings(vehicle, charge);
     updateMediaPlayer(vehicle.media_info);
+    var alarm = data.alarm_state;
+    if (alarm == null && vehicle.alarm_state != null) {
+        alarm = vehicle.alarm_state;
+    }
+    updateAlarmPopup(alarm);
     var lat = drive.latitude;
     var lng = drive.longitude;
     var slide = false;
@@ -956,6 +961,23 @@ function updateMediaPlayer(media) {
     $player.html('<table>' + rows.join('') + '</table>');
 }
 
+function updateAlarmPopup(state) {
+    var active = false;
+    if (state != null) {
+        if (typeof state === 'string') {
+            var norm = state.toLowerCase();
+            active = norm !== 'off' && norm !== 'inactive' && norm !== '0';
+        } else {
+            active = !!state;
+        }
+    }
+    if (active) {
+        $('#alarm-popup').show();
+    } else {
+        $('#alarm-popup').hide();
+    }
+}
+
 function getStatus(data) {
     var drive = data.drive_state || {};
     var charge = data.charge_state || {};
@@ -1332,4 +1354,8 @@ $('#sms-send').on('click', function() {
             $('#sms-status').text('Fehler: ' + msg);
         }
     });
+});
+
+$('#alarm-close').on('click', function() {
+    $('#alarm-popup').hide();
 });

--- a/templates/index.html
+++ b/templates/index.html
@@ -56,6 +56,12 @@
                     <hr />
                 </div>
                 <div id="announcement-box" aria-live="polite"></div>
+                <div id="alarm-popup" role="alert">
+                    <div class="box">
+                        Fahrzeugalarm!
+                        <button id="alarm-close">OK</button>
+                    </div>
+                </div>
             </div>
         </div>
     <hr />


### PR DESCRIPTION
## Summary
- add alert element on the dashboard
- style alarm popup overlay
- show/hide popup based on alarm state
- expose `/api/alarm_state` endpoint
- refine popup overlay and add example alarm logger script

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68670c1ed1e08321b062520181f9e756