### PR TITLE
Reorganize config page layout

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1089,3 +1089,63 @@ select {
   right: 0;
   text-align: center;
 }
+
+/* Config page */
+.config-container {
+  max-width: 600px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.config-section {
+  padding: 15px;
+  background: var(--surface-color);
+  border: 1px solid #444;
+  border-radius: 8px;
+}
+
+.config-section h2,
+.config-section h3 {
+  margin-top: 0;
+}
+
+.config-section label {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-bottom: 10px;
+}
+
+.config-section label.checkbox {
+  flex-direction: row;
+  align-items: center;
+}
+
+.config-section input[type="text"],
+.config-section input[type="number"],
+.config-section textarea {
+  padding: 4px 8px;
+  background: var(--surface-color);
+  color: var(--text-color);
+  border: 1px solid #444;
+  border-radius: 4px;
+}
+
+.config-section textarea {
+  width: 100%;
+}
+
+.config-actions {
+  display: flex;
+  gap: 10px;
+}
+
+.config-actions button {
+  padding: 6px 12px;
+  background: var(--surface-color);
+  color: var(--text-color);
+  border: 1px solid #444;
+  border-radius: 4px;
+}

--- a/templates/config.html
+++ b/templates/config.html
@@ -11,146 +11,129 @@
 </head>
 <body>
     <h1>Dashboard Konfiguration</h1>
-    <form method="post">
-        {% for item in items %}
-        <div>
-            <label>
+    <form method="post" class="config-container">
+        <section class="config-section">
+            <h2>Dashboard Optionen</h2>
+            {% for item in items %}
+            <label class="checkbox">
                 {% set default_checked = item.get('default', True) %}
                 <input type="checkbox" name="{{ item.id }}" value="1" {% if config.get(item.id, default_checked) %}checked{% endif %}>
                 {{ item.desc }}
             </label>
-        </div>
-        {% endfor %}
-        <div>
+            {% endfor %}
+        </section>
+
+        <section class="config-section">
+            <h2>APRS</h2>
             <label>
                 APRS Rufzeichen
                 <input type="text" name="aprs_callsign" value="{{ config.get('aprs_callsign','') }}">
             </label>
-        </div>
-        <div>
             <label>
                 APRS Passcode
                 <input type="text" name="aprs_passcode" value="{{ config.get('aprs_passcode','') }}">
             </label>
-        </div>
-        <div>
-            <label>
+            <label class="checkbox">
                 <input type="checkbox" name="aprs_wx_enabled" value="1" {% if config.get('aprs_wx_enabled', True) %}checked{% endif %}>
                 APRS WX-Paket senden
             </label>
-        </div>
-        <div>
             <label>
                 APRS WX Rufzeichen
                 <input type="text" name="aprs_wx_callsign" value="{{ config.get('aprs_wx_callsign','') }}">
             </label>
-        </div>
-        <div>
             <label>
                 APRS Kommentar
                 <input type="text" name="aprs_comment" value="{{ config.get('aprs_comment','') }}">
             </label>
-        </div>
-        <div>
+        </section>
+
+        <section class="config-section">
+            <h2>API</h2>
             <label>
                 API Intervall (Sekunden)
                 <input type="number" name="api_interval" min="1" step="1" value="{{ config.get('api_interval', 3) }}">
             </label>
-        </div>
-        <div>
             <label>
                 API Intervall ohne Client (Sekunden)
                 <input type="number" name="api_interval_idle" min="1" step="1" value="{{ config.get('api_interval_idle', 30) }}">
             </label>
-        </div>
-        <div>
+        </section>
+
+        <section class="config-section">
+            <h2>Anzeige</h2>
             <label>
                 Hinweistext
-                <textarea name="announcement" rows="6" style="width:100%">{{ config.get('announcement','') }}</textarea>
+                <textarea name="announcement" rows="6">{{ config.get('announcement','') }}</textarea>
             </label>
-        </div>
-        <div>
+        </section>
+
+        <section class="config-section">
+            <h2>SMS</h2>
             <label>
                 Handynummer des Fahrers
                 <input type="text" name="phone_number" value="{{ config.get('phone_number','') }}">
             </label>
-        </div>
-        <div>
             <label>
                 Infobip API Key
                 <input type="text" name="infobip_api_key" value="{{ config.get('infobip_api_key','') }}">
             </label>
-        </div>
-        <div>
             <label>
                 Infobip Basis-URL
                 <input type="text" name="infobip_base_url" value="{{ config.get('infobip_base_url','https://api.infobip.com') }}">
             </label>
-        </div>
-        <div>
             <label>
                 SMS Absender
                 <input type="text" name="sms_sender_id" value="{{ config.get('sms_sender_id','') }}">
             </label>
-        </div>
-        <div>
-            <label>
+            <label class="checkbox">
                 <input type="checkbox" name="sms_enabled" value="1" {% if config.get('sms_enabled', True) %}checked{% endif %}>
                 SMS-Versand erlauben
             </label>
-        </div>
-        <div>
-            <label>
+            <label class="checkbox">
                 <input type="checkbox" name="sms_drive_only" value="1" {% if config.get('sms_drive_only', True) %}checked{% endif %}>
                 SMS nur während der Fahrt
             </label>
-        </div>
-        <h2>Taxameter</h2>
-        <div>
+        </section>
+
+        <section class="config-section">
+            <h2>Taxameter</h2>
             <label>
                 Taxiunternehmen
                 <input type="text" name="taxi_company" value="{{ config.get('taxi_company','Taxi Schauer') }}">
             </label>
-        </div>
-        <div>
             <label>
                 Slogan
                 <input type="text" name="taxi_slogan" value="{{ config.get('taxi_slogan','Wir lassen Sie nicht im Regen stehen.') }}">
             </label>
-        </div>
-        <div>
             <label>
                 Wartepreis je 10 Sekunden
                 <input type="number" step="0.01" name="wait_price" value="{{ config.get('taximeter_tariff', {}).get('wait_per_10s', 0.10) }}">
             </label>
-        </div>
-        <h3>Tarif (Euro)</h3>
-        <div>
+
+            <h3>Tarif (Euro)</h3>
             <label>
                 Grundgebühr
                 <input type="number" step="0.01" name="tariff_base" value="{{ config.get('taximeter_tariff', {}).get('base', 4.40) }}">
             </label>
-        </div>
-        <div>
             <label>
                 1.–2. km
                 <input type="number" step="0.01" name="tariff_12" value="{{ config.get('taximeter_tariff', {}).get('rate_1_2', 2.70) }}">
             </label>
-        </div>
-        <div>
             <label>
                 3.–4. km
                 <input type="number" step="0.01" name="tariff_34" value="{{ config.get('taximeter_tariff', {}).get('rate_3_4', 2.60) }}">
             </label>
-        </div>
-        <div>
             <label>
                 ab 5. km
                 <input type="number" step="0.01" name="tariff_5" value="{{ config.get('taximeter_tariff', {}).get('rate_5_plus', 2.40) }}">
             </label>
+        </section>
+
+        <div class="config-actions">
+            <button type="submit">Speichern</button>
+            <button type="submit" name="refresh_vehicle_list" value="1">Fahrzeugliste aktualisieren</button>
         </div>
-        <button type="submit">Speichern</button>
-        <button type="submit" name="refresh_vehicle_list" value="1">Fahrzeugliste aktualisieren</button>
     </form>
 </body>
 </html>
+


### PR DESCRIPTION
## Summary
- Group configuration form into themed sections
- Modernize config page with improved styling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895179af350832196fb6652e4c109ca