### PR TITLE
Add user authentication and admin CLI

### DIFF
--- a/models.py
+++ b/models.py
@@ -1,14 +1,41 @@
 from datetime import datetime
 
+from flask_login import UserMixin
+from sqlalchemy.orm import validates
+from werkzeug.security import generate_password_hash, check_password_hash
+
 try:  # running via `python app.py`
     from __main__ import db  # type: ignore
 except ImportError:  # pragma: no cover
     from app import db  # type: ignore
 
 
-class User(db.Model):
+class User(db.Model, UserMixin):
     id = db.Column(db.Integer, primary_key=True)
+    username = db.Column(db.String(80), unique=True, nullable=False)
+    username_slug = db.Column(db.String(80), unique=True, nullable=False)
+    email = db.Column(db.String(120), unique=True, nullable=False)
+    password_hash = db.Column(db.String(128), nullable=False)
+    role = db.Column(db.String(5), default="user")
+    subscription = db.Column(db.String(5), default="free")
+    is_ham_operator = db.Column(db.Boolean, default=False)
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        if self.username and not self.username_slug:
+            self.username_slug = self.username.lower()
+
+    @validates("username")
+    def _set_slug(self, key, value):  # pragma: no cover - simple setter
+        self.username_slug = value.lower()
+        return value
+
+    def set_password(self, password):
+        self.password_hash = generate_password_hash(password)
+
+    def check_password(self, password):
+        return check_password_hash(self.password_hash, password)
 
 
 def init_db():

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="de">
+<head>
+    <meta charset="utf-8">
+    <title>Anmeldung</title>
+</head>
+<body>
+    <h2>Anmeldung</h2>
+    {% if error %}<p style="color:red;">{{ error }}</p>{% endif %}
+    <form method="post">
+        <label for="username">Benutzername oder E-Mail</label>
+        <input type="text" id="username" name="username" required>
+        <label for="password">Passwort</label>
+        <input type="password" id="password" name="password" required>
+        <button type="submit">Anmelden</button>
+    </form>
+    <p>Noch kein Konto? <a href="{{ url_for('register') }}">Registrieren</a></p>
+</body>
+</html>

--- a/templates/register.html
+++ b/templates/register.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="de">
+<head>
+    <meta charset="utf-8">
+    <title>Registrierung</title>
+</head>
+<body>
+    <h2>Registrierung</h2>
+    {% if error %}<p style="color:red;">{{ error }}</p>{% endif %}
+    <form method="post">
+        <label for="username">Benutzername</label>
+        <input type="text" id="username" name="username" required>
+        <label for="email">E-Mail</label>
+        <input type="email" id="email" name="email" required>
+        <label for="password">Passwort</label>
+        <input type="password" id="password" name="password" required>
+        <button type="submit">Registrieren</button>
+    </form>
+    <p>Bereits registriert? <a href="{{ url_for('login') }}">Anmelden</a></p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- extend `User` model with username, email, password hash, roles and subscription data
- integrate Flask-Login with registration, login, logout routes and protect dashboard
- add `ensure-admin` CLI helper and simple templates for authentication

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68968e897d548321b1d833d3675d0754