### PR TITLE
Allow custom Tesla OAuth redirect URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ This is a simple Flask application that displays real-time data from a Tesla veh
     - `ADMIN_USERNAME`
     - `TESLA_EMAIL` and `TESLA_PASSWORD` **or**
     - `TESLA_ACCESS_TOKEN` and `TESLA_REFRESH_TOKEN`
+    - `TESLA_REDIRECT_URI` (optional, defaults to the local callback)
+
+   When Tesla's sign-in page reports an unknown `redirect_uri`, set
+   `TESLA_REDIRECT_URI` to the URL registered for your Tesla OAuth
+   application, for example `https://auth.tesla.com/void/callback`.
 
 3. Run the server:
     ```bash

--- a/views/auth.py
+++ b/views/auth.py
@@ -79,11 +79,14 @@ def oauth_start():
         .rstrip(b"=")
         .decode("utf-8")
     )
+    redirect_uri = os.getenv(
+        "TESLA_REDIRECT_URI", url_for("auth.oauth_callback", _external=True)
+    )
     params = {
         "client_id": os.getenv("TESLA_CLIENT_ID", "ownerapi"),
         "scope": "openid email offline_access",
         "response_type": "code",
-        "redirect_uri": url_for("auth.oauth_callback", _external=True),
+        "redirect_uri": redirect_uri,
         "code_challenge": challenge,
         "code_challenge_method": "S256",
     }
@@ -98,11 +101,14 @@ def oauth_callback():
     verifier = session.get("code_verifier")
     if not code or not verifier:
         abort(400)
+    redirect_uri = os.getenv(
+        "TESLA_REDIRECT_URI", url_for("auth.oauth_callback", _external=True)
+    )
     data = {
         "grant_type": "authorization_code",
         "client_id": os.getenv("TESLA_CLIENT_ID", "ownerapi"),
         "code": code,
-        "redirect_uri": url_for("auth.oauth_callback", _external=True),
+        "redirect_uri": redirect_uri,
         "code_verifier": verifier,
     }
     headers = {"User-Agent": os.getenv("TESLA_USER_AGENT", "Mozilla/5.0")}


### PR DESCRIPTION
## Summary
- make Tesla OAuth redirect URL configurable via `TESLA_REDIRECT_URI`
- document optional `TESLA_REDIRECT_URI` environment variable

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6897da6576208321b262bd19c8ff8d5d