### PR TITLE
Add SMS log

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ This is a simple Flask application that displays real-time data from a Tesla veh
 6. You can also enter the driver's phone number in international format (for example `+491701234567`), your Infobip API key and an optional sender ID here. Leave the sender field empty if the account does not support custom senders. SMS messages to the driver can be enabled or disabled and you may choose whether they are only allowed while driving or at any time. When restricted to driving mode, messages are still allowed for five minutes after parking.
 7. When sending a text message the sender's name is requested as well. The entire message including the name must not exceed 160 characters.
 
+All sent text messages are written to `data/sms.log` and can be viewed on the `/sms` page.
+
 All API calls are logged to `data/api.log` without storing request details. The log file uses rotation and will grow to at most 1&nbsp;MB.
 Vehicle state changes are written to `data/state.log`.
 Added charging energy is appended to `data/energy.log` once a charging session finishes. Timestamps in this file are recorded in the Europe/Berlin timezone.
@@ -78,6 +80,7 @@ The same information is also stored as hierarchical JSON in `data/api-liste.json
 * `/state` – display the vehicle state log
 * `/debug` – display environment info and recent log lines
 * `/apilog` – show the raw API log
+* `/sms` – show the SMS log
 * `/api/vehicles` – list available vehicles as JSON
 * `/api/state` – return the current vehicle state as JSON
 * `/api/version` – return the current dashboard version as JSON

--- a/templates/sms.html
+++ b/templates/sms.html
@@ -1,0 +1,18 @@
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="Tesla Dashboard zur Anzeige aktueller Fahrzeugdaten">
+    <meta name="keywords" content="Tesla, Dashboard, Fahrzeugdaten, Statistik, Karte, Elektroauto, Ladung, Stromverbrauch, Standort, Routenplanung, Fahrzeugstatus, Kilometerstand, Trip, Tesla Model S, Model 3, Model X, Model Y">
+    <title>SMS Log</title>
+    <link rel="stylesheet" href="/static/css/style.css" />
+    {% include 'analytics.html' %}
+    <style>
+        pre { background:#1f1f1f; padding:10px; overflow-x:auto; color: var(--text-color); }
+    </style>
+</head>
+<body>
+    <h1>SMS Log</h1>
+    <pre>{{ log_lines|join('') }}</pre>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- store sent SMS in `data/sms.log`
- expose `/sms` page to view the log
- document new feature and endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68719b23c6a8832193f947da4bbb8f15