### PR TITLE
Bump version to 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Clients periodically fetch `/api/version` and reload the page when the version c
 so the browser always shows the latest release.
 The footer also includes a copyright notice:
 ```
-Tesla-Dashboard Version 1.0.X - © <current year> Erik Schauer, do1ffe@darc.de
+Tesla-Dashboard Version 2.0.X - © <current year> Erik Schauer, do1ffe@darc.de
 ```
 
 ## Reference

--- a/app.py
+++ b/app.py
@@ -1311,7 +1311,7 @@ def get_vehicle_list():
 def reverse_geocode(lat, lon):
     """Return address information for given coordinates using OpenStreetMap."""
 
-    headers = {"User-Agent": "TeslaDashboard/1.0"}
+    headers = {"User-Agent": "TeslaDashboard/2.0"}
     try:
         url = "https://nominatim.openstreetmap.org/reverse"
         params = {"lat": lat, "lon": lon, "format": "jsonv2"}

--- a/version.py
+++ b/version.py
@@ -11,6 +11,6 @@ def get_version():
             .decode()
             .strip()
         )
-        return f"1.0.{count}"
+        return f"2.0.{count}"
     except Exception:
         return "0.0.0"


### PR DESCRIPTION
## Summary
- update version generator to return `2.0` based versions
- refresh README to reference version 2.0
- send HTTP requests with `TeslaDashboard/2.0` user agent

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688ff32bef60832197825afd665b3aa5