### PR TITLE
Add vehicle model and enforce explicit vehicle IDs

### DIFF
--- a/models.py
+++ b/models.py
@@ -38,5 +38,45 @@ class User(db.Model, UserMixin):
         return check_password_hash(self.password_hash, password)
 
 
+class Vehicle(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
+    vehicle_id = db.Column(db.String, nullable=False)
+    vin = db.Column(db.String(17))
+    model = db.Column(db.String(32))
+    display_name = db.Column(db.String(128))
+    active = db.Column(db.Boolean, default=True)
+
+    __table_args__ = (db.UniqueConstraint("user_id", "vehicle_id"),)
+
+
+class VehicleState(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    vehicle_id = db.Column(
+        db.String, db.ForeignKey("vehicle.vehicle_id"), nullable=False
+    )
+    data = db.Column(db.JSON)
+    recorded_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+
+class EnergyLog(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    vehicle_id = db.Column(
+        db.String, db.ForeignKey("vehicle.vehicle_id"), nullable=False
+    )
+    energy = db.Column(db.Float)
+    recorded_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+
+class TripEntry(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    vehicle_id = db.Column(
+        db.String, db.ForeignKey("vehicle.vehicle_id"), nullable=False
+    )
+    started_at = db.Column(db.DateTime)
+    ended_at = db.Column(db.DateTime)
+    distance = db.Column(db.Float)
+
+
 def init_db():
     db.create_all()

--- a/taximeter.py
+++ b/taximeter.py
@@ -9,7 +9,7 @@ LOCAL_TZ = ZoneInfo("Europe/Berlin")
 
 
 class Taximeter:
-    def __init__(self, db_path, fetch_func, tariff_func, vehicle_id="default"):
+    def __init__(self, db_path, fetch_func, tariff_func, vehicle_id=None):
         self.db_path = db_path
         self.fetch_func = fetch_func
         self.tariff_func = tariff_func
@@ -35,6 +35,8 @@ class Taximeter:
 
     def start(self):
         with self.lock:
+            if self.vehicle_id is None:
+                raise ValueError("vehicle_id is required")
             if self.active:
                 return False
             if self.paused:


### PR DESCRIPTION
## Summary
- Add Vehicle ORM model with per-user unique constraint and supporting tables
- Remove implicit default vehicle handling; API routes now require explicit `vehicle_id`
- Ensure taximeter and reverse geocode utilities raise errors when `vehicle_id` is missing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689694ed23388321b2fe0bd5a9c2a39f