### PR TITLE
Fix vehicle_id usage and receipt width

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1037,7 +1037,7 @@ select {
   display: inline-block;
   margin-top: 20px;
   text-align: left;
-  max-width: 240px;
+  width: max-content;
 }
 #receipt-table {
   width: 100%;

--- a/static/js/taxameter.js
+++ b/static/js/taxameter.js
@@ -1,6 +1,6 @@
 $(function() {
     function update() {
-        $.getJSON('/api/taxameter/status', function(data) {
+        $.getJSON('/api/taxameter/status?vehicle_id=' + encodeURIComponent(VEHICLE_ID), function(data) {
             if (data.price !== undefined) {
                 $('#price').text(Number(data.price).toFixed(2));
             }
@@ -95,19 +95,19 @@ $(function() {
         $('#taximeter-receipt').hide();
         $('.active-btn').removeClass('active-btn');
         $(this).addClass('active-btn');
-        $.post('/api/taxameter/start', update, 'json');
+        $.post('/api/taxameter/start', {vehicle_id: VEHICLE_ID}, update, 'json');
     });
 
     $('#pause-btn').click(function() {
         $('.active-btn').removeClass('active-btn');
         $(this).addClass('active-btn');
-        $.post('/api/taxameter/pause', update, 'json');
+        $.post('/api/taxameter/pause', {vehicle_id: VEHICLE_ID}, update, 'json');
     });
 
     $('#stop-btn').click(function() {
         $('.active-btn').removeClass('active-btn');
         $(this).addClass('active-btn');
-        $.post('/api/taxameter/stop', function(data) {
+        $.post('/api/taxameter/stop', {vehicle_id: VEHICLE_ID}, function(data) {
             if (data.price !== undefined) {
                 $('#price').text(Number(data.price).toFixed(2));
                 $('#dist').text(Number(data.distance).toFixed(2));
@@ -120,7 +120,7 @@ $(function() {
 
     $('#reset-btn').click(function() {
         $('.active-btn').removeClass('active-btn');
-        $.post('/api/taxameter/reset', update);
+        $.post('/api/taxameter/reset', {vehicle_id: VEHICLE_ID}, update);
         $('#price').text('0.00');
         $('#dist').text('0.00');
         $('#time').text('0');

--- a/templates/taxameter.html
+++ b/templates/taxameter.html
@@ -44,6 +44,7 @@
     <script>
         const TAXI_COMPANY = "{{ company }}";
         const TAXI_SLOGAN = "{{ config.get('taxi_slogan','Wir lassen Sie nicht im Regen stehen.') }}";
+        const VEHICLE_ID = "{{ vehicle_id }}";
     </script>
     <script src="/static/js/taxameter.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- respect vehicle ID for taximeter endpoints
- expose `vehicle_id` in taximeter template and JS
- adjust receipt width to fit text

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c2d295d7c83218872565d648fc902