### PR TITLE
Ensure client pages appear in clients view

### DIFF
--- a/app.py
+++ b/app.py
@@ -2249,7 +2249,8 @@ def api_client_details():
                 "browser": data.get("browser"),
                 "os": data.get("os"),
                 "user_agent": data.get("user_agent"),
-                "pages": data.get("pages", []),
+                # Join visited pages into a comma separated string for easier display
+                "pages": ", ".join(str(p) for p in data.get("pages", [])),
                 "duration": f"{days:02d} Tage, {hms}",
             }
         )


### PR DESCRIPTION
## Summary
- Return client page list as comma-separated string in details API

## Testing
- `pytest -q`
- `python app.py` (manual client requests to verify pages column)


------
https://chatgpt.com/codex/tasks/task_e_689d55178ae88321b9abe27e2c8fb3bf