### PR TITLE
Style PTT audio meter

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1029,6 +1029,10 @@ select {
 #audio-level {
   flex: 1;
   min-width: 200px;
+  background: var(--surface-color);
+  color: var(--text-color);
+  border: 1px solid #444;
+  border-radius: 4px;
 }
 
 #ptt-desc {


### PR DESCRIPTION
## Summary
- add background and border styling to Push-to-Talk audio meter for consistent appearance

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898dde40dac8321b692052be36e2984