### PR TITLE
Add real-time refresh for clients page

### DIFF
--- a/app.py
+++ b/app.py
@@ -2048,6 +2048,30 @@ def api_clients():
     return jsonify({"clients": count})
 
 
+@app.route("/api/clients/details")
+def api_client_details():
+    """Return detailed information about connected clients."""
+    now = time.time()
+    items = []
+    for data in active_clients.values():
+        delta = now - data.get("first_seen", now)
+        days = int(delta // 86400)
+        hms = time.strftime("%H:%M:%S", time.gmtime(delta % 86400))
+        items.append(
+            {
+                "ip": data.get("ip"),
+                "hostname": data.get("hostname"),
+                "location": data.get("location"),
+                "browser": data.get("browser"),
+                "os": data.get("os"),
+                "user_agent": data.get("user_agent"),
+                "duration": f"{days:02d} Tage, {hms}",
+            }
+        )
+    items.sort(key=lambda d: d["ip"] or "")
+    return jsonify({"clients": items})
+
+
 @app.route("/api/reverse_geocode")
 def api_reverse_geocode():
     """Return address for given coordinates."""

--- a/static/js/clients.js
+++ b/static/js/clients.js
@@ -1,0 +1,30 @@
+async function fetchClients() {
+    try {
+        const response = await fetch('/api/clients/details');
+        if (!response.ok) {
+            return;
+        }
+        const data = await response.json();
+        const tbody = document.getElementById('clients-body');
+        if (!tbody || !data.clients) {
+            return;
+        }
+        tbody.innerHTML = '';
+        data.clients.forEach(function(c) {
+            const tr = document.createElement('tr');
+            ['ip', 'hostname', 'location', 'browser', 'os', 'user_agent', 'duration'].forEach(function(key) {
+                const td = document.createElement('td');
+                td.textContent = c[key] || '';
+                tr.appendChild(td);
+            });
+            tbody.appendChild(tr);
+        });
+    } catch (err) {
+        console.error('Failed to fetch clients', err);
+    }
+}
+
+document.addEventListener('DOMContentLoaded', function() {
+    fetchClients();
+    setInterval(fetchClients, 5000);
+});

--- a/templates/clients.html
+++ b/templates/clients.html
@@ -27,7 +27,7 @@
                 <th>Verbunden seit</th>
             </tr>
         </thead>
-        <tbody>
+        <tbody id="clients-body">
             {% for c in clients %}
             <tr>
                 <td>{{ c.ip }}</td>
@@ -41,5 +41,6 @@
             {% endfor %}
         </tbody>
     </table>
+    <script src="/static/js/clients.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- expose a new `/api/clients/details` endpoint delivering full information about connected clients
- refresh the `/clients` table every few seconds via a new JavaScript helper

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68986014462c83218aaff1ead9cf537c