### PR TITLE
Refine PTT controls layout

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -996,19 +996,21 @@ select {
 
 #ptt-controls {
   margin: 10px 0;
-  padding: 8px;
+  padding: 10px;
+  color: var(--text-color);
   background: rgba(255, 235, 59, 0.2);
   border: 1px solid #ffeb3b;
   border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.4);
   display: flex;
   flex-direction: column;
-  align-items: stretch;
   gap: 4px;
 }
 
-#ptt-btn,
-#audio-level {
-  width: 100%;
+#ptt-row {
+  display: flex;
+  gap: 4px;
+  align-items: center;
 }
 
 #ptt-btn {
@@ -1029,6 +1031,7 @@ select {
 }
 
 #ptt-desc {
+  display: block;
   margin-bottom: 4px;
 }
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -211,8 +211,10 @@
     {% if config.get('ptt-controls', True) %}
     <div id="ptt-controls">
         <span id="ptt-desc">Taste drücken zum Sprechen. Der Balken zeigt den Audiopegel.</span>
-        <button id="ptt-btn" type="button">Push to Talk</button>
-        <meter id="audio-level" min="0" max="1" value="0"></meter>
+        <div id="ptt-row">
+            <button id="ptt-btn" type="button">Push to Talk</button>
+            <meter id="audio-level" min="0" max="1" value="0"></meter>
+        </div>
     </div>
     {% endif %}
     <div id="loading-msg">Daten werden geladen...</div>


### PR DESCRIPTION
## Summary
- Display push-to-talk description above button and meter with a new layout container
- Style PTT controls with colored border and box shadow similar to other panels

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898e38ab0ac83219267c6145fb90a71