### PR TITLE
Handle unavailable Socket.IO scripts without blocking

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -7,7 +7,7 @@
     <meta name="keywords" content="Tesla, Dashboard, Fahrzeugdaten, Statistik, Karte, Elektroauto, Ladung, Stromverbrauch, Standort, Routenplanung, Fahrzeugstatus, Kilometerstand, Trip, Tesla Model S, Model 3, Model X, Model Y">
     <title>Tesla-Dashboard</title>
     <script src="/static/js/jquery.min.js"></script>
-    {% if config.get('ptt-controls', True) %}<script src="{{ url_for('static', filename=socketio_client_script) }}"></script>{% endif %}
+    {% if config.get('ptt-controls', True) %}<script src="{{ socketio_client_script }}"></script>{% endif %}
     <link rel="stylesheet" href="/static/css/leaflet.css" />
     <link rel="stylesheet" href="/static/css/style.css" />
     {% include 'analytics.html' %}


### PR DESCRIPTION
## Summary
- Detect installed python-socketio version via importlib.metadata and choose the proper client library
- Provide full URL for the client script and reference it directly in the template

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689877d0c5bc832198aa8e34c0cb7d57