### PR TITLE
Fix energy statistics data dir handling

### DIFF
--- a/app.py
+++ b/app.py
@@ -1655,8 +1655,10 @@ def _compute_state_stats(entries):
     return stats
 
 
-def _compute_energy_stats(filename=os.path.join(DATA_DIR, "energy.log")):
+def _compute_energy_stats(filename=None):
     """Return per-day added energy in kWh based on ``energy.log``."""
+    if filename is None:
+        filename = os.path.join(DATA_DIR, "energy.log")
     energy = {}
     last_vals = {}
     last_times = {}

--- a/tests/test_energy_stats.py
+++ b/tests/test_energy_stats.py
@@ -119,3 +119,16 @@ def test_clear_session_allows_follow_up_logging(tmp_path, monkeypatch):
     assert len(lines) == 2
     assert '"added_energy": 8.5' in lines[0]
     assert '"added_energy": 12.0' in lines[1]
+
+
+def test_compute_energy_stats_respects_data_dir(tmp_path, monkeypatch):
+    monkeypatch.setattr(app, "DATA_DIR", str(tmp_path))
+
+    energy_file = tmp_path / "energy.log"
+    energy_file.write_text(
+        '2024-02-25 08:00:00 {"vehicle_id": "veh", "added_energy": 12.3}\n',
+        encoding="utf-8",
+    )
+
+    stats = app._compute_energy_stats()
+    assert stats == {"2024-02-25": 12.3}


### PR DESCRIPTION
## Summary
- resolve the energy log path inside `_compute_energy_stats` so statistics pick up the current data directory
- add a regression test ensuring the energy statistics loader respects a patched data directory

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68dd57727d24832196791f09e4adaf01