### PR TITLE
Fix PTT audio broadcasting

### DIFF
--- a/app.py
+++ b/app.py
@@ -2954,12 +2954,12 @@ def handle_audio_chunk(data):
             app.logger.warning("Invalid audio chunk received: %r", type(data))
             return
         if raw:
-            # ``socketio.emit`` does not broadcast unless explicitly
-            # requested.  Without ``broadcast=True`` the audio chunk would be
-            # sent only to the sender and then discarded because
-            # ``include_self`` is ``False``.  Setting ``broadcast=True``
-            # forwards the binary audio data to all other connected clients.
-            socketio.emit("play_audio", raw, broadcast=True, include_self=False)
+            # ``socketio.emit`` cannot accept the ``broadcast`` flag with the
+            # server version used in this project and would raise a
+            # ``TypeError``.  Using the context-aware ``emit`` instead ensures
+            # the audio chunk is forwarded to all connected clients except the
+            # sender.
+            emit("play_audio", raw, broadcast=True, include_self=False)
         else:
             app.logger.warning("Empty audio chunk received")
 

--- a/tests/test_ptt_audio.py
+++ b/tests/test_ptt_audio.py
@@ -1,0 +1,35 @@
+import pathlib
+import sys
+import pytest
+
+# Ensure the application root is on the import path when tests run from the
+# ``tests`` directory.
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+from app import app, socketio
+
+
+def make_client():
+    flask_client = app.test_client()
+    flask_client.get('/')  # ensure client_id cookie
+    return socketio.test_client(app, flask_test_client=flask_client)
+
+
+def test_audio_chunk_broadcast():
+    speaker = make_client()
+    listener = make_client()
+
+    # Speaker requests PTT
+    speaker.emit('start_speaking')
+    speaker.get_received()
+    listener.get_received()
+
+    payload = b'hello'
+    speaker.emit('audio_chunk', payload)
+
+    # Speaker should not receive its own audio back
+    assert not any(m['name'] == 'play_audio' for m in speaker.get_received())
+
+    # Listener should get the audio chunk
+    received = listener.get_received()
+    msgs = [m for m in received if m['name'] == 'play_audio']
+    assert msgs and msgs[0]['args'][0] == payload


### PR DESCRIPTION
## Summary
- ensure audio chunks are broadcast to all listeners using context-aware `emit`
- add regression test verifying that audio chunks from the speaker reach other clients

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898be3a3aac832185feb2c56a7946a3