### PR TITLE
Highlight active taximeter buttons

### DIFF
--- a/app.py
+++ b/app.py
@@ -2179,10 +2179,19 @@ def taxameter_page():
     cfg = load_config()
     company = cfg.get("taxi_company", "Taxi Schauer")
     files = [os.path.relpath(p, DATA_DIR) for p in _get_trip_files()]
-    recent = files[-10:]
+    recent_files = files[-10:]
+    trips = []
+    for f in recent_files:
+        label = os.path.basename(f)
+        label = label.replace("trip_", "").split(".")[0]
+        try:
+            label = datetime.strptime(label, "%Y%m%d").strftime("%Y-%m-%d")
+        except Exception:
+            pass
+        trips.append({"value": f, "label": label})
     vehicle_id = default_vehicle_id()
     return render_template(
-        "taxameter.html", company=company, config=cfg, trips=recent, vehicle_id=vehicle_id
+        "taxameter.html", company=company, config=cfg, trips=trips, vehicle_id=vehicle_id
     )
 
 

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1027,6 +1027,12 @@ select {
   border-color: var(--accent-color);
 }
 
+.active-btn:disabled {
+  background: var(--accent-color);
+  color: #fff;
+  border-color: var(--accent-color);
+}
+
 #taximeter-receipt {
   background: #000;
   color: #0f0;
@@ -1068,4 +1074,12 @@ select {
 #wait-icon {
   font-size: 1.2rem;
   margin-left: 4px;
+}
+
+#trip-select-box {
+  position: fixed;
+  bottom: 20px;
+  left: 0;
+  right: 0;
+  text-align: center;
 }

--- a/templates/taxameter.html
+++ b/templates/taxameter.html
@@ -34,7 +34,7 @@
             <label for="trip-select">Vergangene Fahrt:</label>
             <select id="trip-select">
                 {% for t in trips %}
-                <option value="{{ t }}">{{ t }}</option>
+                <option value="{{ t.value }}">{{ t.label }}</option>
                 {% endfor %}
             </select>
             <button id="trip-receipt-btn" type="button">Quittung</button>


### PR DESCRIPTION
## Summary
- style active taximeter buttons even when disabled
- pin trip selection control to the bottom
- show only the trip date in the taximeter list

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687c3249e6f483219e7562e00ad6d381