### PR TITLE
Add admin user management

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ aprslib
 phonenumbers==9.0.9
 qrcode
 pytest
+flask-admin

--- a/tests/test_guards.py
+++ b/tests/test_guards.py
@@ -84,3 +84,16 @@ def test_aprs_guard_and_registration(client):
     login(client, "ham@example.com")
     resp = client.get(f"/{ham_slug}/config")
     assert resp.status_code == 200
+
+
+def test_admin_users_list_access(client):
+    with app.app_context():
+        create_user("admin", role="admin")
+        create_user("user")
+    login(client, "user@example.com")
+    resp = client.get("/admin/users/")
+    assert resp.status_code == 403
+    logout(client)
+    login(client, "admin@example.com")
+    resp = client.get("/admin/users/")
+    assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- integrate Flask-Admin and secure admin views
- allow admins to list/edit/delete users and vehicles
- cover admin access with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f7c4074788321ac80e600deb0fa92