### PR TITLE
Avoid waking vehicle

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,9 @@ All required JavaScript and CSS libraries are bundled under `static/` so the das
 
 The backend continuously polls the Tesla API and pushes new data to clients using Server-Sent Events (SSE). The frontend never talks to the Tesla API directly. It only requests data from the backend using the `/api/...` endpoints so tokens remain secure on the server.
 The frontend first checks `/api/state` to make sure the car is online before
-opening the streaming connection.  When the vehicle is reported as `offline` or
-`asleep` no further API requests are made, preventing the car from waking up
-unexpectedly.  Only when occupant presence is reported via `/api/occupant` will
-the application wake the vehicle and query live data.
+opening the streaming connection. When the vehicle is reported as `offline` or
+`asleep` no further API requests are made so the car remains in its current
+state. The dashboard never wakes the vehicle automatically.
 
 ## Features
 
@@ -87,9 +86,9 @@ The same information is also stored as hierarchical JSON in `data/api-liste.json
 * `/api/version` – return the current dashboard version as JSON
 * `/api/clients` – number of connected clients as JSON
 * `/api/occupant` – get or set occupant presence flag
-* `/api/announcement` – return the current announcement text as JSON
     * Use `POST` with a JSON body like `{ "present": true }` or `{ "present": false }`
-      to keep the vehicle awake only when someone is inside.
+      to notify the dashboard whether someone is inside.
+* `/api/announcement` – return the current announcement text as JSON
 * `/stream/<vehicle_id>` – Server-Sent Events endpoint used by the frontend
 
 ## Version

--- a/app.py
+++ b/app.py
@@ -1374,14 +1374,6 @@ def _refresh_state(vehicle, times=2):
         if state == "online":
             return state
 
-    if state == "asleep":
-        try:
-            vehicle.sync_wake_up(timeout=10)
-            state = vehicle.get("state") or vehicle["state"]
-            log_vehicle_state(vehicle["id_s"], state)
-            log_api_data("wake_up_retry", {"state": state})
-        except Exception:
-            pass
     return state
 
 
@@ -1451,19 +1443,7 @@ def get_vehicle_data(vehicle_id=None, state=None):
             return {"error": "Vehicle unavailable", "state": "offline"}
 
     if state != "online":
-        if occupant_present and state in ("asleep", "offline"):
-            try:
-                vehicle.sync_wake_up()
-                state = vehicle.get("state") or vehicle["state"]
-                log_vehicle_state(vehicle["id_s"], state)
-                log_api_data("wake_up", {"state": state})
-            except Exception as exc:
-                _log_api_error(exc)
-                return {"error": str(exc), "state": state}
-            if state != "online":
-                return {"state": state}
-        else:
-            return {"state": state}
+        return {"state": state}
 
     try:
         vehicle_data = vehicle.get_vehicle_data()


### PR DESCRIPTION
## Summary
- prevent backend from invoking wake-up commands
- clarify in README that the dashboard never wakes the vehicle

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68943f4572d48321a93e0436c16c2da7