### PR TITLE
Fix ungewollte 5–10s Verzögerung trotz 1s API-Intervall

### DIFF
--- a/app.py
+++ b/app.py
@@ -4747,11 +4747,14 @@ def _tessie_battery_temp(vin):
             verbleibend = TESLA_TESSIE_MIN_INTERVAL - (jetzt - letzte_anfrage)
             if verbleibend > 0:
                 logging.info(
-                    "Tessie-Abfrage für VIN %s wird um %.1f Sekunden verzögert.",
+                    (
+                        "Tessie-Abfrage für VIN %s zu früh angefordert "
+                        "(noch %.1f Sekunden); nutze Cachewert."
+                    ),
                     vin,
                     verbleibend,
                 )
-                time.sleep(verbleibend)
+                return letzte_batterie_temp_pro_vin.get(vin)
         try:
             resp = requests.get(url, headers=headers, timeout=TESLA_REQUEST_TIMEOUT)
         finally:


### PR DESCRIPTION
## Zusammenfassung
- Ursache gefunden: In `_tessie_battery_temp` wurde bei zu schneller Folgeabfrage per `time.sleep(...)` blockiert.
- Diese Blockierung lief im normalen Daten-Fetch-Loop und konnte dadurch den gesamten Update-Takt auf ~5s (oder mehr) hochziehen.
- Verhalten geändert: Bei Unterschreitung des Tessie-Minimalintervalls wird nun **nicht mehr geschlafen**, sondern sofort der zuletzt gecachte Batterietemperaturwert genutzt.

## Technische Details
- Datei: `app.py`
- Funktion: `_tessie_battery_temp(vin)`
- Änderung:
  - Logik für `verbleibend > 0` angepasst.
  - Statt Verzögerung (`time.sleep(verbleibend)`) wird jetzt direkt der Cachewert (`letzte_batterie_temp_pro_vin.get(vin)`) zurückgegeben.

## Erwarteter Effekt
- Der Haupt-Update-Loop bleibt im konfigurierten 1s-Intervall reaktionsfähig, auch wenn Tessie-Abfragen rate-limitiert sind.
- Kein unnötiges Hochspringen des UI-Zählers auf 5/10 Sekunden durch blockierende Sleeps in der Temperaturabfrage.

## Tests
- `pytest -q` ausgeführt: 55 passed.
- `pytest -q` erneut ausgeführt: 55 passed.
- Bekannte bestehende Warnungen (Eventlet deprecation, Thread-Warning) bleiben unverändert.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cef5b806508321b012f478391b7499)