### PR TITLE
Revert H2 layout changes while keeping header logo image

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -46,10 +46,6 @@ h2 {
   text-align: left;
   border-bottom: 1px solid #333;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
-  display: flex;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: 0;
 }
 
 .header-logo {
@@ -410,8 +406,7 @@ select {
 }
 
 #header-right {
-  margin-left: auto;
-  white-space: nowrap;
+  float: right;
 }
 
 #header-right span {
@@ -981,9 +976,8 @@ select {
 /* Responsive adjustments */
 @media (max-width: 600px) {
   #header-right {
-    margin-left: 0;
+    float: none;
     display: block;
-    width: 100%;
     text-align: right;
   }
   #header-right span {


### PR DESCRIPTION
## Summary
- reverted the recent H2 layout styling changes in `static/css/style.css`
- restored the previous `#header-right` float behavior (including mobile override)
- kept the logo rendered as an `<img>` inside the dashboard header in `templates/index.html`

## Validation
- `pytest -q`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef22ecf7288321824c05ca8ea6c1f2)