### PR TITLE
Ensure PTT audio plays at full volume

### DIFF
--- a/app.py
+++ b/app.py
@@ -2948,10 +2948,13 @@ def stop_speaking():
 def handle_audio_chunk(data):
     """Forward audio data from the active speaker to all listeners."""
     if _client_id() == current_speaker_id:
-        # ``socketio.emit`` broadcasts to all clients by default.  Using the
-        # ``include_self`` flag avoids echoing the audio back to the active
-        # speaker while keeping the data in its original binary form.
-        socketio.emit("play_audio", data, include_self=False)
+        if isinstance(data, (bytes, bytearray)) and len(data) > 0:
+            # ``socketio.emit`` broadcasts to all clients by default.  Using the
+            # ``include_self`` flag avoids echoing the audio back to the active
+            # speaker while keeping the data in its original binary form.
+            socketio.emit("play_audio", data, include_self=False)
+        else:
+            app.logger.warning("Invalid audio chunk received: %r", type(data))
 
 
 @socketio.on("disconnect")

--- a/static/js/ptt.js
+++ b/static/js/ptt.js
@@ -10,7 +10,7 @@
         const gain = audioCtx.createGain();
         osc.type = 'sine';
         osc.frequency.value = 880;
-        gain.gain.value = 0.2;
+        gain.gain.value = 1.0;
         osc.connect(gain);
         gain.connect(audioCtx.destination);
         osc.start();
@@ -144,9 +144,15 @@
     // Reconstruct the binary data into a playable blob.  The server forwards
     // a ``Uint8Array`` which we turn back into a Blob before playback.
     const chunk = new Uint8Array(data);
+    if (!chunk.length) {
+      console.error('Received empty audio data');
+      return;
+    }
     const audioBlob = new Blob([chunk], { type: 'audio/webm;codecs=opus' });
     const url = URL.createObjectURL(audioBlob);
     const audio = new Audio(url);
+    audio.volume = 1.0;
+    audio.addEventListener('error', (e) => console.error('Audio element error', e));
     const playMain = () => {
       audio.play().catch((err) => console.error('Audio playback failed', err));
       audio.addEventListener('ended', () => URL.revokeObjectURL(url));


### PR DESCRIPTION
## Summary
- Increase ping tone gain and playback volume
- Add client-side checks for empty audio data and playback errors
- Validate incoming audio chunks on the server before broadcasting

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6898a49622748321961c803e27ebbd86