### PR TITLE
Fix push-to-talk audio streaming

### DIFF
--- a/app.py
+++ b/app.py
@@ -2948,7 +2948,10 @@ def stop_speaking():
 def handle_audio_chunk(data):
     """Forward audio data from the active speaker to all listeners."""
     if _client_id() == current_speaker_id:
-        emit("play_audio", data, broadcast=True, include_self=False, binary=True)
+        # ``socketio.emit`` broadcasts to all clients by default.  Using the
+        # ``include_self`` flag avoids echoing the audio back to the active
+        # speaker while keeping the data in its original binary form.
+        socketio.emit("play_audio", data, include_self=False)
 
 
 @socketio.on("disconnect")


### PR DESCRIPTION
## Summary
- Send push-to-talk audio as raw byte arrays and replay with explicit WebM/Opus codec
- Forward audio chunks server-side via `socketio.emit` without echoing to the speaker

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68989cd942288321847c35464de679f9