### PR TITLE
Fix daily energy stats rollover

### DIFF
--- a/app.py
+++ b/app.py
@@ -1693,9 +1693,11 @@ def _compute_energy_stats(filename=None):
                     prev_ts = None
                     session_day = None
 
+                current_day = ts_dt.date()
+
                 if prev_val is None or prev_ts is None:
                     if val > eps:
-                        session_day = ts_dt.date()
+                        session_day = current_day
                         day = session_day.isoformat()
                         energy[day] = energy.get(day, 0.0) + val
                 else:
@@ -1703,6 +1705,10 @@ def _compute_energy_stats(filename=None):
                     if delta > eps:
                         if session_day is None:
                             session_day = prev_ts.date()
+
+                        if session_day != current_day:
+                            session_day = current_day
+
                         day = session_day.isoformat()
                         energy[day] = energy.get(day, 0.0) + delta
 

--- a/tests/test_energy_stats.py
+++ b/tests/test_energy_stats.py
@@ -132,3 +132,22 @@ def test_compute_energy_stats_respects_data_dir(tmp_path, monkeypatch):
 
     stats = app._compute_energy_stats()
     assert stats == {"2024-02-25": 12.3}
+
+
+def test_compute_energy_stats_resets_on_new_day(tmp_path, monkeypatch):
+    monkeypatch.setattr(app, "DATA_DIR", str(tmp_path))
+
+    energy_file = tmp_path / "energy.log"
+    energy_file.write_text(
+        "\n".join(
+            [
+                '2024-03-01 23:45:00 {"vehicle_id": "veh", "added_energy": 4.0}',
+                '2024-03-02 00:15:00 {"vehicle_id": "veh", "added_energy": 6.5}',
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    stats = app._compute_energy_stats()
+    assert stats == {"2024-03-01": 4.0, "2024-03-02": 2.5}


### PR DESCRIPTION
## Summary
- ensure energy statistics attribute new energy.log samples to the current calendar day so the latest entry appears on /statistik
- cover the midnight rollover scenario with a regression test for _compute_energy_stats

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68dd5a0958088321ba811b8fafcc0345