### PR TITLE
Configure Tesla API timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This is a simple Flask application that displays real-time data from a Tesla veh
 2. Copy `.env.example` to `.env` and fill in your Tesla credentials:
     - `TESLA_EMAIL` and `TESLA_PASSWORD` **or**
     - `TESLA_ACCESS_TOKEN` and `TESLA_REFRESH_TOKEN`
+    - optionally set `TESLA_REQUEST_TIMEOUT` (in seconds) to limit Tesla API calls and avoid gateway timeouts
 
 3. Run the server:
     ```bash


### PR DESCRIPTION
## Summary
- allow configuring Tesla API request timeout via `TESLA_REQUEST_TIMEOUT`
- reduce vehicle state refresh retries and log timeouts
- document optional timeout setting

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68987f413014832189f784a8f565a38a