### PR TITLE
Adjust 404 image to page height

### DIFF
--- a/templates/blocked.html
+++ b/templates/blocked.html
@@ -8,7 +8,7 @@
             margin: 0;
             height: 100vh;
             background: url('/images/404.jpg') no-repeat center center fixed;
-            background-size: cover;
+            background-size: auto 100%;
         }
     </style>
 </head>


### PR DESCRIPTION
## Summary
- Ensure 404 background image scales to the full page height via CSS

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d01a7781c8321aa960bbcb6bd3c8a