### PR TITLE
Fix reverse geocode retry logic

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -1173,9 +1173,9 @@ function fetchAnnouncement() {
 function fetchAddress(lat, lon) {
     if (lat == null || lon == null) return;
     if (lastAddressLat === lat && lastAddressLng === lon) return;
-    lastAddressLat = lat;
-    lastAddressLng = lon;
     $.getJSON('/api/reverse_geocode', {lat: lat, lon: lon}, function(resp) {
+        lastAddressLat = lat;
+        lastAddressLng = lon;
         var addr = null;
         if (resp.raw && resp.raw.address) {
             var a = resp.raw.address;


### PR DESCRIPTION
## Summary
- only save coordinates after successful reverse geocode call

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c8cf319348321ac22d6ea1c66071b