### PR TITLE
Show received audio chunks in marquee

### DIFF
--- a/static/js/ptt.js
+++ b/static/js/ptt.js
@@ -271,6 +271,14 @@
         return;
       }
 
+      if (audioDataDisplay) {
+        const hex = Array.from(chunk.slice(0, 20))
+          .map((b) => b.toString(16).padStart(2, '0'))
+          .join(' ');
+        audioDataDisplay.textContent =
+          (audioDataDisplay.textContent + ' ' + hex).slice(-400);
+      }
+
       // ``decodeAudioData`` expects an ``ArrayBuffer`` containing the encoded
       // audio.  ``slice`` ensures the view only covers the transmitted bytes.
       const ab = chunk.buffer.slice(


### PR DESCRIPTION
## Summary
- Update PTT client to display audio chunk hex data for listeners in marquee

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898d62770dc8321b795780001dda2e8