### PR TITLE
Add clients overview endpoint

### DIFF
--- a/templates/clients.html
+++ b/templates/clients.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html lang="de">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="Tesla Dashboard zur Anzeige aktueller Fahrzeugdaten">
+    <meta name="keywords" content="Tesla, Dashboard, Fahrzeugdaten, Statistik, Karte, Elektroauto, Ladung, Stromverbrauch, Standort, Routenplanung, Fahrzeugstatus, Kilometerstand, Trip, Tesla Model S, Model 3, Model X, Model Y">
+    <title>Clients</title>
+    <link rel="stylesheet" href="/static/css/style.css" />
+    {% include 'analytics.html' %}
+    <style>
+        table { border-collapse: collapse; width: 100%; }
+        th, td { border: 1px solid #444; padding: 4px; text-align: left; }
+    </style>
+</head>
+<body>
+    <h1>Aktuelle Clients</h1>
+    <table>
+        <thead>
+            <tr>
+                <th>IP-Adresse</th>
+                <th>Namensauflösung</th>
+                <th>Browserdaten</th>
+                <th>Verbunden seit</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for c in clients %}
+            <tr>
+                <td>{{ c.ip }}</td>
+                <td>{{ c.hostname }}</td>
+                <td>{{ c.user_agent }}</td>
+                <td>seit {{ c.duration }}</td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- track connecting clients using X-Forwarded-For IP and hostname lookup
- expose new `/clients` route showing IP, hostname, browser data and connection duration
- add corresponding HTML template

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68985acf025883219157b9a7d88af3fa