### PR TITLE
Allow selecting default vehicle via config

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -264,6 +264,8 @@ function fetchVehicles() {
         }
         if (!currentVehicle && vehicles.length > 0) {
             currentVehicle = vehicles[0].id;
+        }
+        if (currentVehicle) {
             $select.val(currentVehicle);
             startStreamIfOnline();
         }
@@ -1300,14 +1302,17 @@ function startStreamIfOnline() {
     });
 }
 
-fetchVehicles();
 $.getJSON('/api/config', function(cfg) {
     applyConfig(cfg);
     lastConfigJSON = JSON.stringify(cfg || {});
     if (cfg) {
         lastApiInterval = cfg.api_interval;
         lastApiIntervalIdle = cfg.api_interval_idle;
+        if (cfg.vehicle_id) {
+            currentVehicle = cfg.vehicle_id;
+        }
     }
+    fetchVehicles();
 });
 
 function fetchConfig() {
@@ -1315,7 +1320,8 @@ function fetchConfig() {
         var json = JSON.stringify(cfg || {});
         if (json !== lastConfigJSON) {
             if (cfg && (cfg.api_interval !== lastApiInterval ||
-                        cfg.api_interval_idle !== lastApiIntervalIdle)) {
+                        cfg.api_interval_idle !== lastApiIntervalIdle ||
+                        cfg.vehicle_id !== currentVehicle)) {
                 location.reload(true);
                 return;
             }

--- a/templates/config.html
+++ b/templates/config.html
@@ -23,6 +23,20 @@
             {% endfor %}
         </section>
 
+        {% if vehicles %}
+        <section class="config-section">
+            <h2>Fahrzeug</h2>
+            <label>
+                Fahrzeug auswählen
+                <select name="vehicle_id">
+                    {% for v in vehicles %}
+                    <option value="{{ v.id }}" {% if v.id == selected_vehicle_id %}selected{% endif %}>{{ v.display_name }}</option>
+                    {% endfor %}
+                </select>
+            </label>
+        </section>
+        {% endif %}
+
         <section class="config-section">
             <h2>APRS</h2>
             <label>


### PR DESCRIPTION
## Summary
- Add vehicle selection dropdown to configuration page
- Persist chosen vehicle ID and use it as default
- Initialize frontend with configured vehicle and reload when changed

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c797a1555c83218852d197dadd286a