### PR TITLE
Allow public admin dashboard

### DIFF
--- a/app.py
+++ b/app.py
@@ -1752,8 +1752,10 @@ def logout():
 
 
 @app.route("/")
-@login_required
 def index():
+    user = User.query.filter_by(role="admin").first()
+    if user:
+        login_user(user)
     cfg = load_config()
     return render_template(
         "index.html",

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1149,3 +1149,25 @@ select {
   border: 1px solid #444;
   border-radius: 4px;
 }
+
+.share-container {
+  position: fixed;
+  top: 10px;
+  right: 10px;
+  z-index: 1000;
+}
+
+.public-banner {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  text-align: center;
+  background: var(--surface-color);
+  padding: 10px 0;
+  box-shadow: 0 -2px 4px rgba(0, 0, 0, 0.5);
+}
+
+.public-banner a {
+  color: var(--accent-color);
+}

--- a/static/js/share.js
+++ b/static/js/share.js
@@ -1,0 +1,11 @@
+function copyUrl() {
+    var url = window.location.href;
+    navigator.clipboard.writeText(url);
+}
+
+document.addEventListener('DOMContentLoaded', function () {
+    var btn = document.getElementById('share-button');
+    if (btn) {
+        btn.addEventListener('click', copyUrl);
+    }
+});

--- a/templates/history.html
+++ b/templates/history.html
@@ -101,5 +101,6 @@
         var tripHeading = {{ heading|tojson }};
     </script>
     <script src="/static/js/history.js"></script>
+    {% include 'public_banner.html' %}
 </body>
 </html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -226,5 +226,6 @@
         window.APP_VERSION = "{{ version }}";
     </script>
     <script src="/static/js/main.js"></script>
+    {% include 'public_banner.html' %}
 </body>
 </html>

--- a/templates/map.html
+++ b/templates/map.html
@@ -32,5 +32,6 @@
         window.APP_VERSION = "{{ version }}";
     </script>
     <script src="/static/js/main.js"></script>
+    {% include 'public_banner.html' %}
 </body>
 </html>

--- a/templates/public_banner.html
+++ b/templates/public_banner.html
@@ -1,0 +1,9 @@
+<div class="share-container">
+    <button id="share-button" type="button">Teilen</button>
+</div>
+{% if not current_user.is_authenticated %}
+<div class="public-banner">
+    Dein eigenes Dashboard? <a href="{{ url_for('register') }}">Jetzt registrieren</a> / <a href="{{ url_for('login') }}">einloggen</a>.
+</div>
+{% endif %}
+<script src="/static/js/share.js"></script>

--- a/templates/statistik.html
+++ b/templates/statistik.html
@@ -39,5 +39,6 @@
         </tr>
         {% endfor %}
     </table>
+    {% include 'public_banner.html' %}
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Serve the admin dashboard to anonymous users by auto-loading the admin account
- Add a share button and public registration/login banner to dashboards
- Style and script for clipboard sharing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68968fffa3188321af27b0f2827ddcd6