### PR TITLE
Add taximeter receipt display

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1013,3 +1013,15 @@ select {
   border: 1px solid #444;
   border-radius: 4px;
 }
+
+#taximeter-receipt {
+  background: #000;
+  color: #0f0;
+  font-family: 'Courier New', monospace;
+  padding: 10px;
+  border: 2px solid #444;
+  border-radius: 8px;
+  display: inline-block;
+  margin-top: 20px;
+  text-align: left;
+}

--- a/static/js/taxameter.js
+++ b/static/js/taxameter.js
@@ -22,7 +22,35 @@ $(function() {
         });
     }
 
+    function showReceipt(breakdown) {
+        if (!breakdown) {
+            return;
+        }
+        var lines = [];
+        lines.push('Grundpreis: ' + breakdown.base.toFixed(2) + ' \xE2\x82\xAC');
+        if (breakdown.km_1_2 > 0) {
+            lines.push(breakdown.km_1_2.toFixed(2) + ' km x ' +
+                breakdown.rate_1_2.toFixed(2) + ' \xE2\x82\xAC = ' +
+                breakdown.cost_1_2.toFixed(2) + ' \xE2\x82\xAC');
+        }
+        if (breakdown.km_3_4 > 0) {
+            lines.push(breakdown.km_3_4.toFixed(2) + ' km x ' +
+                breakdown.rate_3_4.toFixed(2) + ' \xE2\x82\xAC = ' +
+                breakdown.cost_3_4.toFixed(2) + ' \xE2\x82\xAC');
+        }
+        if (breakdown.km_5_plus > 0) {
+            lines.push(breakdown.km_5_plus.toFixed(2) + ' km x ' +
+                breakdown.rate_5_plus.toFixed(2) + ' \xE2\x82\xAC = ' +
+                breakdown.cost_5_plus.toFixed(2) + ' \xE2\x82\xAC');
+        }
+        lines.push('--------------------');
+        lines.push('Gesamt: ' + breakdown.total.toFixed(2) + ' \xE2\x82\xAC');
+        $('#receipt-text').text(lines.join('\n'));
+        $('#taximeter-receipt').show();
+    }
+
     $('#start-btn').click(function() {
+        $('#taximeter-receipt').hide();
         $.post('/api/taxameter/start', update, 'json');
     });
 
@@ -32,6 +60,7 @@ $(function() {
                 $('#price').text(Number(data.price).toFixed(2));
                 $('#dist').text(Number(data.distance).toFixed(2));
                 $('#time').text(Math.round(data.duration));
+                showReceipt(data.breakdown);
             }
             update();
         }, 'json');
@@ -42,6 +71,7 @@ $(function() {
         $('#price').text('0.00');
         $('#dist').text('0.00');
         $('#time').text('0');
+        $('#taximeter-receipt').hide();
     });
 
     update();

--- a/templates/taxameter.html
+++ b/templates/taxameter.html
@@ -23,6 +23,9 @@
             <button id="stop-btn" disabled>Stop</button>
             <button id="reset-btn" disabled>Reset</button>
         </div>
+        <div id="taximeter-receipt" style="display:none;">
+            <pre id="receipt-text"></pre>
+        </div>
     </div>
     <script src="/static/js/taxameter.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- show a breakdown of the taximeter tariff when stopping a ride
- hide receipt on start/reset and style new element

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bed701b188321bbf1e8a0f7c234ba