### PR TITLE
Hide software update message without version

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -1120,8 +1120,13 @@ function updateVehicleState(state) {
 
 function updateSoftwareUpdate(info) {
     var $msg = $('#software-update');
-    var available = info && info.version ? parseVersion(info.version) : null;
-    if (!info || !available || !installedVersion || !isNewerVersion(installedVersion, available)) {
+    var version = info && typeof info.version === 'string' ? info.version.trim() : '';
+    if (!version) {
+        $msg.hide().text('');
+        return;
+    }
+    var available = parseVersion(version);
+    if (!installedVersion || !isNewerVersion(installedVersion, available)) {
         $msg.hide().text('');
         return;
     }

--- a/templates/index.html
+++ b/templates/index.html
@@ -199,7 +199,7 @@
             </svg>
         </div>
     </div>
-    <div id="software-update"></div>
+    <div id="software-update" hidden></div>
     <div id="offline-msg"></div>
     {% if config.get('phone_number') and config.get('sms_enabled', True) %}
     <div id="sms-form" style="display:none;">


### PR DESCRIPTION
## Summary
- ensure software update banner only shows when a version string is returned
- hide software update placeholder by default in template

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aeae02f1d0832180ed9a29942d1d81