### PR TITLE
Use eventlet for SocketIO to avoid PTT timeouts

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,3 +1,6 @@
+import eventlet
+eventlet.monkey_patch()
+
 import os
 import json
 import queue
@@ -51,7 +54,7 @@ load_dotenv()
 app = Flask(__name__)
 app.config["SEND_FILE_MAX_AGE_DEFAULT"] = 3600
 Compress(app)
-socketio = SocketIO(app)
+socketio = SocketIO(app, async_mode="eventlet")
 __version__ = get_version()
 CURRENT_YEAR = datetime.now(ZoneInfo("Europe/Berlin")).year
 GA_TRACKING_ID = os.getenv("GA_TRACKING_ID")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 flask
 flask-compress
 flask-socketio
+eventlet
 teslapy
 python-dotenv
 requests


### PR DESCRIPTION
## Summary
- switch Socket.IO to eventlet-based async server for proper concurrent PTT connections
- add eventlet dependency

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689890f90d5c8321a46361e93eae2607