### PR TITLE
Add admin user and vehicle management via Flask-Admin

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ aprslib
 phonenumbers==9.0.9
 qrcode
 stripe
+flask-admin


### PR DESCRIPTION
## Summary
- integrate Flask-Admin with guarded access for admin users
- expose user and vehicle management views with search, sorting and editing
- add flask-admin dependency

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6896a213b7948321944c17bf1ddf75d1