### PR TITLE
Header: kleines Logo hinzufügen und h2 auf Flex-Layout umstellen

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -46,6 +46,17 @@ h2 {
   text-align: left;
   border-bottom: 1px solid #333;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0;
+}
+
+.header-logo {
+  height: 16px;
+  width: auto;
+  margin-right: 6px;
+  flex: 0 0 auto;
 }
 
 label {
@@ -399,7 +410,8 @@ select {
 }
 
 #header-right {
-  float: right;
+  margin-left: auto;
+  white-space: nowrap;
 }
 
 #header-right span {
@@ -969,8 +981,9 @@ select {
 /* Responsive adjustments */
 @media (max-width: 600px) {
   #header-right {
-    float: none;
+    margin-left: 0;
     display: block;
+    width: 100%;
     text-align: right;
   }
   #header-right span {

--- a/templates/index.html
+++ b/templates/index.html
@@ -24,7 +24,7 @@
         <img src="{{ splash_logo_data_uri }}" alt="Tesla Dashboard Splashscreen" loading="eager" decoding="async">
     </div>
     <a href="#dashboard-content" class="skip-link">Zum Inhalt springen</a>
-    <h2>Tesla-Dashboard V{{ version }}
+    <h2><img class="header-logo" src="{{ splash_logo_data_uri }}" alt="" aria-hidden="true">Tesla-Dashboard V{{ version }}
         <span id="header-right">
             <span id="vehicle-info"></span>&nbsp;&nbsp;&nbsp;<span id="vehicle-status"></span>
         </span>


### PR DESCRIPTION
### Motivation
- Das Dashboard-Header-Layout soll ein kleines Logo neben dem Titel anzeigen und sicherstellen, dass Logo, Titeltext und der rechte Statusbereich sauber ausgerichtet und responsiv bleiben.

### Description
- Eingefügt ein `<img class="header-logo" src="{{ splash_logo_data_uri }}" alt="" aria-hidden="true">` direkt vor `Tesla-Dashboard V{{ version }}` in `templates/index.html`, und `h2` in `static/css/style.css` auf ein flexbasiertes Layout (`display: flex; align-items: center;`) umgestellt; zusätzlich `.header-logo` mit fester Höhe (`height: 16px`) und kleinem Abstand definiert und `#header-right` für Desktop (`margin-left: auto; white-space: nowrap;`) sowie für Mobile (`@media (max-width: 600px)` -> `width: 100%`) angepasst.

### Testing
- Automatisierte Tests mit `pytest -q` wurden ausgeführt und erfolgreich abgeschlossen (`55 passed, 1 warning`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef210787a8832183f8a4f520a98f9a)