### PR TITLE
Ensure PTT audio reaches all clients

### DIFF
--- a/static/js/ptt.js
+++ b/static/js/ptt.js
@@ -1,10 +1,6 @@
 (function () {
-  const pttBtn = document.getElementById('ptt-btn');
-  if (!pttBtn) {
-    return;
-  }
-
   const socket = io();
+  const pttBtn = document.getElementById('ptt-btn');
   let clientId;
   let mediaStream;
   let recorder;
@@ -28,8 +24,6 @@
     }
   }
 
-  initMedia();
-
   function startRecording() {
     if (!mediaStream) return;
     recorder = new MediaRecorder(mediaStream, { mimeType: 'audio/webm' });
@@ -47,35 +41,39 @@
     }
   }
 
-  pttBtn.addEventListener('mousedown', () => {
-    if (canSpeak) {
-      pttBtn.classList.add('active-btn');
-      socket.emit('start_speaking');
-    }
-  });
+  if (pttBtn) {
+    initMedia();
 
-  pttBtn.addEventListener('mouseup', () => {
-    socket.emit('stop_speaking');
-    stopRecording();
-    pttBtn.classList.remove('active-btn');
-    clearTot();
-  });
+    pttBtn.addEventListener('mousedown', () => {
+      if (canSpeak) {
+        pttBtn.classList.add('active-btn');
+        socket.emit('start_speaking');
+      }
+    });
 
-  pttBtn.addEventListener('touchstart', (e) => {
-    e.preventDefault();
-    if (canSpeak) {
-      pttBtn.classList.add('active-btn');
-      socket.emit('start_speaking');
-    }
-  });
+    pttBtn.addEventListener('mouseup', () => {
+      socket.emit('stop_speaking');
+      stopRecording();
+      pttBtn.classList.remove('active-btn');
+      clearTot();
+    });
 
-  pttBtn.addEventListener('touchend', (e) => {
-    e.preventDefault();
-    socket.emit('stop_speaking');
-    stopRecording();
-    pttBtn.classList.remove('active-btn');
-    clearTot();
-  });
+    pttBtn.addEventListener('touchstart', (e) => {
+      e.preventDefault();
+      if (canSpeak) {
+        pttBtn.classList.add('active-btn');
+        socket.emit('start_speaking');
+      }
+    });
+
+    pttBtn.addEventListener('touchend', (e) => {
+      e.preventDefault();
+      socket.emit('stop_speaking');
+      stopRecording();
+      pttBtn.classList.remove('active-btn');
+      clearTot();
+    });
+  }
 
   socket.on('your_id', (data) => {
     clientId = data.id;
@@ -87,26 +85,34 @@
     totTimer = setTimeout(() => {
       socket.emit('stop_speaking');
       stopRecording();
-      pttBtn.classList.remove('active-btn');
+      if (pttBtn) {
+        pttBtn.classList.remove('active-btn');
+      }
       totTimer = null;
     }, 30000);
   });
 
   socket.on('start_denied', () => {
-    pttBtn.classList.remove('active-btn');
+    if (pttBtn) {
+      pttBtn.classList.remove('active-btn');
+    }
   });
 
-  socket.on('lock_ptt', (data) => {
+  socket.on('lock_ptt', () => {
     canSpeak = false;
-    pttBtn.disabled = true;
-    pttBtn.classList.remove('active-btn');
+    if (pttBtn) {
+      pttBtn.disabled = true;
+      pttBtn.classList.remove('active-btn');
+    }
     clearTot();
   });
 
   socket.on('unlock_ptt', () => {
     canSpeak = true;
-    pttBtn.disabled = false;
-    pttBtn.classList.remove('active-btn');
+    if (pttBtn) {
+      pttBtn.disabled = false;
+      pttBtn.classList.remove('active-btn');
+    }
     clearTot();
   });
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -7,7 +7,7 @@
     <meta name="keywords" content="Tesla, Dashboard, Fahrzeugdaten, Statistik, Karte, Elektroauto, Ladung, Stromverbrauch, Standort, Routenplanung, Fahrzeugstatus, Kilometerstand, Trip, Tesla Model S, Model 3, Model X, Model Y">
     <title>Tesla-Dashboard</title>
     <script src="/static/js/jquery.min.js"></script>
-    {% if config.get('ptt-controls', True) %}<script src="{{ socketio_client_script }}"></script>{% endif %}
+    <script src="{{ socketio_client_script }}"></script>
     <link rel="stylesheet" href="/static/css/leaflet.css" />
     <link rel="stylesheet" href="/static/css/style.css" />
     {% include 'analytics.html' %}
@@ -232,6 +232,6 @@
         window.APP_VERSION = "{{ version }}";
     </script>
     <script src="/static/js/main.js"></script>
-    {% if config.get('ptt-controls', True) %}<script src="/static/js/ptt.js"></script>{% endif %}
+    <script src="/static/js/ptt.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Always include Socket.IO and PTT scripts so listeners without controls can receive audio
- Initialize PTT socket for all clients and attach microphone events only when a PTT button exists

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689894e9bf3c8321a01a0cf152426ddd