### PR TITLE
Implement local timezone for SMS log

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ This is a simple Flask application that displays real-time data from a Tesla veh
 7. When sending a text message the sender's name is requested as well. The entire message including the name must not exceed 160 characters.
 
 All sent text messages are written to `data/sms.log` and can be viewed on the `/sms` page.
+Timestamps in this file are recorded in the Europe/Berlin timezone.
 
 All API calls are logged to `data/api.log` without storing request details. The log file uses rotation and will grow to at most 1&nbsp;MB.
 Vehicle state changes are written to `data/state.log`.

--- a/app.py
+++ b/app.py
@@ -148,6 +148,7 @@ if not sms_logger.handlers:
         os.path.join(DATA_DIR, "sms.log"), maxBytes=100_000, backupCount=1
     )
     formatter = logging.Formatter("%(asctime)s %(message)s")
+    formatter.converter = lambda ts: datetime.fromtimestamp(ts, LOCAL_TZ).timetuple()
     handler.setFormatter(formatter)
     sms_logger.addHandler(handler)
     sms_logger.setLevel(logging.INFO)


### PR DESCRIPTION
## Summary
- store SMS log timestamps in Europe/Berlin timezone
- document SMS log timezone in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687209f82b1c83218b5f1e4bf87eb57a