### PR TITLE
Add border and reorder PTT controls

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -750,19 +750,6 @@ select {
     margin-left: 0;
     margin-top: 4px;
   }
-
-  #ptt-controls {
-    flex-direction: column;
-    align-items: stretch;
-  }
-  #ptt-btn,
-  #audio-level {
-    width: 100%;
-  }
-  #ptt-desc {
-    margin-left: 0;
-    margin-top: 4px;
-  }
 }
 
 #openings-indicator {
@@ -1003,9 +990,9 @@ select {
   border-radius: 4px;
 }
 
-#sms-status {
-  margin-left: 10px;
-}
+  #sms-status {
+    margin-left: 10px;
+  }
 
 #ptt-controls {
   margin: 10px 0;
@@ -1014,8 +1001,14 @@ select {
   border: 1px solid #ffeb3b;
   border-radius: 8px;
   display: flex;
-  align-items: center;
+  flex-direction: column;
+  align-items: stretch;
   gap: 4px;
+}
+
+#ptt-btn,
+#audio-level {
+  width: 100%;
 }
 
 #ptt-btn {
@@ -1036,7 +1029,7 @@ select {
 }
 
 #ptt-desc {
-  margin-left: 10px;
+  margin-bottom: 4px;
 }
 
 /* Taximeter page */

--- a/templates/index.html
+++ b/templates/index.html
@@ -210,9 +210,9 @@
 {% endif %}
     {% if config.get('ptt-controls', True) %}
     <div id="ptt-controls">
+        <span id="ptt-desc">Taste drücken zum Sprechen. Der Balken zeigt den Audiopegel.</span>
         <button id="ptt-btn" type="button">Push to Talk</button>
         <meter id="audio-level" min="0" max="1" value="0"></meter>
-        <span id="ptt-desc">Taste drücken zum Sprechen. Der Balken zeigt den Audiopegel.</span>
     </div>
     {% endif %}
     <div id="loading-msg">Daten werden geladen...</div>


### PR DESCRIPTION
## Summary
- Add yellow border and column layout to Push-to-Talk controls
- Move PTT description above button and audio meter

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898e046b5988321a12dedcdb18fc8c4