### PR TITLE
Show blocked page for unknown routes

### DIFF
--- a/app.py
+++ b/app.py
@@ -2523,6 +2523,12 @@ def blocked():
     return render_template("blocked.html"), 403
 
 
+@app.errorhandler(404)
+def handle_404(_):
+    """Display blocked page for unknown routes."""
+    return render_template("blocked.html"), 404
+
+
 @app.route("/error")
 def error_page():
     """Display collected API errors."""


### PR DESCRIPTION
## Summary
- Display blocked page when navigating to unknown routes by handling 404 errors.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d00527158832198cf976a786cc798