### PR TITLE
Buffer PTT audio before broadcasting

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1150,8 +1150,3 @@ select {
   border-radius: 4px;
 }
 
-#audio-data {
-  width: 200px;
-  display: inline-block;
-  margin-left: 10px;
-}

--- a/static/js/ptt.js
+++ b/static/js/ptt.js
@@ -2,7 +2,6 @@
   const socket = io();
   const pttBtn = document.getElementById('ptt-btn');
   const levelMeter = document.getElementById('audio-level');
-  const audioDataDisplay = document.getElementById('audio-data');
   const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
 
   function playPing() {
@@ -65,13 +64,6 @@
           // Send a typed array so that the Python backend receives the raw
           // bytes without any additional encoding.
           socket.emit('audio_chunk', chunk);
-          if (audioDataDisplay) {
-            const hex = Array.from(chunk.slice(0, 20))
-              .map((b) => b.toString(16).padStart(2, '0'))
-              .join(' ');
-            audioDataDisplay.textContent =
-              (audioDataDisplay.textContent + ' ' + hex).slice(-400);
-          }
         });
       }
     };
@@ -269,14 +261,6 @@
       if (!chunk.length) {
         console.error('Received empty audio data');
         return;
-      }
-
-      if (audioDataDisplay) {
-        const hex = Array.from(chunk.slice(0, 20))
-          .map((b) => b.toString(16).padStart(2, '0'))
-          .join(' ');
-        audioDataDisplay.textContent =
-          (audioDataDisplay.textContent + ' ' + hex).slice(-400);
       }
 
       // ``decodeAudioData`` expects an ``ArrayBuffer`` containing the encoded

--- a/templates/index.html
+++ b/templates/index.html
@@ -212,7 +212,6 @@
     <div id="ptt-controls">
         <button id="ptt-btn" type="button">Push to Talk</button>
         <meter id="audio-level" min="0" max="1" value="0"></meter>
-        <marquee id="audio-data"></marquee>
     </div>
     {% endif %}
     <div id="loading-msg">Daten werden geladen...</div>

--- a/tests/test_ptt_audio.py
+++ b/tests/test_ptt_audio.py
@@ -23,11 +23,13 @@ def reset_ptt():
     if app_module.ptt_timer:
         app_module.ptt_timer.cancel()
         app_module.ptt_timer = None
+    app_module.audio_buffer.clear()
     yield
     app_module.current_speaker_id = None
     if app_module.ptt_timer:
         app_module.ptt_timer.cancel()
         app_module.ptt_timer = None
+    app_module.audio_buffer.clear()
 
 
 def test_audio_chunk_broadcast():
@@ -41,11 +43,15 @@ def test_audio_chunk_broadcast():
 
     payload = b'hello'
     speaker.emit('audio_chunk', payload)
+    # No audio should be broadcast until speaking stops
+    assert not any(m['name'] == 'play_audio' for m in listener.get_received())
+
+    speaker.emit('stop_speaking')
 
     # Speaker should not receive its own audio back
     assert not any(m['name'] == 'play_audio' for m in speaker.get_received())
 
-    # Listener should get the audio chunk
+    # Listener should get the buffered audio chunk
     received = listener.get_received()
     msgs = [m for m in received if m['name'] == 'play_audio']
     assert msgs and msgs[0]['args'][0] == payload
@@ -63,6 +69,11 @@ def test_audio_chunk_multiple_listeners():
 
     payload = b'data'
     speaker.emit('audio_chunk', payload)
+    # No audio should be broadcast until speaking stops
+    assert not any(m['name'] == 'play_audio' for m in listener1.get_received())
+    assert not any(m['name'] == 'play_audio' for m in listener2.get_received())
+
+    speaker.emit('stop_speaking')
 
     msgs1 = [m for m in listener1.get_received() if m['name'] == 'play_audio']
     msgs2 = [m for m in listener2.get_received() if m['name'] == 'play_audio']


### PR DESCRIPTION
## Summary
- buffer push-to-talk audio server-side and emit after speaking stops
- remove legacy audio debug marquee and related client code
- update tests for buffered audio behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6898d9013f5c832191332707959077b1