### PR TITLE
Implement pause and wait indicator for taximeter

### DIFF
--- a/app.py
+++ b/app.py
@@ -2152,6 +2152,12 @@ def api_taxameter_start():
     return jsonify(taximeter.status())
 
 
+@app.route("/api/taxameter/pause", methods=["POST"])
+def api_taxameter_pause():
+    taximeter.pause()
+    return jsonify(taximeter.status())
+
+
 @app.route("/api/taxameter/stop", methods=["POST"])
 def api_taxameter_stop():
     result = taximeter.stop()

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -997,6 +997,8 @@ select {
   color: #0f0;
   font-family: 'Courier New', monospace;
   font-size: 2.5rem;
+  letter-spacing: 0.1rem;
+  text-shadow: 0 0 6px #0f0;
   padding: 20px;
   border: 3px solid #444;
   border-radius: 8px;
@@ -1014,6 +1016,11 @@ select {
   border-radius: 4px;
 }
 
+.active-btn {
+  background: #444;
+  color: #fff;
+}
+
 #taximeter-receipt {
   background: #000;
   color: #0f0;
@@ -1024,6 +1031,9 @@ select {
   display: inline-block;
   margin-top: 20px;
   text-align: left;
+}
+#receipt-text {
+  text-align: right;
 }
 #receipt-company {
   text-align: center;
@@ -1038,4 +1048,10 @@ select {
 }
 #receipt-qr {
   margin-top: 10px;
+  text-align: center;
+}
+
+#wait-icon {
+  font-size: 1.2rem;
+  margin-left: 4px;
 }

--- a/static/js/taxameter.js
+++ b/static/js/taxameter.js
@@ -10,14 +10,36 @@ $(function() {
             if (data.duration !== undefined) {
                 $('#time').text(Math.round(data.duration));
             }
-            if (!data.active) {
-                $('#start-btn').prop('disabled', false);
-                $('#stop-btn').prop('disabled', true);
-                $('#reset-btn').prop('disabled', !('price' in data));
+            if (data.waiting) {
+                $('#wait-icon').show();
             } else {
-                $('#start-btn').prop('disabled', true);
+                $('#wait-icon').hide();
+            }
+
+            if (data.active) {
+                $('#start-btn').prop('disabled', true).removeClass('active-btn');
+                $('#pause-btn').prop('disabled', false);
                 $('#stop-btn').prop('disabled', false);
                 $('#reset-btn').prop('disabled', true);
+                $('#start-btn').addClass('active-btn');
+                $('#pause-btn').removeClass('active-btn');
+                $('#stop-btn').removeClass('active-btn');
+            } else if (data.paused) {
+                $('#start-btn').prop('disabled', false);
+                $('#pause-btn').prop('disabled', true).removeClass('active-btn');
+                $('#stop-btn').prop('disabled', false);
+                $('#reset-btn').prop('disabled', true);
+                $('#pause-btn').addClass('active-btn');
+                $('#start-btn').removeClass('active-btn');
+                $('#stop-btn').removeClass('active-btn');
+            } else {
+                $('#start-btn').prop('disabled', false);
+                $('#pause-btn').prop('disabled', true).removeClass('active-btn');
+                $('#stop-btn').prop('disabled', true).removeClass('active-btn');
+                $('#reset-btn').prop('disabled', !('price' in data));
+                $('#start-btn').removeClass('active-btn');
+                $('#pause-btn').removeClass('active-btn');
+                $('#stop-btn').removeClass('active-btn');
             }
         });
     }
@@ -66,10 +88,20 @@ $(function() {
 
     $('#start-btn').click(function() {
         $('#taximeter-receipt').hide();
+        $('.active-btn').removeClass('active-btn');
+        $(this).addClass('active-btn');
         $.post('/api/taxameter/start', update, 'json');
     });
 
+    $('#pause-btn').click(function() {
+        $('.active-btn').removeClass('active-btn');
+        $(this).addClass('active-btn');
+        $.post('/api/taxameter/pause', update, 'json');
+    });
+
     $('#stop-btn').click(function() {
+        $('.active-btn').removeClass('active-btn');
+        $(this).addClass('active-btn');
         $.post('/api/taxameter/stop', function(data) {
             if (data.price !== undefined) {
                 $('#price').text(Number(data.price).toFixed(2));
@@ -82,6 +114,7 @@ $(function() {
     });
 
     $('#reset-btn').click(function() {
+        $('.active-btn').removeClass('active-btn');
         $.post('/api/taxameter/reset', update);
         $('#price').text('0.00');
         $('#dist').text('0.00');

--- a/templates/taxameter.html
+++ b/templates/taxameter.html
@@ -16,10 +16,11 @@
         </div>
         <div id="taximeter-info">
             <span id="dist">0.00</span> km |
-            <span id="time">0</span> s
+            <span id="time">0</span> s <span id="wait-icon" style="display:none">&#x23F3;</span>
         </div>
         <div id="taximeter-buttons">
             <button id="start-btn">Start</button>
+            <button id="pause-btn" disabled>Pause</button>
             <button id="stop-btn" disabled>Stop</button>
             <button id="reset-btn" disabled>Reset</button>
         </div>


### PR DESCRIPTION
## Summary
- add pause mode and waiting indicator to taximeter
- allow pausing and resuming via new API route
- update taximeter page with a wait icon and pause button
- highlight active button and tweak matrix-style display
- align receipt text to the right and center QR code

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c1207d45c8321b79dd00b55f82149