### PR TITLE
Show IP provider on clients page

### DIFF
--- a/static/js/clients.js
+++ b/static/js/clients.js
@@ -12,7 +12,7 @@ async function fetchClients() {
         tbody.innerHTML = '';
         data.clients.forEach(function(c) {
             const tr = document.createElement('tr');
-            ['ip', 'hostname', 'location', 'browser', 'os', 'user_agent', 'duration'].forEach(function(key) {
+            ['ip', 'hostname', 'location', 'provider', 'browser', 'os', 'user_agent', 'duration'].forEach(function(key) {
                 const td = document.createElement('td');
                 td.textContent = c[key] || '';
                 tr.appendChild(td);

--- a/templates/clients.html
+++ b/templates/clients.html
@@ -21,6 +21,7 @@
                 <th>IP-Adresse</th>
                 <th>Namensauflösung</th>
                 <th>Standort</th>
+                <th>Anbieter</th>
                 <th>Browser</th>
                 <th>Betriebssystem</th>
                 <th>Browserdaten</th>
@@ -33,6 +34,7 @@
                 <td>{{ c.ip }}</td>
                 <td>{{ c.hostname }}</td>
                 <td>{{ c.location }}</td>
+                <td>{{ c.provider }}</td>
                 <td>{{ c.browser }}</td>
                 <td>{{ c.os }}</td>
                 <td>{{ c.user_agent }}</td>


### PR DESCRIPTION
## Summary
- fetch provider information for client IPs via ipinfo.io and cache responses
- include provider field in clients API and server-side rendering
- render provider column on clients page with updated JavaScript

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68986614b88c8321bbf4fefaefe0bde9