### PR TITLE
Implement configurable waiting charges for taximeter

### DIFF
--- a/static/js/taxameter.js
+++ b/static/js/taxameter.js
@@ -26,35 +26,40 @@ $(function() {
         if (!breakdown) {
             return;
         }
+        function fmt(value) {
+            return value.toFixed(2).padStart(7);
+        }
         var lines = [];
-        lines.push('Grundpreis: ' + breakdown.base.toFixed(2) + ' €');
+        lines.push('Grundpreis:' + fmt(breakdown.base) + ' €');
         if (breakdown.km_1_2 > 0) {
             lines.push(breakdown.km_1_2.toFixed(2) + ' km x ' +
-                breakdown.rate_1_2.toFixed(2) + ' € = ' +
-                breakdown.cost_1_2.toFixed(2) + ' €');
+                breakdown.rate_1_2.toFixed(2) + ' € =' + fmt(breakdown.cost_1_2) + ' €');
         }
         if (breakdown.km_3_4 > 0) {
             lines.push(breakdown.km_3_4.toFixed(2) + ' km x ' +
-                breakdown.rate_3_4.toFixed(2) + ' € = ' +
-                breakdown.cost_3_4.toFixed(2) + ' €');
+                breakdown.rate_3_4.toFixed(2) + ' € =' + fmt(breakdown.cost_3_4) + ' €');
         }
         if (breakdown.km_5_plus > 0) {
             lines.push(breakdown.km_5_plus.toFixed(2) + ' km x ' +
-                breakdown.rate_5_plus.toFixed(2) + ' € = ' +
-                breakdown.cost_5_plus.toFixed(2) + ' €');
+                breakdown.rate_5_plus.toFixed(2) + ' € =' + fmt(breakdown.cost_5_plus) + ' €');
+        }
+        if (breakdown.wait_cost > 0) {
+            lines.push('Standzeit ' + Math.round(breakdown.wait_time) + 's =' + fmt(breakdown.wait_cost) + ' €');
         }
         lines.push('--------------------');
+        lines.push('Gesamt:' + fmt(breakdown.total) + ' €');
         lines.push('Fahrstrecke: ' + distance.toFixed(2) + ' km');
-        lines.push('Gesamt: ' + breakdown.total.toFixed(2) + ' €');
         $('#receipt-text').text(lines.join('\n'));
         $('#receipt-company').empty();
         if (company) {
             $('#receipt-company').append('<div class="company-name">' + company + '</div>');
-            $('#receipt-company').append('<div class="company-slogan">Wir lassen Sie nicht im Regen stehen.</div>');
+            if (typeof TAXI_SLOGAN !== 'undefined' && TAXI_SLOGAN) {
+                $('#receipt-company').append('<div class="company-slogan">' + TAXI_SLOGAN + '</div>');
+            }
         }
         $('#receipt-qr').empty();
         if (qr_path) {
-            $('#receipt-qr').append('<img src="' + qr_path + '" alt="QR">');
+            $('#receipt-qr').append('<img src="' + qr_path + '" alt="QR" style="width:50%">');
         }
         $('#taximeter-receipt').show();
     }

--- a/templates/config.html
+++ b/templates/config.html
@@ -71,12 +71,6 @@
         </div>
         <div>
             <label>
-                Taxiunternehmen
-                <input type="text" name="taxi_company" value="{{ config.get('taxi_company','Taxi Schauer') }}">
-            </label>
-        </div>
-        <div>
-            <label>
                 Handynummer des Fahrers
                 <input type="text" name="phone_number" value="{{ config.get('phone_number','') }}">
             </label>
@@ -111,7 +105,26 @@
                 SMS nur während der Fahrt
             </label>
         </div>
-        <h2>Taxameter Tarif (Euro)</h2>
+        <h2>Taxameter</h2>
+        <div>
+            <label>
+                Taxiunternehmen
+                <input type="text" name="taxi_company" value="{{ config.get('taxi_company','Taxi Schauer') }}">
+            </label>
+        </div>
+        <div>
+            <label>
+                Slogan
+                <input type="text" name="taxi_slogan" value="{{ config.get('taxi_slogan','Wir lassen Sie nicht im Regen stehen.') }}">
+            </label>
+        </div>
+        <div>
+            <label>
+                Wartepreis je 10 Sekunden
+                <input type="number" step="0.01" name="wait_price" value="{{ config.get('taximeter_tariff', {}).get('wait_per_10s', 0.10) }}">
+            </label>
+        </div>
+        <h3>Tarif (Euro)</h3>
         <div>
             <label>
                 Grundgebühr
@@ -134,31 +147,6 @@
             <label>
                 ab 5. km
                 <input type="number" step="0.01" name="tariff_5" value="{{ config.get('taximeter_tariff', {}).get('rate_5_plus', 2.40) }}">
-            </label>
-        </div>
-        <h3>Nachttarif (22–6 Uhr)</h3>
-        <div>
-            <label>
-                Grundgebühr
-                <input type="number" step="0.01" name="night_base" value="{{ config.get('taximeter_tariff', {}).get('night_base', config.get('taximeter_tariff', {}).get('base', 4.40)) }}">
-            </label>
-        </div>
-        <div>
-            <label>
-                1.–2. km
-                <input type="number" step="0.01" name="night_12" value="{{ config.get('taximeter_tariff', {}).get('night_rate_1_2', config.get('taximeter_tariff', {}).get('rate_1_2', 2.70)) }}">
-            </label>
-        </div>
-        <div>
-            <label>
-                3.–4. km
-                <input type="number" step="0.01" name="night_34" value="{{ config.get('taximeter_tariff', {}).get('night_rate_3_4', config.get('taximeter_tariff', {}).get('rate_3_4', 2.60)) }}">
-            </label>
-        </div>
-        <div>
-            <label>
-                ab 5. km
-                <input type="number" step="0.01" name="night_5" value="{{ config.get('taximeter_tariff', {}).get('night_rate_5_plus', config.get('taximeter_tariff', {}).get('rate_5_plus', 2.40)) }}">
             </label>
         </div>
         <button type="submit">Speichern</button>

--- a/templates/taxameter.html
+++ b/templates/taxameter.html
@@ -31,6 +31,7 @@
     </div>
     <script>
         const TAXI_COMPANY = "{{ company }}";
+        const TAXI_SLOGAN = "{{ config.get('taxi_slogan','Wir lassen Sie nicht im Regen stehen.') }}";
     </script>
     <script src="/static/js/taxameter.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- add configurable wait charge and slogan to taximeter
- remove night tariff
- calculate standstill price when speed < 5 km/h
- align receipt prices and move distance line
- expose new options on the config page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c0da172908321941eb395e01bba81