### PR TITLE
Prepare multiuser Flask base with SQLAlchemy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__/
 .env
 *.pyc
 data/
+instance/

--- a/config.py
+++ b/config.py
@@ -1,0 +1,2 @@
+SQLALCHEMY_DATABASE_URI = "sqlite:///dashboard.db"
+SQLALCHEMY_TRACK_MODIFICATIONS = False

--- a/models.py
+++ b/models.py
@@ -1,0 +1,15 @@
+from datetime import datetime
+
+try:  # running via `python app.py`
+    from __main__ import db  # type: ignore
+except ImportError:  # pragma: no cover
+    from app import db  # type: ignore
+
+
+class User(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+
+def init_db():
+    db.create_all()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,10 @@
 flask
+flask-login
+flask-sqlalchemy
 teslapy
 python-dotenv
 requests
 aprslib
 phonenumbers==9.0.9
 qrcode
+stripe


### PR DESCRIPTION
## Summary
- Initialize Flask app with SQLAlchemy, LoginManager, and Stripe support
- Add configuration and placeholder User model using UTC timestamps
- Replace file-based logging and caches with in-memory stores and ignore instance DB

## Testing
- `pip install flask-login flask-sqlalchemy stripe`
- `pytest -q`
- `python app.py` (creates `instance/dashboard.db`)


------
https://chatgpt.com/codex/tasks/task_e_68968a8b0d488321a0ab02135ef385e3