### PR TITLE
Add trip receipts and button highlights

### DIFF
--- a/app.py
+++ b/app.py
@@ -2162,7 +2162,11 @@ def sms_log_page():
 def taxameter_page():
     cfg = load_config()
     company = cfg.get("taxi_company", "Taxi Schauer")
-    return render_template("taxameter.html", company=company, config=cfg)
+    files = [os.path.relpath(p, DATA_DIR) for p in _get_trip_files()]
+    recent = files[-10:]
+    return render_template(
+        "taxameter.html", company=company, config=cfg, trips=recent
+    )
 
 
 @app.route("/api/taxameter/start", methods=["POST"])

--- a/static/js/taxameter.js
+++ b/static/js/taxameter.js
@@ -22,29 +22,29 @@ $(function() {
             }
 
             if (data.active) {
-                $('#start-btn').prop('disabled', true).removeClass('active-btn');
+                $('#start-btn').prop('disabled', true);
                 $('#pause-btn').prop('disabled', false);
                 $('#stop-btn').prop('disabled', false);
                 $('#reset-btn').prop('disabled', true);
+                $('#taximeter-buttons button').removeClass('active-btn');
                 $('#start-btn').addClass('active-btn');
-                $('#pause-btn').removeClass('active-btn');
-                $('#stop-btn').removeClass('active-btn');
             } else if (data.paused) {
                 $('#start-btn').prop('disabled', false);
-                $('#pause-btn').prop('disabled', true).removeClass('active-btn');
+                $('#pause-btn').prop('disabled', true);
                 $('#stop-btn').prop('disabled', false);
                 $('#reset-btn').prop('disabled', true);
+                $('#taximeter-buttons button').removeClass('active-btn');
                 $('#pause-btn').addClass('active-btn');
-                $('#start-btn').removeClass('active-btn');
-                $('#stop-btn').removeClass('active-btn');
             } else {
                 $('#start-btn').prop('disabled', false);
-                $('#pause-btn').prop('disabled', true).removeClass('active-btn');
-                $('#stop-btn').prop('disabled', true).removeClass('active-btn');
-                $('#reset-btn').prop('disabled', !('price' in data));
-                $('#start-btn').removeClass('active-btn');
-                $('#pause-btn').removeClass('active-btn');
-                $('#stop-btn').removeClass('active-btn');
+                $('#pause-btn').prop('disabled', true);
+                var hasResult = ('price' in data);
+                $('#stop-btn').prop('disabled', !hasResult);
+                $('#reset-btn').prop('disabled', !hasResult);
+                $('#taximeter-buttons button').removeClass('active-btn');
+                if (hasResult) {
+                    $('#stop-btn').addClass('active-btn');
+                }
             }
         });
     }

--- a/static/js/taxameter.js
+++ b/static/js/taxameter.js
@@ -127,6 +127,13 @@ $(function() {
         $('#taximeter-receipt').hide();
     });
 
+    $('#trip-receipt-btn').click(function() {
+        var file = $('#trip-select').val();
+        if (file) {
+            window.open('/taxameter/trip_receipt?file=' + encodeURIComponent(file), '_blank');
+        }
+    });
+
     update();
     setInterval(update, 2000);
 });

--- a/templates/history.html
+++ b/templates/history.html
@@ -58,6 +58,9 @@
             {% endif %}
         </select>
     </form>
+    {% if selected %}
+    <a id="receipt-link" class="menu-button" href="/taxameter/trip_receipt?file={{ selected }}">Quittung</a>
+    {% endif %}
     <div id="map">
         <div id="slider-container">
             <div id="slider-row">

--- a/templates/taxameter.html
+++ b/templates/taxameter.html
@@ -29,6 +29,17 @@
             <table id="receipt-table"></table>
             <div id="receipt-qr"></div>
         </div>
+        {% if trips %}
+        <div id="trip-select-box">
+            <label for="trip-select">Vergangene Fahrt:</label>
+            <select id="trip-select">
+                {% for t in trips %}
+                <option value="{{ t }}">{{ t }}</option>
+                {% endfor %}
+            </select>
+            <button id="trip-receipt-btn" type="button">Quittung</button>
+        </div>
+        {% endif %}
     </div>
     <script>
         const TAXI_COMPANY = "{{ company }}";


### PR DESCRIPTION
## Summary
- show which taximeter button is currently active
- allow generating receipts for recorded trips
- link to trip receipt from history page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c2919398c8321b9a0f0ef95f5220b