### PR TITLE
Add monthly summary to statistics page

### DIFF
--- a/templates/statistik.html
+++ b/templates/statistik.html
@@ -38,6 +38,17 @@
             <td>{{ row.energy }}</td>
         </tr>
         {% endfor %}
+        {% if summary %}
+        <tr>
+            <td><strong>{{ summary.date }} Summe</strong></td>
+            <td>{{ summary.online }}</td>
+            <td>{{ summary.offline }}</td>
+            <td>{{ summary.asleep }}</td>
+            <td>{{ summary.km }}</td>
+            <td>{{ summary.speed }}</td>
+            <td>{{ summary.energy }}</td>
+        </tr>
+        {% endif %}
     </table>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- aggregate daily statistics for the current month and compute a summary
- display a summary row for the current month at the bottom of the Statistik page

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aea32712488321b49585454b6cd94c