### PR TITLE
Add database and login support

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,0 +1,2 @@
+SQLALCHEMY_DATABASE_URI = "sqlite:///dashboard.db"
+SQLALCHEMY_TRACK_MODIFICATIONS = False

--- a/models.py
+++ b/models.py
@@ -1,0 +1,20 @@
+from datetime import datetime, timezone
+from flask_login import UserMixin
+from app import db
+
+
+class User(db.Model, UserMixin):
+    id = db.Column(db.Integer, primary_key=True)
+    email = db.Column(db.String(120), unique=True, nullable=False)
+    password = db.Column(db.String(128), nullable=False)
+    created_at = db.Column(db.DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
+
+
+class Payment(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    amount = db.Column(db.Integer, nullable=False)
+    created_at = db.Column(db.DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
+
+
+def init_db():
+    db.create_all()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,7 @@
 flask
+flask-login
+flask-sqlalchemy
+stripe
 teslapy
 python-dotenv
 requests


### PR DESCRIPTION
## Summary
- configure Flask app with SQLAlchemy, Flask-Login and Stripe
- add configuration module and placeholder models with automatic table creation
- drop file-based logging and state persistence

## Testing
- `python - <<'PY'
import os
import app
print('db exists', os.path.exists(os.path.join('instance','dashboard.db')))
PY`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f625e08b883218d242bf468c5e908