### PR TITLE
Add admin taximeter backed by database

### DIFF
--- a/models.py
+++ b/models.py
@@ -79,6 +79,44 @@ class TripEntry(db.Model):
     distance = db.Column(db.Float)
 
 
+class TaximeterRide(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    status = db.Column(db.String(10), nullable=False, default="ready")
+    started_at = db.Column(db.DateTime)
+    ended_at = db.Column(db.DateTime)
+    duration_s = db.Column(db.Float)
+    distance_m = db.Column(db.Float)
+    wait_time_s = db.Column(db.Float)
+    cost_base = db.Column(db.Float)
+    cost_distance = db.Column(db.Float)
+    cost_wait = db.Column(db.Float)
+    cost_total = db.Column(db.Float)
+    tariff_snapshot_json = db.Column(db.JSON)
+    receipt_json = db.Column(db.JSON)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
+    vehicle_id = db.Column(
+        db.String, db.ForeignKey("vehicle.vehicle_id"), nullable=False
+    )
+
+
+class TaximeterPoint(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    ride_id = db.Column(
+        db.Integer, db.ForeignKey("taximeter_ride.id"), nullable=False
+    )
+    ts = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
+    lat = db.Column(db.Float)
+    lon = db.Column(db.Float)
+    speed_kph = db.Column(db.Float)
+    heading_deg = db.Column(db.Float)
+    odo_m = db.Column(db.Float)
+    is_pause = db.Column(db.Boolean, default=False)
+    is_wait = db.Column(db.Boolean, default=False)
+
+    ride = db.relationship("TaximeterRide", backref="points")
+
+
 class ConfigOption(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     key = db.Column(db.String(80), unique=True, nullable=False)

--- a/static/js/taxameter.js
+++ b/static/js/taxameter.js
@@ -131,7 +131,7 @@ $(function() {
     $('#trip-receipt-btn').click(function() {
         var query = $('#trip-select').val();
         if (query) {
-            window.open('/' + window.USER_SLUG + '/taxameter/trip_receipt?' + query, '_blank');
+            window.open('/taxameter/trip_receipt?' + query, '_blank');
         }
     });
 

--- a/templates/taxameter.html
+++ b/templates/taxameter.html
@@ -51,8 +51,7 @@
         const TAXI_COMPANY = "{{ company }}";
         const TAXI_SLOGAN = "{{ config.get('taxi_slogan','Wir lassen Sie nicht im Regen stehen.') }}";
         const VEHICLE_ID = "{{ vehicle_id }}";
-        window.USER_SLUG = "{{ user.username_slug }}";
-        window.API_PREFIX = '/' + window.USER_SLUG + '/api';
+        window.API_PREFIX = '/api';
     </script>
     <script src="/static/js/taxameter.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- Replace sqlite storage with SQLAlchemy models `TaximeterRide` and `TaximeterPoint`
- Record rides and GPS points in the central database with tariff snapshot and receipt JSON
- Expose admin-only taximeter page and `/api/taxameter/*` endpoints at the root URL

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68969fed2e58832188442e58a39ad892