### PR TITLE
Use courier font for taximeter receipt

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,6 +1,7 @@
 
 @import url('https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;700&display=swap');
 @import url('https://fonts.googleapis.com/css2?family=DotGothic16&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Courier+Prime&display=swap');
 
 :root {
   --bg-color: #121212;
@@ -1029,7 +1030,7 @@ select {
 #taximeter-receipt {
   background: #000;
   color: #0f0;
-  font-family: 'DotGothic16', monospace;
+  font-family: 'Courier Prime', 'Courier New', Courier, monospace;
   padding: 10px;
   border: 2px solid #444;
   border-radius: 8px;


### PR DESCRIPTION
## Summary
- load Courier Prime font
- use Courier font stack for the taximeter receipt

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c20afc7388321a3a62474330f1afb