### PR TITLE
Fix vehicle alarm popup on page load

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -281,10 +281,13 @@ select {
   color: #fff;
   font-size: 1.2em;
   text-align: center;
-  display: flex;
   align-items: center;
   justify-content: center;
   flex-direction: column;
+}
+
+#alarm-popup.show {
+  display: flex;
 }
 
 #alarm-popup .box {

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -972,9 +972,9 @@ function updateAlarmPopup(state) {
         }
     }
     if (active) {
-        $('#alarm-popup').show();
+        $('#alarm-popup').addClass('show');
     } else {
-        $('#alarm-popup').hide();
+        $('#alarm-popup').removeClass('show');
     }
 }
 
@@ -1357,5 +1357,5 @@ $('#sms-send').on('click', function() {
 });
 
 $('#alarm-close').on('click', function() {
-    $('#alarm-popup').hide();
+    $('#alarm-popup').removeClass('show');
 });


### PR DESCRIPTION
## Summary
- ensure alarm popup is hidden by default and only shown when needed
- adjust CSS and JS to toggle a `show` class instead of using `.show()`/`.hide()`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686710c08b4483219277a0510b493691