### PR TITLE
Add proxy headers to SSE stream

### DIFF
--- a/app.py
+++ b/app.py
@@ -2147,7 +2147,10 @@ def stream_vehicle(vehicle_id="default"):
                 if info["connections"] <= 0:
                     active_clients.pop(ip, None)
 
-    return Response(gen(), mimetype="text/event-stream")
+    resp = Response(gen(), mimetype="text/event-stream")
+    resp.headers["Cache-Control"] = "no-cache"
+    resp.headers["X-Accel-Buffering"] = "no"
+    return resp
 
 
 @app.route("/api/vehicles")


### PR DESCRIPTION
## Summary
- Disable reverse proxy buffering for `/stream` SSE responses
- Ensure streamed data is not cached

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68988c9020e08321853ad21fd0935daa