### PR TITLE
Fix pages column on clients view

### DIFF
--- a/app.py
+++ b/app.py
@@ -2249,7 +2249,7 @@ def api_client_details():
                 "browser": data.get("browser"),
                 "os": data.get("os"),
                 "user_agent": data.get("user_agent"),
-                "pages": ", ".join(data.get("pages", [])),
+                "pages": data.get("pages", []),
                 "duration": f"{days:02d} Tage, {hms}",
             }
         )
@@ -2930,7 +2930,7 @@ def clients_view():
                 "browser": data.get("browser"),
                 "os": data.get("os"),
                 "user_agent": data.get("user_agent"),
-                "pages": ", ".join(data.get("pages", [])),
+                "pages": ", ".join(str(p) for p in data.get("pages", [])),
                 "duration": f"{days:02d} Tage, {hms}",
             }
         )

--- a/static/js/clients.js
+++ b/static/js/clients.js
@@ -14,7 +14,11 @@ async function fetchClients() {
             const tr = document.createElement('tr');
             ['ip', 'hostname', 'location', 'provider', 'browser', 'os', 'user_agent', 'pages', 'duration'].forEach(function(key) {
                 const td = document.createElement('td');
-                td.textContent = c[key] || '';
+                let value = c[key];
+                if (key === 'pages' && Array.isArray(value)) {
+                    value = value.join(', ');
+                }
+                td.textContent = value || '';
                 tr.appendChild(td);
             });
             tbody.appendChild(tr);


### PR DESCRIPTION
## Summary
- Ensure API returns list of pages for each client
- Render pages list in UI, joining items for display

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689d524e16e08321bf9ba7d89bae9603