### PR TITLE
Fix PTT audio playback by sending binary buffers

### DIFF
--- a/static/js/ptt.js
+++ b/static/js/ptt.js
@@ -29,7 +29,9 @@
     recorder = new MediaRecorder(mediaStream, { mimeType: 'audio/webm' });
     recorder.ondataavailable = (e) => {
       if (e.data.size > 0) {
-        socket.emit('audio_chunk', e.data);
+        e.data.arrayBuffer().then((buf) => {
+          socket.emit('audio_chunk', buf);
+        });
       }
     };
     recorder.start(250);


### PR DESCRIPTION
## Summary
- send push-to-talk audio chunks as ArrayBuffer to ensure binary delivery

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68989a6fbd9c832186912bd60ad0ca18