### PR TITLE
Reverse order of statistics entries

### DIFF
--- a/templates/statistik.html
+++ b/templates/statistik.html
@@ -29,7 +29,7 @@
     {% endif %}
     <table>
         <tr><th>Datum</th><th>Online %</th><th>Offline %</th><th>Asleep %</th><th>Gefahrene km</th><th>Höchste Geschwindigkeit (km/h)</th><th>Hinzugefügte Energie (kWh)</th></tr>
-        {% for row in rows %}
+        {% for row in rows|reverse %}
         {% set is_today = (row.date == today) %}
         <tr{% if is_today %} class="current-day"{% endif %}>
             <td>{{ row.date }}</td>


### PR DESCRIPTION
## Summary
- reverse the iteration order of statistik rows so entries render in reverse chronological order

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e1e7416d748321b05565cfc6624d36