### PR TITLE
Use Tesla email login and admin menu

### DIFF
--- a/templates/history.html
+++ b/templates/history.html
@@ -27,11 +27,12 @@
     {% set show_dash = config.get('menu-dashboard', True) %}
     {% set show_stat = config.get('menu-statistik', True) %}
     {% set show_hist = config.get('menu-history', True) %}
-    {% if config.get('page-menu', True) and (show_dash or show_stat or show_hist) %}
+    {% if config.get('page-menu', True) and (show_dash or show_stat or show_hist or user.role == 'admin') %}
     <nav id="page-menu">
         {% if show_dash %}<a class="menu-button" href="/{{ user.username_slug }}">Dashboard</a>{% endif %}
         {% if show_stat %}<a class="menu-button" href="/{{ user.username_slug }}/statistik">Statistik</a>{% endif %}
         {% if show_hist %}<a class="menu-button" href="/{{ user.username_slug }}/history">History</a>{% endif %}
+        {% if user.role == 'admin' %}<a class="menu-button" href="/admin">Admin</a>{% endif %}
     </nav>
     {% endif %}
     <form id="trip-form" method="get" action="/{{ user.username_slug }}/history">

--- a/templates/index.html
+++ b/templates/index.html
@@ -27,11 +27,12 @@
     {% set show_dash = config.get('menu-dashboard', True) %}
     {% set show_stat = config.get('menu-statistik', True) %}
     {% set show_hist = config.get('menu-history', True) %}
-    {% if config.get('page-menu', True) and (show_dash or show_stat or show_hist) %}
+    {% if config.get('page-menu', True) and (show_dash or show_stat or show_hist or user.role == 'admin') %}
     <nav id="page-menu">
         {% if show_dash %}<a class="menu-button" href="/{{ user.username_slug }}">Dashboard</a>{% endif %}
         {% if show_stat %}<a class="menu-button" href="/{{ user.username_slug }}/statistik">Statistik</a>{% endif %}
         {% if show_hist %}<a class="menu-button" href="/{{ user.username_slug }}/history">History</a>{% endif %}
+        {% if user.role == 'admin' %}<a class="menu-button" href="/admin">Admin</a>{% endif %}
     </nav>
     {% endif %}
     <div id="dashboard-content">

--- a/templates/login.html
+++ b/templates/login.html
@@ -9,9 +9,9 @@
     {% if inactive %}<p style="color:red;">Ihr Abo ist inaktiv.</p>{% endif %}
     {% if error %}<p style="color:red;">{{ error }}</p>{% endif %}
     <form method="post">
-        <label for="username">Benutzername oder E-Mail</label>
-        <input type="text" id="username" name="username" required>
-        <label for="password">Passwort</label>
+        <label for="email">Tesla E-Mail</label>
+        <input type="email" id="email" name="email" required>
+        <label for="password">Tesla Passwort</label>
         <input type="password" id="password" name="password" required>
         <button type="submit">Anmelden</button>
     </form>

--- a/templates/register.html
+++ b/templates/register.html
@@ -8,11 +8,11 @@
     <h2>Registrierung</h2>
     {% if error %}<p style="color:red;">{{ error }}</p>{% endif %}
     <form method="post">
-        <label for="username">Benutzername</label>
+        <label for="username">Benutzername (intern)</label>
         <input type="text" id="username" name="username" required>
-        <label for="email">E-Mail</label>
+        <label for="email">Tesla E-Mail</label>
         <input type="email" id="email" name="email" required>
-        <label for="password">Passwort</label>
+        <label for="password">Tesla Passwort</label>
         <input type="password" id="password" name="password" required>
         <button type="submit">Registrieren</button>
     </form>

--- a/templates/statistik.html
+++ b/templates/statistik.html
@@ -18,11 +18,12 @@
     {% set show_dash = config.get('menu-dashboard', True) %}
     {% set show_stat = config.get('menu-statistik', True) %}
     {% set show_hist = config.get('menu-history', True) %}
-    {% if config.get('page-menu', True) and (show_dash or show_stat or show_hist) %}
+    {% if config.get('page-menu', True) and (show_dash or show_stat or show_hist or user.role == 'admin') %}
     <nav id="page-menu">
         {% if show_dash %}<a class="menu-button" href="/{{ user.username_slug }}">Dashboard</a>{% endif %}
         {% if show_stat %}<a class="menu-button" href="/{{ user.username_slug }}/statistik">Statistik</a>{% endif %}
         {% if show_hist %}<a class="menu-button" href="/{{ user.username_slug }}/history">History</a>{% endif %}
+        {% if user.role == 'admin' %}<a class="menu-button" href="/admin">Admin</a>{% endif %}
     </nav>
     {% endif %}
     <table>

--- a/tests/test_guards.py
+++ b/tests/test_guards.py
@@ -35,8 +35,9 @@ def client():
 
 
 def login(client, username):
+    email = f"{username}@example.com"
     return client.post(
-        "/login", data={"username": username, "password": "pw"}, follow_redirects=True
+        "/login", data={"email": email, "password": "pw"}, follow_redirects=True
     )
 
 


### PR DESCRIPTION
## Summary
- Require login via Tesla email and password only
- Automatically promote TESLA_EMAIL account to admin with an admin menu
- Adjust tests for email-based login

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897bea9b22c8321a62aa97fb837b464