### PR TITLE
Enable compression for faster page loads

### DIFF
--- a/app.py
+++ b/app.py
@@ -28,6 +28,7 @@ from datetime import datetime, timedelta
 from zoneinfo import ZoneInfo
 from importlib import metadata
 from flask_socketio import SocketIO, emit
+from flask_compress import Compress
 
 try:
     import teslapy
@@ -46,6 +47,8 @@ except ImportError:
 
 load_dotenv()
 app = Flask(__name__)
+app.config["SEND_FILE_MAX_AGE_DEFAULT"] = 3600
+Compress(app)
 socketio = SocketIO(app)
 __version__ = get_version()
 CURRENT_YEAR = datetime.now(ZoneInfo("Europe/Berlin")).year

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,9 @@
 flask
+flask-compress
+flask-socketio
 teslapy
 python-dotenv
 requests
 aprslib
 phonenumbers==9.0.9
 qrcode
-flask-socketio


### PR DESCRIPTION
## Summary
- compress Flask responses using Flask-Compress
- cache static assets for faster loading
- document new dependency

## Testing
- `curl -v https://tesla.do1ffe.de`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68987c587710832194c558902f581ed3