### PR TITLE
Add Stripe subscription support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,9 @@ TESLA_REFRESH_TOKEN=
 
 # Google Analytics Tracking ID (optional)
 GA_TRACKING_ID=
+
+# Stripe configuration
+STRIPE_SECRET_KEY=
+STRIPE_WEBHOOK_SECRET=
+STRIPE_BASIC_PRICE_ID=
+STRIPE_PRO_PRICE_ID=

--- a/models.py
+++ b/models.py
@@ -19,6 +19,7 @@ class User(db.Model, UserMixin):
     password_hash = db.Column(db.String(128), nullable=False)
     role = db.Column(db.String(16), default="user")
     subscription = db.Column(db.String(16), default="free")
+    stripe_subscription_id = db.Column(db.String(64))
     is_ham_operator = db.Column(db.Boolean, default=False)
     created_at = db.Column(
         db.DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)

--- a/templates/index.html
+++ b/templates/index.html
@@ -22,6 +22,7 @@
             <button id="share-btn" type="button">Teilen</button>
         </span>
     </h2>
+    {% if inactive %}<p style="color:red;">Kein aktives Abonnement</p>{% endif %}
     {% set show_dash = config.get('menu-dashboard', True) %}
     {% set show_stat = config.get('menu-statistik', True) %}
     {% set show_hist = config.get('menu-history', True) %}

--- a/templates/login.html
+++ b/templates/login.html
@@ -6,6 +6,7 @@
 <body>
     <h2>Login</h2>
     {% if error %}<p style="color:red;">{{ error }}</p>{% endif %}
+    {% if inactive %}<p style="color:red;">Kein aktives Abonnement</p>{% endif %}
     <form method="post">
         <label for="email">E-Mail:</label><br />
         <input type="email" id="email" name="email" required><br />


### PR DESCRIPTION
## Summary
- integrate Stripe checkout and webhook endpoints for BASIC and PRO plans
- cancel subscriptions on account deletion and track Stripe subscription IDs
- show inactive subscription warnings on login and dashboard

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f74498110832194e1c68a36938f5a