### PR TITLE
Enforce explicit vehicle IDs in data models and API

### DIFF
--- a/models.py
+++ b/models.py
@@ -40,6 +40,48 @@ class User(db.Model, UserMixin):
         return check_password_hash(self.password_hash, password)
 
 
+class Vehicle(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
+    vehicle_id = db.Column(db.String, nullable=False)
+    vin = db.Column(db.String)
+    model = db.Column(db.String)
+    display_name = db.Column(db.String)
+    active = db.Column(db.Boolean, default=True)
+
+    __table_args__ = (
+        db.UniqueConstraint("user_id", "vehicle_id", name="uix_user_vehicle"),
+    )
+
+
+class VehicleState(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    vehicle_id = db.Column(db.Integer, db.ForeignKey("vehicle.id"), nullable=False)
+    state = db.Column(db.String(32), nullable=False)
+    created_at = db.Column(
+        db.DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
+
+
+class EnergyLog(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    vehicle_id = db.Column(db.Integer, db.ForeignKey("vehicle.id"), nullable=False)
+    added_energy = db.Column(db.Float, nullable=False)
+    created_at = db.Column(
+        db.DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
+
+
+class TripEntry(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    vehicle_id = db.Column(db.Integer, db.ForeignKey("vehicle.id"), nullable=False)
+    started_at = db.Column(
+        db.DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
+    ended_at = db.Column(db.DateTime(timezone=True))
+    distance_km = db.Column(db.Float, default=0.0)
+
+
 class Payment(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     amount = db.Column(db.Integer, nullable=False)

--- a/taximeter.py
+++ b/taximeter.py
@@ -9,7 +9,7 @@ LOCAL_TZ = ZoneInfo("Europe/Berlin")
 
 
 class Taximeter:
-    def __init__(self, db_path, fetch_func, tariff_func, vehicle_id="default"):
+    def __init__(self, db_path, fetch_func, tariff_func, vehicle_id=None):
         self.db_path = db_path
         self.fetch_func = fetch_func
         self.tariff_func = tariff_func
@@ -34,6 +34,8 @@ class Taximeter:
         return hour >= 22 or hour < 6
 
     def start(self):
+        if not self.vehicle_id:
+            raise ValueError("vehicle_id required")
         with self.lock:
             if self.active:
                 return False
@@ -63,6 +65,8 @@ class Taximeter:
         return True
 
     def pause(self):
+        if not self.vehicle_id:
+            raise ValueError("vehicle_id required")
         with self.lock:
             if not self.active:
                 return False
@@ -74,6 +78,8 @@ class Taximeter:
         return True
 
     def stop(self):
+        if not self.vehicle_id:
+            raise ValueError("vehicle_id required")
         with self.lock:
             if not self.active:
                 return None
@@ -106,6 +112,8 @@ class Taximeter:
         return result
 
     def status(self):
+        if not self.vehicle_id:
+            raise ValueError("vehicle_id required")
         with self.lock:
             if not self.active:
                 result = {"active": False, "paused": self.paused, "waiting": self.waiting}
@@ -260,6 +268,8 @@ class Taximeter:
         return ride_id
 
     def reset(self):
+        if not self.vehicle_id:
+            raise ValueError("vehicle_id required")
         with self.lock:
             self.active = False
             self.paused = False


### PR DESCRIPTION
## Summary
- add Vehicle model with unique user+vehicle constraint
- require vehicle_id on VehicleState, EnergyLog and TripEntry
- drop implicit `default` vehicle handling in API and taximeter

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f6e1a4f3c83219f7c0d5bb88a911f