### PR TITLE
Gate push-to-talk audio by config

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -237,6 +237,8 @@
         window.APP_VERSION = "{{ version }}";
     </script>
     <script src="/static/js/main.js"></script>
+    {% if config.get('ptt-controls', True) %}
     <script src="/static/js/ptt.js"></script>
+    {% endif %}
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a helper to read the push-to-talk toggle from the configuration
- guard Socket.IO audio handlers so they do nothing when push-to-talk is disabled
- only include the push-to-talk script on the dashboard when the feature is enabled

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68cb7a1757088321a41ac32611109fd0