### PR TITLE
Show software update info and adjust seat heater label

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -65,6 +65,14 @@ select {
 }
 
 
+#software-update {
+  display: none;
+  text-align: center;
+  font-size: 1.1em;
+  margin: 10px 0;
+  color: var(--accent-color);
+}
+
 #offline-msg {
   display: none;
   text-align: center;

--- a/templates/index.html
+++ b/templates/index.html
@@ -55,7 +55,7 @@
                     <div id="seat-left" title="Sitzheizung Fahrer"></div>
                     <div id="seat-right" title="Sitzheizung Beifahrer"></div>
                     <div id="seat-rear-left" title="Sitzheizung hinten links"></div>
-                    <div id="seat-rear-center" title="Sitzheizung hinten Mitte"></div>
+                    <div id="seat-rear-center" title="Sitzheizung hinten mitte"></div>
                     <div id="seat-rear-right" title="Sitzheizung hinten rechts"></div>
                     <hr />
                 </div>
@@ -199,6 +199,7 @@
             </svg>
         </div>
     </div>
+    <div id="software-update"></div>
     <div id="offline-msg"></div>
     {% if config.get('phone_number') and config.get('sms_enabled', True) %}
     <div id="sms-form" style="display:none;">


### PR DESCRIPTION
## Summary
- rename rear center seat heater to use lower-case "mitte"
- display software update details in a new banner above the offline message
- style software update banner consistently with existing status messages

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aea8593c7c8321a1bbf6035d289bea