### PR TITLE
Improve push-to-talk audio handling

### DIFF
--- a/static/js/ptt.js
+++ b/static/js/ptt.js
@@ -50,9 +50,12 @@
   function startRecording() {
     if (!mediaStream) return;
     audioCtx.resume().catch((err) => console.error('Audio context resume failed', err));
-    recorder = new MediaRecorder(mediaStream, {
-      mimeType: 'audio/webm;codecs=opus'
-    });
+    let mimeType = 'audio/webm;codecs=opus';
+    if (typeof MediaRecorder.isTypeSupported === 'function' &&
+        !MediaRecorder.isTypeSupported(mimeType)) {
+      mimeType = 'audio/ogg;codecs=opus';
+    }
+    recorder = new MediaRecorder(mediaStream, { mimeType });
     recorder.ondataavailable = (e) => {
       if (e.data.size > 0) {
         e.data.arrayBuffer().then((buf) => {
@@ -62,9 +65,9 @@
         });
       }
     };
-    // Use a small timeslice so that audio chunks are delivered frequently,
-    // enabling smoother streaming on the receiving side.
-    recorder.start(100);
+    // Use a modest timeslice so that audio chunks are delivered frequently
+    // while still containing enough data for smooth decoding.
+    recorder.start(250);
   }
 
   function stopRecording() {


### PR DESCRIPTION
## Summary
- check supported codecs before recording and fall back to Ogg/Opus when WebM isn't available
- lengthen media recorder timeslice for smoother decoding

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6898b986c9b483218724c4b2fddcc9c3