### PR TITLE
Implement trip splitting in taxameter

### DIFF
--- a/static/js/taxameter.js
+++ b/static/js/taxameter.js
@@ -128,11 +128,29 @@ $(function() {
     });
 
     $('#trip-receipt-btn').click(function() {
-        var file = $('#trip-select').val();
-        if (file) {
-            window.open('/taxameter/trip_receipt?file=' + encodeURIComponent(file), '_blank');
+        var query = $('#trip-select').val();
+        if (query) {
+            window.open('/taxameter/trip_receipt?' + query, '_blank');
         }
     });
+
+    function loadTrips(file) {
+        if (!file) return;
+        $.getJSON('/api/taxameter/trips?file=' + encodeURIComponent(file), function(data) {
+            $('#trip-select').empty();
+            $.each(data, function(idx, t) {
+                $('#trip-select').append($('<option>').val(t.value).text(t.label));
+            });
+        });
+    }
+
+    $('#file-select').change(function() {
+        loadTrips($(this).val());
+    });
+
+    if ($('#file-select').length) {
+        loadTrips($('#file-select').val());
+    }
 
     update();
     setInterval(update, 2000);

--- a/templates/taxameter.html
+++ b/templates/taxameter.html
@@ -29,9 +29,15 @@
             <table id="receipt-table"></table>
             <div id="receipt-qr"></div>
         </div>
-        {% if trips %}
+        {% if trip_files %}
         <div id="trip-select-box">
-            <label for="trip-select">Vergangene Fahrt:</label>
+            <label for="file-select">Trip-Datei:</label>
+            <select id="file-select">
+                {% for f in trip_files %}
+                <option value="{{ f.value }}"{% if selected_file==f.value %} selected{% endif %}>{{ f.label }}</option>
+                {% endfor %}
+            </select>
+            <label for="trip-select">Fahrt:</label>
             <select id="trip-select">
                 {% for t in trips %}
                 <option value="{{ t.value }}">{{ t.label }}</option>


### PR DESCRIPTION
## Summary
- create `_split_trip_segments` to divide trip logs by gear state and collect wait time when speed <5 km/h
- list trips on `/taxameter` by time range and allow file selection
- add `/api/taxameter/trips` endpoint
- support `segment` parameter for taximeter receipts
- update template and JS to load trips dynamically

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c35b0b63883218da09ce9d323f80d