### PR TITLE
Update taximeter UI

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,5 +1,6 @@
 
 @import url('https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=VT323&display=swap');
 
 :root {
   --bg-color: #121212;
@@ -995,15 +996,18 @@ select {
 #taximeter-display {
   background: #000;
   color: #0f0;
-  font-family: 'Courier New', monospace;
-  font-size: 2.5rem;
-  letter-spacing: 0.1rem;
-  text-shadow: 0 0 6px #0f0;
-  padding: 20px;
+  font-family: 'VT323', monospace;
+  font-size: 3rem;
+  letter-spacing: 0.15rem;
+  text-shadow:
+    0 0 4px #0f0,
+    0 0 8px #0f0,
+    0 0 12px #0f0;
+  padding: 20px 30px;
   border: 3px solid #444;
   border-radius: 8px;
   display: inline-block;
-  min-width: 200px;
+  min-width: 220px;
   margin-bottom: 10px;
 }
 
@@ -1017,22 +1021,31 @@ select {
 }
 
 .active-btn {
-  background: #444;
+  background: var(--accent-color);
   color: #fff;
+  border-color: var(--accent-color);
 }
 
 #taximeter-receipt {
   background: #000;
   color: #0f0;
-  font-family: 'Courier New', monospace;
+  font-family: 'VT323', monospace;
   padding: 10px;
   border: 2px solid #444;
   border-radius: 8px;
   display: inline-block;
   margin-top: 20px;
   text-align: left;
+  max-width: 240px;
 }
-#receipt-text {
+#receipt-table {
+  width: 100%;
+  margin: 0 auto;
+}
+#receipt-table td {
+  padding: 2px 4px;
+}
+#receipt-table td.num {
   text-align: right;
 }
 #receipt-company {

--- a/static/js/taxameter.js
+++ b/static/js/taxameter.js
@@ -54,29 +54,29 @@ $(function() {
             return;
         }
         function fmt(value) {
-            return value.toFixed(2).padStart(7);
+            return value.toFixed(2);
         }
-        var lines = [];
-        lines.push('Grundpreis:' + fmt(breakdown.base) + ' €');
+        var html = '';
+        html += '<tr><td>Grundpreis:</td><td class="num">' + fmt(breakdown.base) + ' €</td></tr>';
         if (breakdown.km_1_2 > 0) {
-            lines.push(breakdown.km_1_2.toFixed(2) + ' km x ' +
-                breakdown.rate_1_2.toFixed(2) + ' € =' + fmt(breakdown.cost_1_2) + ' €');
+            html += '<tr><td>' + breakdown.km_1_2.toFixed(2) + ' km x ' +
+                breakdown.rate_1_2.toFixed(2) + ' €</td><td class="num">' + fmt(breakdown.cost_1_2) + ' €</td></tr>';
         }
         if (breakdown.km_3_4 > 0) {
-            lines.push(breakdown.km_3_4.toFixed(2) + ' km x ' +
-                breakdown.rate_3_4.toFixed(2) + ' € =' + fmt(breakdown.cost_3_4) + ' €');
+            html += '<tr><td>' + breakdown.km_3_4.toFixed(2) + ' km x ' +
+                breakdown.rate_3_4.toFixed(2) + ' €</td><td class="num">' + fmt(breakdown.cost_3_4) + ' €</td></tr>';
         }
         if (breakdown.km_5_plus > 0) {
-            lines.push(breakdown.km_5_plus.toFixed(2) + ' km x ' +
-                breakdown.rate_5_plus.toFixed(2) + ' € =' + fmt(breakdown.cost_5_plus) + ' €');
+            html += '<tr><td>' + breakdown.km_5_plus.toFixed(2) + ' km x ' +
+                breakdown.rate_5_plus.toFixed(2) + ' €</td><td class="num">' + fmt(breakdown.cost_5_plus) + ' €</td></tr>';
         }
         if (breakdown.wait_cost > 0) {
-            lines.push('Standzeit ' + Math.round(breakdown.wait_time) + 's =' + fmt(breakdown.wait_cost) + ' €');
+            html += '<tr><td>Standzeit ' + Math.round(breakdown.wait_time) + 's</td><td class="num">' + fmt(breakdown.wait_cost) + ' €</td></tr>';
         }
-        lines.push('--------------------');
-        lines.push('Gesamt:' + fmt(breakdown.total) + ' €');
-        lines.push('Fahrstrecke: ' + distance.toFixed(2) + ' km');
-        $('#receipt-text').text(lines.join('\n'));
+        html += '<tr><td colspan="2"><hr></td></tr>';
+        html += '<tr><td>Gesamt:</td><td class="num">' + fmt(breakdown.total) + ' €</td></tr>';
+        html += '<tr><td colspan="2" style="text-align:center">Fahrstrecke: ' + distance.toFixed(2) + ' km</td></tr>';
+        $('#receipt-table').html(html);
         $('#receipt-company').empty();
         if (company) {
             $('#receipt-company').append('<div class="company-name">' + company + '</div>');

--- a/templates/taxameter.html
+++ b/templates/taxameter.html
@@ -26,7 +26,7 @@
         </div>
         <div id="taximeter-receipt" style="display:none;">
             <div id="receipt-company"></div>
-            <pre id="receipt-text"></pre>
+            <table id="receipt-table"></table>
             <div id="receipt-qr"></div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- tweak font for the taximeter display and receipt
- highlight active buttons with accent color
- shrink receipt width and render breakdown as table

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c1a7068b48321bfd789547a625139