### PR TITLE
Add subscription-aware configuration controls

### DIFF
--- a/templates/config.html
+++ b/templates/config.html
@@ -16,9 +16,12 @@
         <div>
             <label>
                 {% set default_checked = item.get('default', True) %}
-                <input type="checkbox" name="{{ item.id }}" value="1" {% if config.get(item.id, default_checked) %}checked{% endif %}>
+                <input type="checkbox" name="{{ item.id }}" value="1" {% if config.get(item.id, default_checked) %}checked{% endif %}{% if item.locked %} disabled{% endif %}>
                 {{ item.desc }}
             </label>
+            {% if item.locked %}
+            <div class="hint">Nur mit {{ item.required_subscription|upper }}-Abo verfügbar – Jetzt upgraden</div>
+            {% endif %}
         </div>
         {% endfor %}
         <div>


### PR DESCRIPTION
## Summary
- add models for configurable options, visibility and per-user values
- implement subscription gating decorator and config UI restrictions
- show locked config controls with upgrade hint

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f7257ffcc832198e89dfac66e7e16