### PR TITLE
Expose admin dashboard publicly

### DIFF
--- a/app.py
+++ b/app.py
@@ -1606,12 +1606,15 @@ def logout():
 
 @app.route("/")
 def index():
+    admin = User.query.filter_by(role="admin").first()
     cfg = load_config()
     return render_template(
         "index.html",
         version=__version__,
         year=CURRENT_YEAR,
         config=cfg,
+        show_banner=not current_user.is_authenticated,
+        admin=admin,
     )
 
 

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1089,3 +1089,13 @@ select {
   right: 0;
   text-align: center;
 }
+
+#share-btn {
+  margin-left: 10px;
+}
+
+#public-banner {
+  text-align: center;
+  margin-top: 10px;
+  font-size: 0.9em;
+}

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -1393,3 +1393,15 @@ $('#sms-send').on('click', function() {
 $('#alarm-close').on('click', function() {
     $('#alarm-popup').removeClass('show');
 });
+
+var shareBtn = document.getElementById('share-btn');
+if (shareBtn && navigator.clipboard) {
+    shareBtn.addEventListener('click', function() {
+        navigator.clipboard.writeText(window.location.href).then(function() {
+            shareBtn.textContent = 'Link kopiert!';
+            setTimeout(function() {
+                shareBtn.textContent = 'Teilen';
+            }, 2000);
+        });
+    });
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -19,6 +19,7 @@
     <h2>Tesla-Dashboard V{{ version }}
         <span id="header-right">
             <span id="vehicle-info"></span>&nbsp;&nbsp;&nbsp;<span id="vehicle-status"></span>
+            <button id="share-btn" type="button">Teilen</button>
         </span>
     </h2>
     {% set show_dash = config.get('menu-dashboard', True) %}
@@ -221,6 +222,11 @@
         <span id="data-age"></span>
         <span>Tesla-Dashboard V{{ version }} - © {{ year }} Erik Schauer, do1ffe@darc.de</span>
     </footer>
+    {% if show_banner %}
+    <div id="public-banner">
+        Dein eigenes Dashboard? Jetzt <a href="/register">registrieren</a> / <a href="/login">einloggen</a>.
+    </div>
+    {% endif %}
 
     <script>
         window.APP_VERSION = "{{ version }}";


### PR DESCRIPTION
## Summary
- Render the admin dashboard at `/` without requiring login and toggle banner visibility for unauthenticated visitors.
- Add a "Teilen" button with clipboard copy functionality and a footer banner prompting registration or login.
- Style the new share button and public banner for consistent appearance.

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688f6816ae7483219964af47a6b13a7d