### PR TITLE
Highlight current day and state on statistics page

### DIFF
--- a/app.py
+++ b/app.py
@@ -2681,9 +2681,23 @@ def statistics_page():
         total = summary["online"] + summary["offline"] + summary["asleep"]
         diff = round(100.0 - total, 2)
         summary["offline"] = round(summary["offline"] + diff, 2)
+    # highlight today's statistics and current vehicle state
+    today = datetime.now(LOCAL_TZ).date().isoformat()
+    vid = str(_default_vehicle_id or "default")
+    state = last_vehicle_state.get(vid)
+    if state is None and last_vehicle_state:
+        # fall back to any known state if default ID is missing
+        state = next(iter(last_vehicle_state.values()))
 
     cfg = load_config()
-    return render_template("statistik.html", rows=rows, summary=summary, config=cfg)
+    return render_template(
+        "statistik.html",
+        rows=rows,
+        summary=summary,
+        config=cfg,
+        today=today,
+        current_state=state,
+    )
 
 
 @app.route("/api/errors")

--- a/templates/statistik.html
+++ b/templates/statistik.html
@@ -11,6 +11,8 @@
     <style>
         table { border-collapse: collapse; }
         th, td { padding: 4px 8px; border: 1px solid #444; }
+        tr.current-day { background-color: #fffae6; }
+        td.current-state { background-color: #ffe0e0; font-weight: bold; }
     </style>
 </head>
 <body>
@@ -28,11 +30,12 @@
     <table>
         <tr><th>Datum</th><th>Online %</th><th>Offline %</th><th>Asleep %</th><th>Gefahrene km</th><th>Höchste Geschwindigkeit (km/h)</th><th>Hinzugefügte Energie (kWh)</th></tr>
         {% for row in rows %}
-        <tr>
+        {% set is_today = (row.date == today) %}
+        <tr{% if is_today %} class="current-day"{% endif %}>
             <td>{{ row.date }}</td>
-            <td>{{ row.online }}</td>
-            <td>{{ row.offline }}</td>
-            <td>{{ row.asleep }}</td>
+            <td{% if is_today and current_state == 'online' %} class="current-state"{% endif %}>{{ row.online }}</td>
+            <td{% if is_today and current_state == 'offline' %} class="current-state"{% endif %}>{{ row.offline }}</td>
+            <td{% if is_today and current_state == 'asleep' %} class="current-state"{% endif %}>{{ row.asleep }}</td>
             <td>{{ row.km }}</td>
             <td>{{ row.speed }}</td>
             <td>{{ row.energy }}</td>


### PR DESCRIPTION
## Summary
- Add detection of today's date and vehicle state to statistics view
- Highlight current day row and emphasize the active state cell in statistics table

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b86f4e4d988321a57e36377e7e337f