### PR TITLE
Log client pages and serve blocked view directly

### DIFF
--- a/static/js/clients.js
+++ b/static/js/clients.js
@@ -12,7 +12,7 @@ async function fetchClients() {
         tbody.innerHTML = '';
         data.clients.forEach(function(c) {
             const tr = document.createElement('tr');
-            ['ip', 'hostname', 'location', 'provider', 'browser', 'os', 'user_agent', 'duration'].forEach(function(key) {
+            ['ip', 'hostname', 'location', 'provider', 'browser', 'os', 'user_agent', 'pages', 'duration'].forEach(function(key) {
                 const td = document.createElement('td');
                 td.textContent = c[key] || '';
                 tr.appendChild(td);

--- a/templates/clients.html
+++ b/templates/clients.html
@@ -25,6 +25,7 @@
                 <th>Browser</th>
                 <th>Betriebssystem</th>
                 <th>Browserdaten</th>
+                <th>Seiten</th>
                 <th>Verbunden seit</th>
             </tr>
         </thead>
@@ -38,6 +39,7 @@
                 <td>{{ c.browser }}</td>
                 <td>{{ c.os }}</td>
                 <td>{{ c.user_agent }}</td>
+                <td>{{ c.pages }}</td>
                 <td>seit {{ c.duration }}</td>
             </tr>
             {% endfor %}


### PR DESCRIPTION
## Summary
- track visited pages for each client and list them in `/clients`
- include blocked IPs and return the blocked template immediately
- extend clients API, template, and JS to show visited pages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689d4dbd44948321a44c518b94e8ada7