### PR TITLE
Integrate taximeter with central database

### DIFF
--- a/models.py
+++ b/models.py
@@ -83,6 +83,41 @@ class TripEntry(db.Model):
     distance_km = db.Column(db.Float, default=0.0)
 
 
+class TaximeterRide(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    status = db.Column(db.String(16), nullable=False, default="ready")
+    started_at = db.Column(db.DateTime(timezone=True))
+    ended_at = db.Column(db.DateTime(timezone=True))
+    duration_s = db.Column(db.Float)
+    distance_m = db.Column(db.Float)
+    wait_time_s = db.Column(db.Float)
+    cost_base = db.Column(db.Float)
+    cost_distance = db.Column(db.Float)
+    cost_wait = db.Column(db.Float)
+    cost_total = db.Column(db.Float)
+    tariff_snapshot_json = db.Column(db.Text)
+    receipt_json = db.Column(db.Text)
+    created_at = db.Column(
+        db.DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"))
+    vehicle_id = db.Column(db.Integer, db.ForeignKey("vehicle.id"), nullable=False)
+    points = db.relationship("TaximeterPoint", backref="ride")
+
+
+class TaximeterPoint(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    ride_id = db.Column(db.Integer, db.ForeignKey("taximeter_ride.id"), nullable=False)
+    ts = db.Column(db.DateTime(timezone=True))
+    lat = db.Column(db.Float)
+    lon = db.Column(db.Float)
+    speed_kph = db.Column(db.Float)
+    heading_deg = db.Column(db.Float)
+    odo_m = db.Column(db.Float)
+    is_pause = db.Column(db.Boolean, default=False)
+    is_wait = db.Column(db.Boolean, default=False)
+
+
 class Payment(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     amount = db.Column(db.Integer, nullable=False)

--- a/templates/history.html
+++ b/templates/history.html
@@ -59,7 +59,7 @@
         </select>
     </form>
     {% if selected %}
-    <a id="receipt-link" class="menu-button" href="{{ prefix }}/taxameter/trip_receipt?file={{ selected }}">Quittung</a>
+    <a id="receipt-link" class="menu-button" href="/taxameter/trip_receipt?file={{ selected }}">Quittung</a>
     {% endif %}
     <div id="map">
         <div id="slider-container">

--- a/templates/taxameter.html
+++ b/templates/taxameter.html
@@ -51,7 +51,7 @@
         const TAXI_COMPANY = "{{ company }}";
         const TAXI_SLOGAN = "{{ config.get('taxi_slogan','Wir lassen Sie nicht im Regen stehen.') }}";
         const VEHICLE_ID = "{{ vehicle_id }}";
-        window.BASE_PATH = "{{ prefix }}";
+        window.BASE_PATH = "";
     </script>
     <script src="/static/js/taxameter.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- replace sqlite-based taximeter storage with SQLAlchemy models `TaximeterRide` and `TaximeterPoint`
- log rides and points on each position update and capture tariff snapshots
- restrict taximeter page and APIs to admin at root path and clean templates/links

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688f795e7308832181274e5e5553b3f4