### PR TITLE
Fix taximeter receipt persistence

### DIFF
--- a/static/js/taxameter.js
+++ b/static/js/taxameter.js
@@ -16,6 +16,11 @@ $(function() {
                 $('#wait-icon').hide();
             }
 
+            if (!data.active && !data.paused && data.ride_id !== undefined) {
+                var qr = '/receipts/' + data.ride_id + '.png';
+                showReceipt(data.breakdown, TAXI_COMPANY, data.distance, qr);
+            }
+
             if (data.active) {
                 $('#start-btn').prop('disabled', true).removeClass('active-btn');
                 $('#pause-btn').prop('disabled', false);

--- a/taximeter.py
+++ b/taximeter.py
@@ -115,6 +115,8 @@ class Taximeter:
                             "distance": round(self.last_result["distance"], 3),
                             "price": round(self.last_result["price"], 2),
                             "duration": self.last_result["duration"],
+                            "breakdown": self.last_result.get("breakdown"),
+                            "ride_id": self.last_result.get("ride_id"),
                         }
                     )
                 return result


### PR DESCRIPTION
## Summary
- include ride_id and breakdown in taximeter status
- display receipt when a previous ride exists on reload

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687c17b49aec83218b59730eb740c008