### PR TITLE
Add user namespace routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ This is a simple Flask application that displays real-time data from a Tesla veh
     ```
 
 4. Open `http://localhost:8013` in your browser (the server listens on `0.0.0.0:8013`).
-5. On the configuration page (`/config`) you can set your APRS call sign, passcode and an optional comment to transmit position packets via an EU APRS-IS server. You may also enable an additional WX packet using a separate call sign. Temperatures are included in Celsius within the comment. Positions are sent at most every 30 seconds while driving and at least every 10 minutes even without changes. WX packets obey the same limits and are only transmitted when the outside temperature changes or after ten minutes without an update. The page also lets you adjust the Tesla API polling interval and disable the announcement text.
+5. On the configuration page (`/<username_slug>/config`) you can set your APRS call sign, passcode and an optional comment to transmit position packets via an EU APRS-IS server. You may also enable an additional WX packet using a separate call sign. Temperatures are included in Celsius within the comment. Positions are sent at most every 30 seconds while driving and at least every 10 minutes even without changes. WX packets obey the same limits and are only transmitted when the outside temperature changes or after ten minutes without an update. The page also lets you adjust the Tesla API polling interval and disable the announcement text.
 6. You can also enter the driver's phone number in international format (for example `+491701234567`), your Infobip API key and an optional sender ID here. Leave the sender field empty if the account does not support custom senders. SMS messages to the driver can be enabled or disabled and you may choose whether they are only allowed while driving or at any time. When restricted to driving mode, messages are still allowed for five minutes after parking.
 7. When sending a text message the sender's name is requested as well. The entire message including the name must not exceed 160 characters.
 
-All sent text messages are written to `data/sms.log` and can be viewed on the `/sms` page.
+All sent text messages are written to `data/sms.log` and can be viewed on the `/<username_slug>/sms` page.
 Timestamps in this file are recorded in the Europe/Berlin timezone.
 
 All API calls are logged to `data/api.log` without storing request details. The log file uses rotation and will grow to at most 1&nbsp;MB.
@@ -42,7 +42,7 @@ can be started from any location while still accessing existing trips and logs.
 
 All required JavaScript and CSS libraries are bundled under `static/` so the dashboard works even without Internet access.
 
-The backend continuously polls the Tesla API and pushes new data to clients using Server-Sent Events (SSE). The frontend never talks to the Tesla API directly. It only requests data from the backend using the `/api/...` endpoints so tokens remain secure on the server.
+The backend continuously polls the Tesla API and pushes new data to clients using Server-Sent Events (SSE). The frontend never talks to the Tesla API directly. It only requests data from the backend using the `/<username_slug>/api/...` endpoints so tokens remain secure on the server.
 The frontend first checks `/api/state` to make sure the car is online before
 opening the streaming connection. When the vehicle is reported as `offline` or
 `asleep` no further API requests are made so the car remains in its current
@@ -53,7 +53,7 @@ state. The dashboard never wakes the vehicle automatically.
 The dashboard shows a short overview depending on whether the vehicle is parked, driving or charging. Below this, additional tables are grouped by category (battery/charging, climate, drive state, vehicle status and media information) to make the raw API data easier to read. While parked the dashboard also displays tire pressures, power usage of the drive unit and the 12V battery as well as how long the vehicle has been parked.
 
 While driving, a blue path is drawn on the map using the reported GPS positions. All trips of a day are logged to a single CSV file under `data/<vehicle_id>/trips` for later analysis.
-The `/history` page lists these files so previous trips can be selected and displayed on an interactive map.
+The `/<username_slug>/history` page lists these files so previous trips can be selected and displayed on an interactive map.
 Entire weeks or months can also be chosen to display longer time spans at once.
 Using the slider you can inspect each recorded point and see the exact timestamp along with speed and power information.
 When multiple cars are available a drop-down menu lets you switch between vehicles.
@@ -65,31 +65,31 @@ Clients reload automatically when the polling interval changes so the new settin
 
 Whenever a door, window, the trunk or the frunk is open or the vehicle is unlocked the backend switches to the normal polling interval. The same happens when someone is detected inside or the gear lever is in R, N or D. In all other situations the idle interval is used so the car can enter sleep mode.
 
-Data is streamed to the frontend via `/stream/<vehicle_id>` using Server-Sent Events so the dashboard updates instantly when new information arrives.
-The endpoint `/apiliste` exposes a text file listing all seen API variables and their latest values.
+Data is streamed to the frontend via `/<username_slug>/stream/<vehicle_id>` using Server-Sent Events so the dashboard updates instantly when new information arrives.
+The endpoint `/<username_slug>/apiliste` exposes a text file listing all seen API variables and their latest values.
 
 The same information is also stored as hierarchical JSON in `data/api-liste.json`.
 
 ## Endpoints
 
-* `/` – main dashboard with map and status information
-* `/map` – map-only view without additional details
-* `/daten` – vehicle data without the map
-* `/history` – select and display recorded trips
-* `/error` – show recent API errors (JSON via `/api/errors`)
-* `/state` – display the vehicle state log
-* `/debug` – display environment info and recent log lines
-* `/apilog` – show the raw API log
-* `/sms` – show the SMS log
-* `/api/vehicles` – list available vehicles as JSON
-* `/api/state` – return the current vehicle state as JSON
-* `/api/version` – return the current dashboard version as JSON
-* `/api/clients` – number of connected clients as JSON
-* `/api/occupant` – get or set occupant presence flag
+* `/<username_slug>` – main dashboard with map and status information
+* `/<username_slug>/map` – map-only view without additional details
+* `/<username_slug>/data` – vehicle data without the map
+* `/<username_slug>/history` – select and display recorded trips
+* `/<username_slug>/error` – show recent API errors (JSON via `/<username_slug>/api/errors`)
+* `/<username_slug>/state` – display the vehicle state log
+* `/<username_slug>/debug` – display environment info and recent log lines
+* `/<username_slug>/apilog` – show the raw API log
+* `/<username_slug>/sms` – show the SMS log
+* `/<username_slug>/api/vehicles` – list available vehicles as JSON
+* `/<username_slug>/api/state` – return the current vehicle state as JSON
+* `/<username_slug>/api/version` – return the current dashboard version as JSON
+* `/<username_slug>/api/clients` – number of connected clients as JSON
+* `/<username_slug>/api/occupant` – get or set occupant presence flag
     * Use `POST` with a JSON body like `{ "present": true }` or `{ "present": false }`
       to notify the dashboard whether someone is inside.
-* `/api/announcement` – return the current announcement text as JSON
-* `/stream/<vehicle_id>` – Server-Sent Events endpoint used by the frontend
+* `/<username_slug>/api/announcement` – return the current announcement text as JSON
+* `/<username_slug>/stream/<vehicle_id>` – Server-Sent Events endpoint used by the frontend
 
 ## Version
 

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -1,5 +1,6 @@
 var currentVehicle = null;
 var APP_VERSION = window.APP_VERSION || null;
+var API_PREFIX = window.API_PREFIX || '/api';
 var MILES_TO_KM = 1.60934;
 var announcementRaw = '';
 var announcementList = [];
@@ -226,7 +227,7 @@ function updateHeader(data) {
 }
 
 function fetchVehicles() {
-    $.getJSON('/api/vehicles', function(resp) {
+    $.getJSON(API_PREFIX + '/vehicles', function(resp) {
         var vehicles = Array.isArray(resp) ? resp : [];
         var $select = $('#vehicle-select');
         var $label = $('label[for="vehicle-select"]');
@@ -1125,7 +1126,7 @@ function updateOfflineInfo(state, serviceMode, serviceModePlus) {
 }
 
 function updateClientCount() {
-    $.getJSON('/api/clients', function(resp) {
+    $.getJSON(API_PREFIX + '/clients', function(resp) {
         if (typeof resp.clients === 'number') {
             $('#client-count').text('Clients: ' + resp.clients);
         }
@@ -1163,7 +1164,7 @@ function updateAnnouncement() {
 }
 
 function fetchAnnouncement() {
-    $.getJSON('/api/announcement', function(resp) {
+    $.getJSON(API_PREFIX + '/announcement', function(resp) {
         if (typeof resp.announcement !== 'undefined') {
             if (resp.announcement !== announcementRaw) {
                 announcementRaw = resp.announcement;
@@ -1199,7 +1200,7 @@ function startStream() {
         eventSource.close();
     }
     showLoading();
-    eventSource = new EventSource('/stream/' + currentVehicle);
+    eventSource = new EventSource('/' + window.USER_SLUG + '/stream/' + currentVehicle);
     eventSource.onmessage = function(e) {
         var data = JSON.parse(e.data);
         if (!data.error) {
@@ -1212,11 +1213,11 @@ function startStream() {
             eventSource = null;
         }
         if (!currentVehicle) return;
-        $.getJSON('/api/state/' + currentVehicle, function(resp) {
+        $.getJSON(API_PREFIX + '/state/' + currentVehicle, function(resp) {
             var st = resp.state;
             updateVehicleState(st);
             updateOfflineInfo(st, resp.service_mode, resp.service_mode_plus);
-            $.getJSON('/api/data/' + currentVehicle, function(data) {
+            $.getJSON(API_PREFIX + '/data/' + currentVehicle, function(data) {
                 if (data && !data.error) {
                     handleData(data);
                 }
@@ -1241,12 +1242,12 @@ function startStreamIfOnline() {
         return;
     }
     showLoading();
-    $.getJSON('/api/state/' + currentVehicle, function(resp) {
+    $.getJSON(API_PREFIX + '/state/' + currentVehicle, function(resp) {
         var st = resp.state;
         updateVehicleState(st);
         updateOfflineInfo(st, resp.service_mode, resp.service_mode_plus);
         startStream();
-        $.getJSON('/api/data/' + currentVehicle, function(data) {
+        $.getJSON(API_PREFIX + '/data/' + currentVehicle, function(data) {
             if (data && !data.error) {
                 handleData(data);
             }
@@ -1254,7 +1255,7 @@ function startStreamIfOnline() {
     });
 }
 
-$.getJSON('/api/config', function(cfg) {
+$.getJSON(API_PREFIX + '/config', function(cfg) {
     applyConfig(cfg);
     lastConfigJSON = JSON.stringify(cfg || {});
     if (cfg) {
@@ -1265,7 +1266,7 @@ $.getJSON('/api/config', function(cfg) {
 });
 
 function fetchConfig() {
-    $.getJSON('/api/config', function(cfg) {
+    $.getJSON(API_PREFIX + '/config', function(cfg) {
         var json = JSON.stringify(cfg || {});
         if (json !== lastConfigJSON) {
             if (cfg && (cfg.api_interval !== lastApiInterval ||
@@ -1284,7 +1285,7 @@ function fetchConfig() {
 }
 
 function checkAppVersion() {
-    $.getJSON('/api/version', function(resp) {
+    $.getJSON(API_PREFIX + '/version', function(resp) {
         if (resp.version && APP_VERSION && resp.version !== APP_VERSION) {
             location.reload(true);
         }
@@ -1313,7 +1314,7 @@ $('#sms-send').on('click', function() {
     }
     $('#sms-status').text('Senden...');
     $.ajax({
-        url: '/api/sms',
+        url: API_PREFIX + '/sms',
         method: 'POST',
         contentType: 'application/json',
         data: JSON.stringify({message: msg, name: name}),

--- a/static/js/taxameter.js
+++ b/static/js/taxameter.js
@@ -1,6 +1,7 @@
 $(function() {
+    var API_PREFIX = window.API_PREFIX || '';
     function update() {
-        $.getJSON('/api/taxameter/status?vehicle_id=' + encodeURIComponent(VEHICLE_ID), function(data) {
+        $.getJSON(API_PREFIX + '/taxameter/status?vehicle_id=' + encodeURIComponent(VEHICLE_ID), function(data) {
             if (data.price !== undefined) {
                 $('#price').text(Number(data.price).toFixed(2));
             }
@@ -95,19 +96,19 @@ $(function() {
         $('#taximeter-receipt').hide();
         $('.active-btn').removeClass('active-btn');
         $(this).addClass('active-btn');
-        $.post('/api/taxameter/start', {vehicle_id: VEHICLE_ID}, update, 'json');
+        $.post(API_PREFIX + '/taxameter/start', {vehicle_id: VEHICLE_ID}, update, 'json');
     });
 
     $('#pause-btn').click(function() {
         $('.active-btn').removeClass('active-btn');
         $(this).addClass('active-btn');
-        $.post('/api/taxameter/pause', {vehicle_id: VEHICLE_ID}, update, 'json');
+        $.post(API_PREFIX + '/taxameter/pause', {vehicle_id: VEHICLE_ID}, update, 'json');
     });
 
     $('#stop-btn').click(function() {
         $('.active-btn').removeClass('active-btn');
         $(this).addClass('active-btn');
-        $.post('/api/taxameter/stop', {vehicle_id: VEHICLE_ID}, function(data) {
+        $.post(API_PREFIX + '/taxameter/stop', {vehicle_id: VEHICLE_ID}, function(data) {
             if (data.price !== undefined) {
                 $('#price').text(Number(data.price).toFixed(2));
                 $('#dist').text(Number(data.distance).toFixed(2));
@@ -120,7 +121,7 @@ $(function() {
 
     $('#reset-btn').click(function() {
         $('.active-btn').removeClass('active-btn');
-        $.post('/api/taxameter/reset', {vehicle_id: VEHICLE_ID}, update);
+        $.post(API_PREFIX + '/taxameter/reset', {vehicle_id: VEHICLE_ID}, update);
         $('#price').text('0.00');
         $('#dist').text('0.00');
         $('#time').text('0');
@@ -130,13 +131,13 @@ $(function() {
     $('#trip-receipt-btn').click(function() {
         var query = $('#trip-select').val();
         if (query) {
-            window.open('/taxameter/trip_receipt?' + query, '_blank');
+            window.open('/' + window.USER_SLUG + '/taxameter/trip_receipt?' + query, '_blank');
         }
     });
 
     function loadTrips(file) {
         if (!file) return;
-        $.getJSON('/api/taxameter/trips?file=' + encodeURIComponent(file), function(data) {
+        $.getJSON(API_PREFIX + '/taxameter/trips?file=' + encodeURIComponent(file), function(data) {
             $('#trip-select').empty();
             $.each(data, function(idx, t) {
                 $('#trip-select').append($('<option>').val(t.value).text(t.label));

--- a/templates/history.html
+++ b/templates/history.html
@@ -29,12 +29,12 @@
     {% set show_hist = config.get('menu-history', True) %}
     {% if config.get('page-menu', True) and (show_dash or show_stat or show_hist) %}
     <nav id="page-menu">
-        {% if show_dash %}<a class="menu-button" href="/">Dashboard</a>{% endif %}
-        {% if show_stat %}<a class="menu-button" href="/statistik">Statistik</a>{% endif %}
-        {% if show_hist %}<a class="menu-button" href="/history">History</a>{% endif %}
+        {% if show_dash %}<a class="menu-button" href="/{{ user.username_slug }}">Dashboard</a>{% endif %}
+        {% if show_stat %}<a class="menu-button" href="/{{ user.username_slug }}/statistik">Statistik</a>{% endif %}
+        {% if show_hist %}<a class="menu-button" href="/{{ user.username_slug }}/history">History</a>{% endif %}
     </nav>
     {% endif %}
-    <form id="trip-form" method="get" action="/history">
+    <form id="trip-form" method="get" action="/{{ user.username_slug }}/history">
         <label for="file">Fahrt auswählen:</label>
         <select id="file" name="file" onchange="document.getElementById('trip-form').submit();">
             <optgroup label="Tage">
@@ -59,7 +59,7 @@
         </select>
     </form>
     {% if selected %}
-    <a id="receipt-link" class="menu-button" href="/taxameter/trip_receipt?file={{ selected }}">Quittung</a>
+    <a id="receipt-link" class="menu-button" href="/{{ user.username_slug }}/taxameter/trip_receipt?file={{ selected }}">Quittung</a>
     {% endif %}
     <div id="map">
         <div id="slider-container">

--- a/templates/index.html
+++ b/templates/index.html
@@ -26,9 +26,9 @@
     {% set show_hist = config.get('menu-history', True) %}
     {% if config.get('page-menu', True) and (show_dash or show_stat or show_hist) %}
     <nav id="page-menu">
-        {% if show_dash %}<a class="menu-button" href="/">Dashboard</a>{% endif %}
-        {% if show_stat %}<a class="menu-button" href="/statistik">Statistik</a>{% endif %}
-        {% if show_hist %}<a class="menu-button" href="/history">History</a>{% endif %}
+        {% if show_dash %}<a class="menu-button" href="/{{ user.username_slug }}">Dashboard</a>{% endif %}
+        {% if show_stat %}<a class="menu-button" href="/{{ user.username_slug }}/statistik">Statistik</a>{% endif %}
+        {% if show_hist %}<a class="menu-button" href="/{{ user.username_slug }}/history">History</a>{% endif %}
     </nav>
     {% endif %}
     <div id="dashboard-content">
@@ -224,6 +224,8 @@
 
     <script>
         window.APP_VERSION = "{{ version }}";
+        window.USER_SLUG = "{{ user.username_slug }}";
+        window.API_PREFIX = '/' + window.USER_SLUG + '/api';
     </script>
     <script src="/static/js/main.js"></script>
     {% include 'public_banner.html' %}

--- a/templates/map.html
+++ b/templates/map.html
@@ -30,6 +30,8 @@
     </div>
     <script>
         window.APP_VERSION = "{{ version }}";
+        window.USER_SLUG = "{{ user.username_slug }}";
+        window.API_PREFIX = '/' + window.USER_SLUG + '/api';
     </script>
     <script src="/static/js/main.js"></script>
     {% include 'public_banner.html' %}

--- a/templates/statistik.html
+++ b/templates/statistik.html
@@ -20,9 +20,9 @@
     {% set show_hist = config.get('menu-history', True) %}
     {% if config.get('page-menu', True) and (show_dash or show_stat or show_hist) %}
     <nav id="page-menu">
-        {% if show_dash %}<a class="menu-button" href="/">Dashboard</a>{% endif %}
-        {% if show_stat %}<a class="menu-button" href="/statistik">Statistik</a>{% endif %}
-        {% if show_hist %}<a class="menu-button" href="/history">History</a>{% endif %}
+        {% if show_dash %}<a class="menu-button" href="/{{ user.username_slug }}">Dashboard</a>{% endif %}
+        {% if show_stat %}<a class="menu-button" href="/{{ user.username_slug }}/statistik">Statistik</a>{% endif %}
+        {% if show_hist %}<a class="menu-button" href="/{{ user.username_slug }}/history">History</a>{% endif %}
     </nav>
     {% endif %}
     <table>

--- a/templates/taxameter.html
+++ b/templates/taxameter.html
@@ -51,6 +51,8 @@
         const TAXI_COMPANY = "{{ company }}";
         const TAXI_SLOGAN = "{{ config.get('taxi_slogan','Wir lassen Sie nicht im Regen stehen.') }}";
         const VEHICLE_ID = "{{ vehicle_id }}";
+        window.USER_SLUG = "{{ user.username_slug }}";
+        window.API_PREFIX = '/' + window.USER_SLUG + '/api';
     </script>
     <script src="/static/js/taxameter.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- Support public dashboards and APIs under `/<username_slug>` namespace
- Restrict `/config` with new owner-or-admin guard
- Update frontend scripts and docs for slug-based routing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896918837b8832196ee70613e3c8180