### PR TITLE
Fix repeated address fetch failure

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -1174,8 +1174,6 @@ function fetchAddress(lat, lon) {
     if (lat == null || lon == null) return;
     if (lastAddressLat === lat && lastAddressLng === lon) return;
     $.getJSON('/api/reverse_geocode', {lat: lat, lon: lon}, function(resp) {
-        lastAddressLat = lat;
-        lastAddressLng = lon;
         var addr = null;
         if (resp.raw && resp.raw.address) {
             var a = resp.raw.address;
@@ -1219,6 +1217,8 @@ function fetchAddress(lat, lon) {
                 .text('Adresse konnte nicht abgerufen werden')
                 .show();
         } else {
+            lastAddressLat = lat;
+            lastAddressLng = lon;
             $('#address-error').hide();
         }
     }).fail(function() {


### PR DESCRIPTION
## Summary
- avoid caching coordinates when reverse geocode returns no address
- hide address error only after successful lookup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d73ffd8d083219b73a92a877e9155