### PR TITLE
Fix energy statistics to use session totals

### DIFF
--- a/tests/test_energy_stats.py
+++ b/tests/test_energy_stats.py
@@ -134,7 +134,7 @@ def test_compute_energy_stats_respects_data_dir(tmp_path, monkeypatch):
     assert stats == {"2024-02-25": 12.3}
 
 
-def test_compute_energy_stats_resets_on_new_day(tmp_path, monkeypatch):
+def test_compute_energy_stats_assigns_session_to_last_day(tmp_path, monkeypatch):
     monkeypatch.setattr(app, "DATA_DIR", str(tmp_path))
 
     energy_file = tmp_path / "energy.log"
@@ -150,4 +150,4 @@ def test_compute_energy_stats_resets_on_new_day(tmp_path, monkeypatch):
     )
 
     stats = app._compute_energy_stats()
-    assert stats == {"2024-03-01": 4.0, "2024-03-02": 2.5}
+    assert stats == {"2024-03-02": 6.5}


### PR DESCRIPTION
## Summary
- adjust energy aggregation to assign each charging session to the day of its final entry so the statistics page shows the latest session total
- update the energy statistics test to reflect the new session-based behaviour

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68dd5ca39d608321a08f376bee6f1052