### PR TITLE
Fix audio streaming and level meter

### DIFF
--- a/app.py
+++ b/app.py
@@ -2948,13 +2948,18 @@ def stop_speaking():
 def handle_audio_chunk(data):
     """Forward audio data from the active speaker to all listeners."""
     if _client_id() == current_speaker_id:
-        if isinstance(data, (bytes, bytearray)) and len(data) > 0:
-            # ``socketio.emit`` broadcasts to all clients by default.  Using the
+        try:
+            raw = bytes(data)
+        except Exception:
+            app.logger.warning("Invalid audio chunk received: %r", type(data))
+            return
+        if raw:
+            # ``socketio.emit`` broadcasts to all clients by default. Using the
             # ``include_self`` flag avoids echoing the audio back to the active
             # speaker while keeping the data in its original binary form.
-            socketio.emit("play_audio", data, include_self=False)
+            socketio.emit("play_audio", raw, include_self=False)
         else:
-            app.logger.warning("Invalid audio chunk received: %r", type(data))
+            app.logger.warning("Empty audio chunk received")
 
 
 @socketio.on("disconnect")

--- a/static/js/ptt.js
+++ b/static/js/ptt.js
@@ -48,6 +48,7 @@
 
   function startRecording() {
     if (!mediaStream) return;
+    audioCtx.resume().catch((err) => console.error('Audio context resume failed', err));
     recorder = new MediaRecorder(mediaStream, {
       mimeType: 'audio/webm;codecs=opus'
     });
@@ -72,6 +73,7 @@
 
   function startLevelMonitoring() {
     if (!mediaStream || !levelMeter) return;
+    audioCtx.resume().catch((err) => console.error('Audio context resume failed', err));
     micSource = audioCtx.createMediaStreamSource(mediaStream);
     micAnalyser = audioCtx.createAnalyser();
     micAnalyser.fftSize = 256;


### PR DESCRIPTION
## Summary
- Convert incoming audio chunks to bytes so they broadcast correctly
- Resume the Web Audio context when recording and monitoring levels

## Testing
- `python - <<'PY'
from app import app, socketio
c1 = socketio.test_client(app)
c2 = socketio.test_client(app)
c1.emit('start_speaking')
c1.emit('audio_chunk', [1,2,3])
print([e['name'] for e in c2.get_received()])
PY`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898a922167c8321b796696c34bf5d4d