### PR TITLE
Load initial admin user from .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,7 @@
-# Tesla credentials
+# Username for the initial admin user
+ADMIN_USERNAME=admin
+
+# Tesla credentials (also used for the initial admin user)
 TESLA_EMAIL=your_email@example.com
 TESLA_PASSWORD=your_password
 # Alternatively use access and refresh tokens

--- a/README.md
+++ b/README.md
@@ -10,7 +10,11 @@ This is a simple Flask application that displays real-time data from a Tesla veh
     ```
     The application uses `python-dotenv` to load variables from a `.env` file.
 
-2. Copy `.env.example` to `.env` and fill in your Tesla credentials:
+2. Copy `.env.example` to `.env` and fill in your Tesla credentials and the
+   desired admin username. The email and password are also used for the initial
+   admin account which is automatically imported into the database on first
+   start:
+    - `ADMIN_USERNAME`
     - `TESLA_EMAIL` and `TESLA_PASSWORD` **or**
     - `TESLA_ACCESS_TOKEN` and `TESLA_REFRESH_TOKEN`
 

--- a/app.py
+++ b/app.py
@@ -135,9 +135,24 @@ def load_user(user_id):
     return db.session.get(User, int(user_id))
 
 
+def create_initial_admin():
+    """Create the first admin user from Tesla credentials if needed."""
+    email = os.getenv("TESLA_EMAIL")
+    password = os.getenv("TESLA_PASSWORD")
+    username = os.getenv("ADMIN_USERNAME")
+    if not all([email, password, username]):
+        return
+    if User.query.filter_by(role="admin").first():
+        return
+    user = User(username=username, email=email, role="admin")
+    user.set_password(password)
+    db.session.add(user)
+    db.session.commit()
+
+
 @app.cli.command("ensure-admin")
 @click.option("--email", required=True)
-@click.option("--username", required=True)
+@click.option("--username", required=True, prompt=True)
 @click.option(
     "--password",
     required=True,
@@ -3139,4 +3154,5 @@ if __name__ == "__main__":
     with app.app_context():
         import models
         models.init_db()
+        create_initial_admin()
     app.run(host="0.0.0.0", port=8031, debug=True)


### PR DESCRIPTION
## Summary
- allow specifying the admin username via `ADMIN_USERNAME` instead of deriving it from the email
- prompt for the username in the `ensure-admin` CLI command
- document the new `ADMIN_USERNAME` variable in the sample `.env` and setup instructions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897c946d0ac83218d5ad798615038ef