### PR TITLE
Style PTT controls

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -750,6 +750,19 @@ select {
     margin-left: 0;
     margin-top: 4px;
   }
+
+  #ptt-controls {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  #ptt-btn,
+  #audio-level {
+    width: 100%;
+  }
+  #ptt-desc {
+    margin-left: 0;
+    margin-top: 4px;
+  }
 }
 
 #openings-indicator {
@@ -991,6 +1004,34 @@ select {
 }
 
 #sms-status {
+  margin-left: 10px;
+}
+
+#ptt-controls {
+  margin: 10px 0;
+  padding: 8px;
+  background: rgba(255, 235, 59, 0.2);
+  border: 1px solid #ffeb3b;
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+#ptt-btn {
+  padding: 4px 8px;
+  background: var(--surface-color);
+  color: var(--text-color);
+  border: 1px solid #444;
+  border-radius: 4px;
+}
+
+#audio-level {
+  flex: 1;
+  min-width: 200px;
+}
+
+#ptt-desc {
   margin-left: 10px;
 }
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -212,6 +212,7 @@
     <div id="ptt-controls">
         <button id="ptt-btn" type="button">Push to Talk</button>
         <meter id="audio-level" min="0" max="1" value="0"></meter>
+        <span id="ptt-desc">Taste drücken zum Sprechen. Der Balken zeigt den Audiopegel.</span>
     </div>
     {% endif %}
     <div id="loading-msg">Daten werden geladen...</div>


### PR DESCRIPTION
## Summary
- style PTT control container to match other UI elements
- add concise German description for PTT button and audio meter

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898dbc56a088321badbc37ec7b109e1