### PR TITLE
Forward push-to-talk audio as binary frames

### DIFF
--- a/app.py
+++ b/app.py
@@ -2948,7 +2948,7 @@ def stop_speaking():
 def handle_audio_chunk(data):
     """Forward audio data from the active speaker to all listeners."""
     if _client_id() == current_speaker_id:
-        emit("play_audio", data, broadcast=True, include_self=False)
+        emit("play_audio", data, broadcast=True, include_self=False, binary=True)
 
 
 @socketio.on("disconnect")


### PR DESCRIPTION
## Summary
- ensure audio chunks are emitted as binary to connected clients

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6898986541d88321ac12e9c231c76aa9