### PR TITLE
Behebe Queue-Buchführung im Client-Lookup-Worker

### DIFF
--- a/app.py
+++ b/app.py
@@ -348,7 +348,6 @@ def _lookup_worker():
         finally:
             with _lookup_lock:
                 _queued_ips.discard(ip)
-            _lookup_queue.task_done()
 
 
 def _enqueue_lookup(ip):


### PR DESCRIPTION
### Motivation
- Der Hintergrund-Worker für IP-Lookups rief unnötig `_lookup_queue.task_done()` auf und verursachte dadurch `ValueError: task_done() called too many times`-Warnungen in Threads.

### Description
- Entfernt den Aufruf von `_lookup_queue.task_done()` in `app.py` innerhalb von `_lookup_worker`, sodass die Queue-Buchführung nicht mehr überzählt wird.

### Testing
- `pytest -q` wurde ausgeführt und meldete `55 passed, 1 warning` nach der Änderung.
- `python -m compileall -q .` wurde ausgeführt und war erfolgreich.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e19dffd08c8321861c8384b7246c1b)