### PR TITLE
Add address error handling

### DIFF
--- a/app.py
+++ b/app.py
@@ -1494,16 +1494,30 @@ def get_vehicle_list():
 def reverse_geocode(lat, lon, vehicle_id=None):
     """Return address information for given coordinates using OpenStreetMap."""
 
+    headers = {"User-Agent": "TeslaDashboard/1.0"}
     try:
         url = "https://nominatim.openstreetmap.org/reverse"
         params = {"lat": lat, "lon": lon, "format": "jsonv2"}
-        headers = {"User-Agent": "TeslaDashboard/1.0"}
         r = requests.get(url, params=params, headers=headers, timeout=5)
         r.raise_for_status()
         data = r.json()
         return {"address": data.get("display_name"), "raw": data}
     except Exception as exc:
         _log_api_error(exc)
+        try:
+            url = "https://photon.komoot.io/reverse"
+            params = {"lat": lat, "lon": lon}
+            r = requests.get(url, params=params, headers=headers, timeout=5)
+            r.raise_for_status()
+            data = r.json()
+            features = data.get("features")
+            if features:
+                props = features[0].get("properties", {})
+                label = props.get("label")
+                if label:
+                    return {"address": label, "raw": data}
+        except Exception as exc2:
+            _log_api_error(exc2)
         return {}
 
 

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -81,6 +81,12 @@ select {
   color: var(--accent-color);
 }
 
+#address-error {
+  display: none;
+  color: var(--accent-color);
+  margin-top: 2px;
+}
+
 #map {
   position: relative;
   height: 400px;

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -1214,6 +1214,16 @@ function fetchAddress(lat, lon) {
             }
         }
         $('#address-text').text(addr || '');
+        if (!addr) {
+            $('#address-error')
+                .text('Adresse konnte nicht abgerufen werden')
+                .show();
+        } else {
+            $('#address-error').hide();
+        }
+    }).fail(function() {
+        $('#address-text').text('');
+        $('#address-error').text('Adresse konnte nicht abgerufen werden').show();
     });
 }
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -36,7 +36,10 @@
         <select id="vehicle-select"></select>
         <div id="map-container">
             <div id="map">
-                <div id="location-address"><div id="address-text" aria-live="polite"></div></div>
+                <div id="location-address">
+                    <div id="address-text" aria-live="polite"></div>
+                    <div id="address-error" aria-live="polite" class="address-error"></div>
+                </div>
                 <div id="zoom-level"></div>
             </div>
             <div id="sidebar-right">

--- a/templates/map.html
+++ b/templates/map.html
@@ -22,7 +22,10 @@
 </head>
 <body>
     <div id="map">
-        <div id="location-address"><div id="address-text"></div></div>
+        <div id="location-address">
+            <div id="address-text"></div>
+            <div id="address-error" class="address-error"></div>
+        </div>
         <div id="zoom-level"></div>
     </div>
     <script>


### PR DESCRIPTION
## Summary
- show error message if reverse geocoding fails
- add fallback using photon.komoot.io

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e143bb4b48321894409931dc38204