### PR TITLE
Filter trip directories by vehicle id

### DIFF
--- a/app.py
+++ b/app.py
@@ -860,6 +860,8 @@ def _get_trip_files(vehicle_id=None):
     if vehicle_id is None:
         try:
             for name in os.listdir(DATA_DIR):
+                if not str(name).isdigit():
+                    continue
                 d = os.path.join(DATA_DIR, name, "trips")
                 if os.path.isdir(d):
                     dirs.append(d)


### PR DESCRIPTION
## Summary
- filter `_get_trip_files()` so only numeric vehicle ids are scanned

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c307d75508321a20e93d5ba0a8d8e