### PR TITLE
Fix circular import in authentication blueprint

### DIFF
--- a/views/auth.py
+++ b/views/auth.py
@@ -15,8 +15,9 @@ from flask import (
 )
 from flask_login import current_user, login_required
 
-from app import db
-from models import TeslaToken
+# Avoid circular import by importing the database instance
+# from models instead of app.
+from models import TeslaToken, db
 
 auth_bp = Blueprint("auth", __name__)
 


### PR DESCRIPTION
## Summary
- Avoid circular import in `views/auth.py` by importing `db` from `models`

## Testing
- `pytest -q`
- `python app.py`

------
https://chatgpt.com/codex/tasks/task_e_6897b301b7588321bf2b82e8964b2249