### PR TITLE
Fix circular import in app initialization

### DIFF
--- a/app.py
+++ b/app.py
@@ -16,7 +16,7 @@ from flask import (
     g,
     Blueprint,
 )
-from flask_sqlalchemy import SQLAlchemy
+from extensions import db
 from flask_login import (
     LoginManager,
     login_user,
@@ -56,7 +56,7 @@ except ImportError:
 load_dotenv()
 app = Flask(__name__)
 app.config.from_object("config")
-db = SQLAlchemy(app)
+db.init_app(app)
 login_manager = LoginManager(app)
 login_manager.login_view = "login"
 

--- a/extensions.py
+++ b/extensions.py
@@ -1,0 +1,6 @@
+from flask_sqlalchemy import SQLAlchemy
+
+# Central place to store shared extensions
+# SQLAlchemy instance is initialised in app.py
+
+db = SQLAlchemy()

--- a/models.py
+++ b/models.py
@@ -3,7 +3,7 @@ import re
 from flask_login import UserMixin
 from werkzeug.security import generate_password_hash, check_password_hash
 
-from app import db
+from extensions import db
 
 
 def _slugify(value: str) -> str:


### PR DESCRIPTION
## Summary
- Initialize SQLAlchemy via shared extension to avoid circular imports
- Update models to use the shared database instance
- Add `extensions.py` to house SQLAlchemy setup

## Testing
- `pytest -q`
- `python app.py` (start server)


------
https://chatgpt.com/codex/tasks/task_e_688feb3023808321951f55b12c0b1818