### PR TITLE
Use device OAuth flow

### DIFF
--- a/app.py
+++ b/app.py
@@ -2088,6 +2088,13 @@ def _start_thread(vehicle_id):
 taximeter = Taximeter(_fetch_data_once, get_taximeter_tariff)
 
 
+@app.route("/")
+def root():
+    if current_user.is_authenticated:
+        return redirect(url_for("index", username_slug=current_user.username_slug))
+    return redirect(url_for("login"))
+
+
 @app.route("/register", methods=["GET", "POST"])
 def register():
     if request.method == "POST":

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ flask-sqlalchemy
 teslapy
 python-dotenv
 requests
-pkce
 aprslib
 phonenumbers==9.0.9
 qrcode

--- a/templates/oauth_device.html
+++ b/templates/oauth_device.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="de">
+<head>
+    <meta charset="utf-8">
+    <title>Tesla Anmeldung</title>
+</head>
+<body>
+    <h2>Tesla Anmeldung</h2>
+    <p>Bitte öffnen Sie den folgenden Link und melden Sie sich bei Tesla an:</p>
+    <p><a href="{{ verify_url }}" target="_blank">Bei Tesla anmelden</a></p>
+    <p>Nach erfolgreicher Anmeldung kehren Sie zurück und klicken auf den untenstehenden Button.</p>
+    <form action="{{ url_for('auth.oauth_callback') }}" method="get">
+        <button type="submit">Anmeldung abgeschlossen</button>
+    </form>
+</body>
+</html>

--- a/templates/oauth_pending.html
+++ b/templates/oauth_pending.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="de">
+<head>
+    <meta charset="utf-8">
+    <title>Warten auf Bestätigung</title>
+</head>
+<body>
+    <h2>Warten auf Bestätigung</h2>
+    <p>Die Autorisierung wurde noch nicht abgeschlossen. Bitte schließen Sie die Anmeldung auf der Tesla-Seite ab und versuchen Sie es erneut.</p>
+    <form action="{{ url_for('auth.oauth_callback') }}" method="get">
+        <button type="submit">Erneut prüfen</button>
+    </form>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- replace redirect-based OAuth with device authorization to work around Tesla redirect limits
- add templates guiding users through Tesla login and pending state
- remove unused pkce dependency
- redirect root URL to login or user dashboard instead of 404

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897b72e6414832184b715d35a8eecaf