### PR TITLE
Show location and browser info on client overview

### DIFF
--- a/templates/clients.html
+++ b/templates/clients.html
@@ -20,6 +20,9 @@
             <tr>
                 <th>IP-Adresse</th>
                 <th>Namensauflösung</th>
+                <th>Standort</th>
+                <th>Browser</th>
+                <th>Betriebssystem</th>
                 <th>Browserdaten</th>
                 <th>Verbunden seit</th>
             </tr>
@@ -29,6 +32,9 @@
             <tr>
                 <td>{{ c.ip }}</td>
                 <td>{{ c.hostname }}</td>
+                <td>{{ c.location }}</td>
+                <td>{{ c.browser }}</td>
+                <td>{{ c.os }}</td>
                 <td>{{ c.user_agent }}</td>
                 <td>seit {{ c.duration }}</td>
             </tr>


### PR DESCRIPTION
## Summary
- enrich client tracking with IP geolocation and user agent parsing
- display location, browser and OS details in clients table

## Testing
- `pytest -q`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68985d572c688321bdc122735fcf0385