### PR TITLE
Add user dashboard namespace

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -1,5 +1,6 @@
 var currentVehicle = null;
 var APP_VERSION = window.APP_VERSION || null;
+var BASE_PATH = window.BASE_PATH || '';
 var MILES_TO_KM = 1.60934;
 var announcementRaw = '';
 var announcementList = [];
@@ -228,7 +229,7 @@ function updateHeader(data) {
 }
 
 function fetchVehicles() {
-    $.getJSON('/api/vehicles', function(resp) {
+    $.getJSON(BASE_PATH + '/api/vehicles', function(resp) {
         var vehicles = Array.isArray(resp) ? resp : [];
         var $select = $('#vehicle-select');
         var $label = $('label[for="vehicle-select"]');
@@ -1120,7 +1121,7 @@ function updateOfflineInfo(state, serviceMode, serviceModePlus) {
 }
 
 function updateClientCount() {
-    $.getJSON('/api/clients', function(resp) {
+    $.getJSON(BASE_PATH + '/api/clients', function(resp) {
         if (typeof resp.clients === 'number') {
             $('#client-count').text('Clients: ' + resp.clients);
         }
@@ -1158,7 +1159,7 @@ function updateAnnouncement() {
 }
 
 function fetchAnnouncement() {
-    $.getJSON('/api/announcement', function(resp) {
+    $.getJSON(BASE_PATH + '/api/announcement', function(resp) {
         if (typeof resp.announcement !== 'undefined') {
             if (resp.announcement !== announcementRaw) {
                 announcementRaw = resp.announcement;
@@ -1173,7 +1174,7 @@ function fetchAnnouncement() {
 function fetchAddress(lat, lon) {
     if (lat == null || lon == null) return;
     if (lastAddressLat === lat && lastAddressLng === lon) return;
-    $.getJSON('/api/reverse_geocode', {lat: lat, lon: lon}, function(resp) {
+    $.getJSON(BASE_PATH + '/api/reverse_geocode', {lat: lat, lon: lon}, function(resp) {
         var addr = null;
         if (resp.raw && resp.raw.address) {
             var a = resp.raw.address;
@@ -1263,11 +1264,11 @@ function startStream() {
             eventSource = null;
         }
         if (!currentVehicle) return;
-        $.getJSON('/api/state/' + currentVehicle, function(resp) {
+        $.getJSON(BASE_PATH + '/api/state/' + currentVehicle, function(resp) {
             var st = resp.state;
             updateVehicleState(st);
             updateOfflineInfo(st, resp.service_mode, resp.service_mode_plus);
-            $.getJSON('/api/data/' + currentVehicle, function(data) {
+            $.getJSON(BASE_PATH + '/api/data/' + currentVehicle, function(data) {
                 if (data && !data.error) {
                     handleData(data);
                 }
@@ -1292,12 +1293,12 @@ function startStreamIfOnline() {
         return;
     }
     showLoading();
-    $.getJSON('/api/state/' + currentVehicle, function(resp) {
+    $.getJSON(BASE_PATH + '/api/state/' + currentVehicle, function(resp) {
         var st = resp.state;
         updateVehicleState(st);
         updateOfflineInfo(st, resp.service_mode, resp.service_mode_plus);
         startStream();
-        $.getJSON('/api/data/' + currentVehicle, function(data) {
+        $.getJSON(BASE_PATH + '/api/data/' + currentVehicle, function(data) {
             if (data && !data.error) {
                 handleData(data);
             }
@@ -1305,7 +1306,7 @@ function startStreamIfOnline() {
     });
 }
 
-$.getJSON('/api/config', function(cfg) {
+$.getJSON(BASE_PATH + '/api/config', function(cfg) {
     applyConfig(cfg);
     lastConfigJSON = JSON.stringify(cfg || {});
     if (cfg) {
@@ -1316,7 +1317,7 @@ $.getJSON('/api/config', function(cfg) {
 });
 
 function fetchConfig() {
-    $.getJSON('/api/config', function(cfg) {
+    $.getJSON(BASE_PATH + '/api/config', function(cfg) {
         var json = JSON.stringify(cfg || {});
         if (json !== lastConfigJSON) {
             if (cfg && (cfg.api_interval !== lastApiInterval ||
@@ -1335,7 +1336,7 @@ function fetchConfig() {
 }
 
 function checkAppVersion() {
-    $.getJSON('/api/version', function(resp) {
+    $.getJSON(BASE_PATH + '/api/version', function(resp) {
         if (resp.version && APP_VERSION && resp.version !== APP_VERSION) {
             location.reload(true);
         }
@@ -1364,7 +1365,7 @@ $('#sms-send').on('click', function() {
     }
     $('#sms-status').text('Senden...');
     $.ajax({
-        url: '/api/sms',
+        url: BASE_PATH + '/api/sms',
         method: 'POST',
         contentType: 'application/json',
         data: JSON.stringify({message: msg, name: name}),

--- a/static/js/taxameter.js
+++ b/static/js/taxameter.js
@@ -1,6 +1,7 @@
 $(function() {
+    var BASE_PATH = window.BASE_PATH || '';
     function update() {
-        $.getJSON('/api/taxameter/status?vehicle_id=' + encodeURIComponent(VEHICLE_ID), function(data) {
+        $.getJSON(BASE_PATH + '/api/taxameter/status?vehicle_id=' + encodeURIComponent(VEHICLE_ID), function(data) {
             if (data.price !== undefined) {
                 $('#price').text(Number(data.price).toFixed(2));
             }
@@ -95,19 +96,19 @@ $(function() {
         $('#taximeter-receipt').hide();
         $('.active-btn').removeClass('active-btn');
         $(this).addClass('active-btn');
-        $.post('/api/taxameter/start', {vehicle_id: VEHICLE_ID}, update, 'json');
+        $.post(BASE_PATH + '/api/taxameter/start', {vehicle_id: VEHICLE_ID}, update, 'json');
     });
 
     $('#pause-btn').click(function() {
         $('.active-btn').removeClass('active-btn');
         $(this).addClass('active-btn');
-        $.post('/api/taxameter/pause', {vehicle_id: VEHICLE_ID}, update, 'json');
+        $.post(BASE_PATH + '/api/taxameter/pause', {vehicle_id: VEHICLE_ID}, update, 'json');
     });
 
     $('#stop-btn').click(function() {
         $('.active-btn').removeClass('active-btn');
         $(this).addClass('active-btn');
-        $.post('/api/taxameter/stop', {vehicle_id: VEHICLE_ID}, function(data) {
+        $.post(BASE_PATH + '/api/taxameter/stop', {vehicle_id: VEHICLE_ID}, function(data) {
             if (data.price !== undefined) {
                 $('#price').text(Number(data.price).toFixed(2));
                 $('#dist').text(Number(data.distance).toFixed(2));
@@ -120,7 +121,7 @@ $(function() {
 
     $('#reset-btn').click(function() {
         $('.active-btn').removeClass('active-btn');
-        $.post('/api/taxameter/reset', {vehicle_id: VEHICLE_ID}, update);
+        $.post(BASE_PATH + '/api/taxameter/reset', {vehicle_id: VEHICLE_ID}, update);
         $('#price').text('0.00');
         $('#dist').text('0.00');
         $('#time').text('0');
@@ -130,13 +131,13 @@ $(function() {
     $('#trip-receipt-btn').click(function() {
         var query = $('#trip-select').val();
         if (query) {
-            window.open('/taxameter/trip_receipt?' + query, '_blank');
+            window.open(BASE_PATH + '/taxameter/trip_receipt?' + query, '_blank');
         }
     });
 
     function loadTrips(file) {
         if (!file) return;
-        $.getJSON('/api/taxameter/trips?file=' + encodeURIComponent(file), function(data) {
+        $.getJSON(BASE_PATH + '/api/taxameter/trips?file=' + encodeURIComponent(file), function(data) {
             $('#trip-select').empty();
             $.each(data, function(idx, t) {
                 $('#trip-select').append($('<option>').val(t.value).text(t.label));

--- a/templates/history.html
+++ b/templates/history.html
@@ -29,12 +29,12 @@
     {% set show_hist = config.get('menu-history', True) %}
     {% if config.get('page-menu', True) and (show_dash or show_stat or show_hist) %}
     <nav id="page-menu">
-        {% if show_dash %}<a class="menu-button" href="/">Dashboard</a>{% endif %}
-        {% if show_stat %}<a class="menu-button" href="/statistik">Statistik</a>{% endif %}
-        {% if show_hist %}<a class="menu-button" href="/history">History</a>{% endif %}
+        {% if show_dash %}<a class="menu-button" href="{{ prefix }}/">Dashboard</a>{% endif %}
+        {% if show_stat %}<a class="menu-button" href="{{ prefix }}/statistik">Statistik</a>{% endif %}
+        {% if show_hist %}<a class="menu-button" href="{{ prefix }}/history">History</a>{% endif %}
     </nav>
     {% endif %}
-    <form id="trip-form" method="get" action="/history">
+    <form id="trip-form" method="get" action="{{ prefix }}/history">
         <label for="file">Fahrt auswählen:</label>
         <select id="file" name="file" onchange="document.getElementById('trip-form').submit();">
             <optgroup label="Tage">
@@ -59,7 +59,7 @@
         </select>
     </form>
     {% if selected %}
-    <a id="receipt-link" class="menu-button" href="/taxameter/trip_receipt?file={{ selected }}">Quittung</a>
+    <a id="receipt-link" class="menu-button" href="{{ prefix }}/taxameter/trip_receipt?file={{ selected }}">Quittung</a>
     {% endif %}
     <div id="map">
         <div id="slider-container">
@@ -99,6 +99,9 @@
     <script>
         var tripPath = {{ path|tojson }};
         var tripHeading = {{ heading|tojson }};
+    </script>
+    <script>
+        window.BASE_PATH = "{{ prefix }}";
     </script>
     <script src="/static/js/history.js"></script>
 </body>

--- a/templates/index.html
+++ b/templates/index.html
@@ -27,9 +27,9 @@
     {% set show_hist = config.get('menu-history', True) %}
     {% if config.get('page-menu', True) and (show_dash or show_stat or show_hist) %}
     <nav id="page-menu">
-        {% if show_dash %}<a class="menu-button" href="/">Dashboard</a>{% endif %}
-        {% if show_stat %}<a class="menu-button" href="/statistik">Statistik</a>{% endif %}
-        {% if show_hist %}<a class="menu-button" href="/history">History</a>{% endif %}
+        {% if show_dash %}<a class="menu-button" href="{{ prefix }}/">Dashboard</a>{% endif %}
+        {% if show_stat %}<a class="menu-button" href="{{ prefix }}/statistik">Statistik</a>{% endif %}
+        {% if show_hist %}<a class="menu-button" href="{{ prefix }}/history">History</a>{% endif %}
     </nav>
     {% endif %}
     <div id="dashboard-content">
@@ -230,6 +230,7 @@
 
     <script>
         window.APP_VERSION = "{{ version }}";
+        window.BASE_PATH = "{{ prefix }}";
     </script>
     <script src="/static/js/main.js"></script>
 </body>

--- a/templates/map.html
+++ b/templates/map.html
@@ -30,6 +30,7 @@
     </div>
     <script>
         window.APP_VERSION = "{{ version }}";
+        window.BASE_PATH = "{{ prefix }}";
     </script>
     <script src="/static/js/main.js"></script>
 </body>

--- a/templates/statistik.html
+++ b/templates/statistik.html
@@ -20,9 +20,9 @@
     {% set show_hist = config.get('menu-history', True) %}
     {% if config.get('page-menu', True) and (show_dash or show_stat or show_hist) %}
     <nav id="page-menu">
-        {% if show_dash %}<a class="menu-button" href="/">Dashboard</a>{% endif %}
-        {% if show_stat %}<a class="menu-button" href="/statistik">Statistik</a>{% endif %}
-        {% if show_hist %}<a class="menu-button" href="/history">History</a>{% endif %}
+        {% if show_dash %}<a class="menu-button" href="{{ prefix }}/">Dashboard</a>{% endif %}
+        {% if show_stat %}<a class="menu-button" href="{{ prefix }}/statistik">Statistik</a>{% endif %}
+        {% if show_hist %}<a class="menu-button" href="{{ prefix }}/history">History</a>{% endif %}
     </nav>
     {% endif %}
     <table>

--- a/templates/taxameter.html
+++ b/templates/taxameter.html
@@ -51,6 +51,7 @@
         const TAXI_COMPANY = "{{ company }}";
         const TAXI_SLOGAN = "{{ config.get('taxi_slogan','Wir lassen Sie nicht im Regen stehen.') }}";
         const VEHICLE_ID = "{{ vehicle_id }}";
+        window.BASE_PATH = "{{ prefix }}";
     </script>
     <script src="/static/js/taxameter.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- add blueprint for user-specific dashboards and API routes
- guard user config path for owners or admins only
- adjust templates and scripts to respect per-user URL prefixes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f69de5e608321824576a36b8f6729