### PR TITLE
docs: update instructions and tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,8 +6,7 @@ under `static/`.  Documentation and example files are located in `docs/`.
 
 ## General workflow
 
-- Run `pytest -q` after every change. The project currently has no tests so the
-  command should report `no tests ran`.
+- Run `pytest -q` after every change to ensure the test suite passes.
 - Avoid automatic code formatters like `black` or `isort` unless explicitly
   requested. Follow PEP 8 conventions manually.
 - Keep commit messages short and in English, describing what the change does.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 # Tesla Dashboard
 
-This is a simple Flask application that displays real-time data from a Tesla vehicle using the [teslapy](https://github.com/tdorssers/TeslaPy) library.
+This is a simple Flask application that displays real-time data from a Tesla vehicle using the [TeslaPy](https://github.com/tdorssers/TeslaPy) library.
 
 ## Setup
-
 1. Install dependencies:
     ```bash
     pip install -r requirements.txt
@@ -113,3 +112,11 @@ The API reports doors, windows, trunk and frunk using numeric values. These
 values are `0` when the part is closed and `1` (or any non-zero value) when the
 part is open. The dashboard therefore treats any non-zero value as "open" to
 handle potential future variations.
+
+## Development
+
+Run the test suite with:
+
+```bash
+pytest -q
+```


### PR DESCRIPTION
## Summary
- clarify AGENTS workflow to run the actual test suite
- fix README's TeslaPy link and add test instructions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688fe72f47248321a28f940b3a53b542