### PR TITLE
Add IP-based client blocking

### DIFF
--- a/templates/blocked.html
+++ b/templates/blocked.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="de">
+<head>
+    <meta charset="utf-8">
+    <title>Zugang verweigert</title>
+    <style>
+        body {
+            margin: 0;
+            height: 100vh;
+            background: url('/images/404.jpg') no-repeat center center fixed;
+            background-size: cover;
+        }
+    </style>
+</head>
+<body>
+</body>
+</html>

--- a/templates/config.html
+++ b/templates/config.html
@@ -68,6 +68,14 @@
         </section>
 
         <section class="config-section">
+            <h2>Zugang</h2>
+            <label>
+                Blockierte IP-Adressen (kommagetrennt)
+                <input type="text" name="blocked_ips" value="{{ config.get('blocked_ips','') }}">
+            </label>
+        </section>
+
+        <section class="config-section">
             <h2>SMS</h2>
             <label>
                 Handynummer des Fahrers


### PR DESCRIPTION
## Summary
- Allow administrators to define comma-separated IP addresses in config to block.
- Redirect blocked clients to a dedicated page with 404-style background.
- Expose `/images/` route and template to serve the custom image.
- Reference `404.jpg` so administrators can upload a custom image later.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c9d5a57388321bc53a17417787600