### PR TITLE
Fix: Splashscreen verschwindet nicht in iOS Safari

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1535,6 +1535,7 @@ select {
   background: #000;
   opacity: 1;
   transition: opacity 0.4s ease;
+  animation: splash-autohide 0.4s ease 5s forwards;
 }
 
 #splashscreen.is-hidden {
@@ -1548,4 +1549,12 @@ select {
   object-fit: contain;
   border-radius: 16px;
   box-shadow: 0 0 32px rgba(0, 0, 0, 0.7);
+}
+
+@keyframes splash-autohide {
+  to {
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+  }
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -287,6 +287,11 @@
                 window.setTimeout(function () {
                     splash.remove();
                 }, 400);
+                window.setTimeout(function () {
+                    if (document.body.contains(splash)) {
+                        splash.style.display = "none";
+                    }
+                }, 400);
             }, 5000);
         });
     </script>


### PR DESCRIPTION
### Motivation
- In iOS Safari blieb das Splashscreen-Logo manchmal sichtbar in voller Größe, weil das Entfernen/Verstecken per JavaScript nicht zuverlässig ausgeführt wurde; ein CSS-Fallback und robusteres JS sollen das Overlay nach 5 Sekunden zuverlässig verbergen.

### Description
- Ergänzt in `static/css/style.css` eine Keyframe-Animation `splash-autohide` und `animation: splash-autohide 0.4s ease 5s forwards;` für das `#splashscreen`-Element, sodass es nach 5 s automatisch ausgeblendet und unsichtbar wird.
- JavaScript in `templates/index.html` angepasst: nach dem vorhandenen Fade-Out/`remove()` wird zusätzlich geprüft, ob das Element noch im DOM ist, und falls ja per `style.display = "none"` hart ausgeblendet.

### Testing
- Automatisierte Tests mit `pytest -q` wurden ausgeführt und erfolgreich beendet (`55 passed`).
- Syntaxprüfung mit `python -m py_compile app.py` wurde ausgeführt und war erfolgreich.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a058e9d49b88321bb0559e8e6bffa3a)