### PR TITLE
Prevent duplicate energy log rewrites

### DIFF
--- a/tests/test_energy_stats.py
+++ b/tests/test_energy_stats.py
@@ -1,7 +1,7 @@
 import logging
 import pathlib
 import sys
-from datetime import datetime
+from datetime import datetime, timedelta
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 
@@ -19,6 +19,7 @@ def test_log_energy_uses_provided_timestamp(tmp_path, monkeypatch):
     handler = logging.FileHandler(energy_file, mode="w", encoding="utf-8")
     handler.setFormatter(logging.Formatter("%(message)s"))
     app.energy_logger.addHandler(handler)
+    app._recently_logged_sessions.clear()
 
     try:
         ts = datetime(2024, 1, 1, 23, 30, tzinfo=app.LOCAL_TZ)
@@ -32,6 +33,37 @@ def test_log_energy_uses_provided_timestamp(tmp_path, monkeypatch):
 
     content = energy_file.read_text(encoding="utf-8").strip()
     assert content.startswith("2024-01-01 23:30:00")
+
+
+def test_log_energy_prevents_follow_up_writes(tmp_path, monkeypatch):
+    monkeypatch.setattr(app, "DATA_DIR", str(tmp_path))
+
+    old_handlers = list(app.energy_logger.handlers)
+    for handler in old_handlers:
+        app.energy_logger.removeHandler(handler)
+
+    energy_file = tmp_path / "energy.log"
+    handler = logging.FileHandler(energy_file, mode="w", encoding="utf-8")
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    app.energy_logger.addHandler(handler)
+    app._recently_logged_sessions.clear()
+
+    try:
+        ts = datetime(2024, 1, 5, 21, 0, tzinfo=app.LOCAL_TZ)
+        app._log_energy("veh", 15.0, timestamp=ts)
+
+        earlier = ts - timedelta(days=1)
+        app._log_energy("veh", 18.0, timestamp=earlier)
+        handler.flush()
+    finally:
+        app.energy_logger.removeHandler(handler)
+        handler.close()
+        for original in old_handlers:
+            app.energy_logger.addHandler(original)
+
+    lines = [line for line in energy_file.read_text(encoding="utf-8").splitlines() if line]
+    assert len(lines) == 1
+    assert '"added_energy": 15.0' in lines[0]
 
 
 def test_session_start_persistence(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- guard the energy logger against follow-up writes by rejecting entries for the same session and tracking recently logged vehicles
- reset the protection when a new charging session starts so fresh logs can be written
- add a regression test ensuring duplicate writes are ignored

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d7e69ad7b8832187fddcdfd7c90e71