### PR TITLE
Restrict SMS and APRS access

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ requests
 aprslib
 phonenumbers==9.0.9
 qrcode
+pytest

--- a/templates/config.html
+++ b/templates/config.html
@@ -24,6 +24,7 @@
             {% endif %}
         </div>
         {% endfor %}
+        {% if current_user.role == 'admin' or current_user.is_ham_operator %}
         <div>
             <label>
                 APRS Rufzeichen
@@ -54,6 +55,7 @@
                 <input type="text" name="aprs_comment" value="{{ config.get('aprs_comment','') }}">
             </label>
         </div>
+        {% endif %}
         <div>
             <label>
                 API Intervall (Sekunden)

--- a/templates/index.html
+++ b/templates/index.html
@@ -201,7 +201,7 @@
         </div>
     </div>
     <div id="offline-msg"></div>
-    {% if config.get('phone_number') and config.get('sms_enabled', True) %}
+    {% if not prefix and current_user.is_authenticated and current_user.role == 'admin' and config.get('phone_number') and config.get('sms_enabled', True) %}
     <div id="sms-form" style="display:none;">
         <input id="sms-name" type="text" placeholder="Ihr Name">
         <input id="sms-text" type="text" maxlength="160" placeholder="Nachricht">

--- a/templates/register.html
+++ b/templates/register.html
@@ -13,8 +13,6 @@
         <input type="email" id="email" name="email" required><br />
         <label for="password">Passwort:</label><br />
         <input type="password" id="password" name="password" required><br />
-        <label for="is_ham_operator">Funkamateur?</label>
-        <input type="checkbox" id="is_ham_operator" name="is_ham_operator"><br />
         <button type="submit">Registrieren</button>
     </form>
     <p>Bereits registriert? <a href="{{ url_for('login') }}">Login</a></p>

--- a/tests/test_guards.py
+++ b/tests/test_guards.py
@@ -1,0 +1,86 @@
+import os
+import sys
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from app import app, db, User
+
+
+@pytest.fixture
+def client():
+    app.config.update(
+        SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
+        TESTING=True,
+        WTF_CSRF_ENABLED=False,
+    )
+    with app.app_context():
+        db.create_all()
+        yield app.test_client()
+        db.session.remove()
+        db.drop_all()
+
+
+def create_user(username, role="user", ham=False):
+    user = User(username=username, email=f"{username}@example.com", role=role, is_ham_operator=ham)
+    user.set_password("pw")
+    db.session.add(user)
+    db.session.commit()
+    return user
+
+
+def login(client, email):
+    return client.post("/login", data={"email": email, "password": "pw"}, follow_redirects=True)
+
+
+def logout(client):
+    client.get("/logout", follow_redirects=True)
+
+
+def test_sms_admin_only(client):
+    with app.app_context():
+        admin = create_user("admin", role="admin")
+        user = create_user("user")
+        slug = user.username_slug
+    login(client, "user@example.com")
+    resp = client.post("/api/sms", json={"message": "hi"})
+    assert resp.status_code == 403
+    logout(client)
+    login(client, "admin@example.com")
+    resp = client.post("/api/sms", json={"message": "hi"})
+    assert resp.status_code != 403
+    resp = client.post(f"/{slug}/api/sms", json={"message": "hi"})
+    assert resp.status_code == 404
+
+
+def test_aprs_guard_and_registration(client):
+    with app.app_context():
+        ham = create_user("ham", ham=True)
+        nonham = create_user("nonham")
+        ham_slug = ham.username_slug
+        nonham_slug = nonham.username_slug
+    # registration cannot set ham operator flag
+    client.post(
+        "/register",
+        data={
+            "username": "new",
+            "email": "new@example.com",
+            "password": "pw",
+            "is_ham_operator": "1",
+        },
+        follow_redirects=True,
+    )
+    with app.app_context():
+        new_user = User.query.filter_by(email="new@example.com").first()
+        assert new_user is not None
+        assert not new_user.is_ham_operator
+    logout(client)
+    # non-ham user blocked
+    login(client, "nonham@example.com")
+    resp = client.get(f"/{nonham_slug}/config")
+    assert resp.status_code == 403
+    assert "ham operators" in resp.get_data(as_text=True)
+    logout(client)
+    # ham operator allowed
+    login(client, "ham@example.com")
+    resp = client.get(f"/{ham_slug}/config")
+    assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- add `admin_only` and `ham_only` decorators to guard privileged routes
- hide SMS features behind admin-only root dashboard and restrict APRS config to ham operators
- cover SMS and APRS guards with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f7665680c8321a15cd43f7a09f9a6