### PR TITLE
Add local timestamp to taximeter receipts

### DIFF
--- a/templates/taxameter_receipt.html
+++ b/templates/taxameter_receipt.html
@@ -19,6 +19,9 @@
                 {% endif %}
                 {% endif %}
             </div>
+            {% if printed_at %}
+            <div class="receipt-meta">Datum: {{ printed_at }}</div>
+            {% endif %}
             <table id="receipt-table">
                 <tr><td>Grundpreis:</td><td class="num">{{ '%.2f'|format(breakdown.base) }} €</td></tr>
                 {% if breakdown.km_1_2 > 0 %}


### PR DESCRIPTION
## Summary
- ensure taximeter receipts include the current local date and time when generated
- persist the timestamp in stored receipt metadata and surface it in the UI

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d413a59140832196a6d20cfd6dab8f