### PR TITLE
Prevent indexing of history page

### DIFF
--- a/app.py
+++ b/app.py
@@ -24,6 +24,7 @@ from flask import (
     url_for,
     redirect,
     g,
+    make_response,
 )
 from taximeter import Taximeter
 import requests
@@ -2229,18 +2230,22 @@ def trip_history():
             heading = _bearing(path[0][:2], path[1][:2])
     weekly, monthly = compute_trip_summaries()
     cfg = load_config()
-    return render_template(
-        "history.html",
-        path=path,
-        heading=heading,
-        files=files,
-        weeks=weeks,
-        months=months,
-        selected=selected,
-        weekly=weekly,
-        monthly=monthly,
-        config=cfg,
+    response = make_response(
+        render_template(
+            "history.html",
+            path=path,
+            heading=heading,
+            files=files,
+            weeks=weeks,
+            months=months,
+            selected=selected,
+            weekly=weekly,
+            monthly=monthly,
+            config=cfg,
+        )
     )
+    response.headers["X-Robots-Tag"] = "noindex, nofollow"
+    return response
 
 
 @app.route("/daten")

--- a/templates/history.html
+++ b/templates/history.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="Tesla Dashboard zur Anzeige aktueller Fahrzeugdaten">
     <meta name="keywords" content="Tesla, Dashboard, Fahrzeugdaten, Statistik, Karte, Elektroauto, Ladung, Stromverbrauch, Standort, Routenplanung, Fahrzeugstatus, Kilometerstand, Trip, Tesla Model S, Model 3, Model X, Model Y">
+    <meta name="robots" content="noindex, nofollow">
     <title>Fahrtverlauf</title>
     <script src="/static/js/jquery.min.js"></script>
     <link rel="stylesheet" href="/static/css/leaflet.css" />


### PR DESCRIPTION
## Summary
- add a robots meta tag to the history template so that crawlers skip the page
- send an X-Robots-Tag header from the /history route to enforce noindexing

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d03fbcae1c8321a4ed92c55cbc89f1