### PR TITLE
Enable taximeter without auth

### DIFF
--- a/app.py
+++ b/app.py
@@ -2076,18 +2076,22 @@ def taxameter_page():
 
 
 @app.route("/api/taxameter/start", methods=["POST"])
-@requires_auth
 def api_taxameter_start():
     _start_thread("default")
-    started = taximeter.start()
-    return jsonify({"active": started})
+    taximeter.start()
+    return jsonify(taximeter.status())
 
 
 @app.route("/api/taxameter/stop", methods=["POST"])
-@requires_auth
 def api_taxameter_stop():
     result = taximeter.stop()
     return jsonify(result or {"active": False})
+
+
+@app.route("/api/taxameter/reset", methods=["POST"])
+def api_taxameter_reset():
+    taximeter.reset()
+    return jsonify({"active": False})
 
 
 @app.route("/api/taxameter/status")

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -985,3 +985,31 @@ select {
 #sms-status {
   margin-left: 10px;
 }
+
+/* Taximeter page */
+#taximeter {
+  text-align: center;
+  margin-top: 40px;
+}
+
+#taximeter-display {
+  background: #000;
+  color: #0f0;
+  font-family: 'Courier New', monospace;
+  font-size: 2.5rem;
+  padding: 20px;
+  border: 3px solid #444;
+  border-radius: 8px;
+  display: inline-block;
+  min-width: 200px;
+  margin-bottom: 10px;
+}
+
+#taximeter-buttons button {
+  padding: 10px 16px;
+  margin: 0 4px;
+  background: var(--surface-color);
+  color: var(--text-color);
+  border: 1px solid #444;
+  border-radius: 4px;
+}

--- a/static/js/taxameter.js
+++ b/static/js/taxameter.js
@@ -1,25 +1,47 @@
 $(function() {
     function update() {
         $.getJSON('/api/taxameter/status', function(data) {
+            if (data.price !== undefined) {
+                $('#price').text(Number(data.price).toFixed(2));
+            }
+            if (data.distance !== undefined) {
+                $('#dist').text(Number(data.distance).toFixed(2));
+            }
+            if (data.duration !== undefined) {
+                $('#time').text(Math.round(data.duration));
+            }
             if (!data.active) {
                 $('#start-btn').prop('disabled', false);
                 $('#stop-btn').prop('disabled', true);
+                $('#reset-btn').prop('disabled', !('price' in data));
             } else {
                 $('#start-btn').prop('disabled', true);
                 $('#stop-btn').prop('disabled', false);
-                $('#dist').text(data.distance.toFixed(2));
-                $('#price').text(data.price.toFixed(2));
-                $('#time').text(Math.round(data.duration));
+                $('#reset-btn').prop('disabled', true);
             }
         });
     }
 
     $('#start-btn').click(function() {
-        $.post('/api/taxameter/start', update);
+        $.post('/api/taxameter/start', update, 'json');
     });
 
     $('#stop-btn').click(function() {
-        $.post('/api/taxameter/stop', update);
+        $.post('/api/taxameter/stop', function(data) {
+            if (data.price !== undefined) {
+                $('#price').text(Number(data.price).toFixed(2));
+                $('#dist').text(Number(data.distance).toFixed(2));
+                $('#time').text(Math.round(data.duration));
+            }
+            update();
+        }, 'json');
+    });
+
+    $('#reset-btn').click(function() {
+        $.post('/api/taxameter/reset', update);
+        $('#price').text('0.00');
+        $('#dist').text('0.00');
+        $('#time').text('0');
     });
 
     update();

--- a/templates/taxameter.html
+++ b/templates/taxameter.html
@@ -10,14 +10,19 @@
 </head>
 <body>
     <h1>Taxameter</h1>
-    <div>
-        <button id="start-btn">Start</button>
-        <button id="stop-btn" disabled>Stop</button>
-    </div>
-    <div>
-        <p>Distanz: <span id="dist">0</span> km</p>
-        <p>Zeit: <span id="time">0</span> s</p>
-        <p>Preis: <span id="price">0</span> €</p>
+    <div id="taximeter">
+        <div id="taximeter-display">
+            <span id="price">0.00</span> €
+        </div>
+        <div id="taximeter-info">
+            <span id="dist">0.00</span> km |
+            <span id="time">0</span> s
+        </div>
+        <div id="taximeter-buttons">
+            <button id="start-btn">Start</button>
+            <button id="stop-btn" disabled>Stop</button>
+            <button id="reset-btn" disabled>Reset</button>
+        </div>
     </div>
     <script src="/static/js/taxameter.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- remove auth from taximeter endpoints
- show tariff base price when starting
- retain last result in status endpoint
- add reset function to taximeter
- enhance taximeter page layout and controls
- style taximeter display

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bea6ac7fc83219edb3caeddd8f2d4