### PR TITLE
Improve statistics table highlight contrast

### DIFF
--- a/templates/statistik.html
+++ b/templates/statistik.html
@@ -11,8 +11,8 @@
     <style>
         table { border-collapse: collapse; }
         th, td { padding: 4px 8px; border: 1px solid #444; }
-        tr.current-day { background-color: #fffae6; }
-        td.current-state { background-color: #ffe0e0; font-weight: bold; }
+        tr.current-day { background-color: #333333; }
+        td.current-state { background-color: #550000; font-weight: bold; }
     </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- Darken highlighted row and state cells in statistics page for better readability

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b871c12e6483219ad4d0f8abaaab60