### PR TITLE
Prevent crash when Tesla token requested without login

### DIFF
--- a/views/auth.py
+++ b/views/auth.py
@@ -26,6 +26,8 @@ auth_bp = Blueprint("auth", __name__)
 
 
 def get_user_token():
+    if not current_user.is_authenticated:
+        return None
     token = TeslaToken.query.filter_by(user_id=current_user.id).first()
     if token and token.expires_at <= datetime.utcnow():
         data = {


### PR DESCRIPTION
## Summary
- Guard `get_user_token` against anonymous users to avoid attribute errors when no one is logged in

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897c754fcc883219b29152e7f9e47b9