### PR TITLE
Add marquee for audio stream data

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1149,3 +1149,9 @@ select {
   border: 1px solid #444;
   border-radius: 4px;
 }
+
+#audio-data {
+  width: 200px;
+  display: inline-block;
+  margin-left: 10px;
+}

--- a/static/js/ptt.js
+++ b/static/js/ptt.js
@@ -2,6 +2,7 @@
   const socket = io();
   const pttBtn = document.getElementById('ptt-btn');
   const levelMeter = document.getElementById('audio-level');
+  const audioDataDisplay = document.getElementById('audio-data');
   const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
 
   function playPing() {
@@ -60,9 +61,17 @@
     recorder.ondataavailable = (e) => {
       if (e.data.size > 0) {
         e.data.arrayBuffer().then((buf) => {
+          const chunk = new Uint8Array(buf);
           // Send a typed array so that the Python backend receives the raw
           // bytes without any additional encoding.
-          socket.emit('audio_chunk', new Uint8Array(buf));
+          socket.emit('audio_chunk', chunk);
+          if (audioDataDisplay) {
+            const hex = Array.from(chunk.slice(0, 20))
+              .map((b) => b.toString(16).padStart(2, '0'))
+              .join(' ');
+            audioDataDisplay.textContent =
+              (audioDataDisplay.textContent + ' ' + hex).slice(-400);
+          }
         });
       }
     };

--- a/templates/index.html
+++ b/templates/index.html
@@ -212,6 +212,7 @@
     <div id="ptt-controls">
         <button id="ptt-btn" type="button">Push to Talk</button>
         <meter id="audio-level" min="0" max="1" value="0"></meter>
+        <marquee id="audio-data"></marquee>
     </div>
     {% endif %}
     <div id="loading-msg">Daten werden geladen...</div>


### PR DESCRIPTION
## Summary
- Add marquee element to display audio stream bytes beside the level meter.
- Show hex representation of recent audio chunks as scrolling text.
- Style marquee area to align with push-to-talk controls.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898d390212c832188f5793f503029b1