### PR TITLE
Enable browser-based Tesla authentication

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -24,6 +24,7 @@
             <span id="vehicle-info"></span>&nbsp;&nbsp;&nbsp;<span id="vehicle-status"></span>
         </span>
     </h2>
+    {% if show_tesla_link %}<p><a href="{{ url_for('auth.oauth_start') }}">Tesla-Konto verbinden</a></p>{% endif %}
     {% set show_dash = config.get('menu-dashboard', True) %}
     {% set show_stat = config.get('menu-statistik', True) %}
     {% set show_hist = config.get('menu-history', True) %}


### PR DESCRIPTION
## Summary
- Remove interactive console login, relying solely on existing Tesla tokens
- Show a "Tesla-Konto verbinden" link so users can start OAuth in the browser

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897c145e05083219086eac8f449d14a