### PR TITLE
Log energy per charge

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Timestamps in this file are recorded in the Europe/Berlin timezone.
 
 All API calls are logged to `data/api.log` without storing request details. The log file uses rotation and will grow to at most 1&nbsp;MB.
 Vehicle state changes are written to `data/state.log`.
-The file `data/energy.log` always holds only the most recently added energy once a charging session finishes. Its timestamp is recorded in the Europe/Berlin timezone.
+The file `data/energy.log` keeps a record of the energy added after each charging session. Each entry includes a timestamp in the Europe/Berlin timezone and is used to calculate daily totals on the statistics page.
 The latest successful API response is stored in `data/<vehicle_id>/cache.json`.
 This cache is always updated with the current vehicle state so the dashboard
 knows whether the car is online, asleep or offline even when no fresh data is

--- a/app.py
+++ b/app.py
@@ -723,10 +723,7 @@ def _log_energy(vehicle_id, amount):
         last = _last_logged_energy(vehicle_id)
         if last is None or abs(last - amount) > 0.001:
             entry = json.dumps({"vehicle_id": vehicle_id, "added_energy": amount})
-            ts = datetime.now(LOCAL_TZ).strftime("%Y-%m-%d %H:%M:%S")
-            path = os.path.join(DATA_DIR, "energy.log")
-            with open(path, "w", encoding="utf-8") as f:
-                f.write(f"{ts} {entry}\n")
+            energy_logger.info(entry)
     except Exception:
         pass
 


### PR DESCRIPTION
## Summary
- Append each charging session’s added energy to `energy.log`
- Document energy log usage for daily statistics

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e3e1427788321bff3eed1c9e1b550