### PR TITLE
Show 404 image on blue blocked page

### DIFF
--- a/templates/blocked.html
+++ b/templates/blocked.html
@@ -2,16 +2,24 @@
 <html lang="de">
 <head>
     <meta charset="utf-8">
-    <title>Zugang verweigert</title>
+    <title>Tesla-Dashboard - Error 404</title>
     <style>
         body {
             margin: 0;
             height: 100vh;
-            background: url('/images/404.jpg') no-repeat center center fixed;
-            background-size: auto 100%;
+            background-color: #00008B;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+        }
+
+        img {
+            max-width: 100%;
+            height: auto;
         }
     </style>
 </head>
 <body>
+    <img src="/images/404.jpg" alt="Fehler 404">
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Update blocked page title to "Tesla-Dashboard - Error 404"
- Replace background with dark blue style and center 404.jpg image

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d0350bc24832199b0d12164e720e5