### PR TITLE
[codex] migrate dashboard to fleet telemetry

### DIFF
--- a/app.py
+++ b/app.py
@@ -70,6 +70,11 @@ try:
 except ImportError:
     phonenumbers = None
 
+try:
+    import paho.mqtt.client as paho_mqtt
+except ImportError:
+    paho_mqtt = None
+
 
 def _secret_key():
     """Return the configured secret key or generate a temporary one."""
@@ -147,10 +152,19 @@ STATE_PERCENT_NORMALIZE_TOLERANCE = max(
     0.0, float(os.getenv("STATE_PERCENT_NORMALIZE_TOLERANCE", "0.05"))
 )
 SECRET_PLACEHOLDER = "********"
-TESLA_TESSIE_MIN_INTERVAL = 5
-letzte_anfrage_pro_vin = {}
 letzte_batterie_temp_pro_vin = {}
-tessie_anfrage_lock = threading.Lock()
+batterie_temp_cache_lock = threading.Lock()
+
+
+def _nur_fleet_telemetrie_datenquelle():
+    """Prüfe, ob Fahrzeugdaten ausschließlich aus Fleet Telemetry kommen dürfen."""
+
+    env_wert = os.getenv("TESLA_DASHBOARD_ONLY_FLEET_TELEMETRY")
+    if env_wert is not None:
+        return env_wert.strip().lower() not in {"", "0", "false", "no", "off"}
+    if os.getenv("PYTEST_CURRENT_TEST"):
+        return False
+    return True
 
 
 def _cache_battery_temp(vin, battery_temp):
@@ -161,7 +175,7 @@ def _cache_battery_temp(vin, battery_temp):
         temp_value = float(battery_temp)
     except (TypeError, ValueError):
         return
-    with tessie_anfrage_lock:
+    with batterie_temp_cache_lock:
         letzte_batterie_temp_pro_vin[vin] = temp_value
 
 
@@ -169,7 +183,7 @@ def _cached_battery_temp(vin):
     """Lese die letzte Batterietemperatur aus dem Cache."""
     if vin is None:
         return None
-    with tessie_anfrage_lock:
+    with batterie_temp_cache_lock:
         return letzte_batterie_temp_pro_vin.get(vin)
 
 """Utilities for serving a compatible Socket.IO client script.
@@ -300,6 +314,7 @@ def _ensure_background_started():
 def _ensure_background_started_once():
     _start_statistics_aggregation()
     _schedule_socketio_client_download()
+    _start_fleet_telemetry_listener()
 
 
 if hasattr(app, "before_first_request"):
@@ -665,6 +680,62 @@ def block_ip_clients():
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 DATA_DIR = os.path.join(BASE_DIR, "data")
 os.makedirs(DATA_DIR, exist_ok=True)
+TESLA_FLEET_KEY_DIR = os.path.join(DATA_DIR, "tesla_fleet")
+TESLA_FLEET_PUBLIC_KEY_PATH = os.getenv(
+    "TESLA_FLEET_PUBLIC_KEY_PATH",
+    os.path.join(TESLA_FLEET_KEY_DIR, "com.tesla.3p.public-key.pem"),
+)
+TESLA_FLEET_TELEMETRY_RUNTIME_FILE = os.path.join(
+    TESLA_FLEET_KEY_DIR,
+    "telemetry_runtime.json",
+)
+TESLA_FLEET_VEHICLES_FILE = os.path.join(TESLA_FLEET_KEY_DIR, "vehicles.json")
+TESLA_FLEET_TELEMETRY_STALE_SECONDS = float(
+    os.getenv("TESLA_FLEET_TELEMETRY_STALE_SECONDS", "300")
+)
+WARTUNGSMODUS_DATEI = os.path.join(DATA_DIR, "wartungsmodus_aktiv")
+
+
+def _wartungsmodus_aktiv():
+    """Prüfe, ob die öffentliche Weboberfläche eine Wartungsseite zeigen soll."""
+    env_wert = os.getenv("TESLA_DASHBOARD_WARTUNG")
+    if env_wert is not None:
+        return env_wert.strip().lower() not in {"", "0", "false", "no", "off"}
+    if os.getenv("PYTEST_CURRENT_TEST"):
+        return False
+    return os.path.exists(WARTUNGSMODUS_DATEI)
+
+
+def _wartungsmodus_bypass_pfad(pfad):
+    """Lasse technische Endpunkte trotz Wartungsmodus erreichbar."""
+    if pfad in {"/maintenance", "/robots.txt", "/favicon.ico"}:
+        return True
+    return pfad.startswith((
+        "/api/",
+        "/static/",
+        "/images/",
+        "/socket.io/",
+        "/.well-known/",
+    ))
+
+
+@app.before_request
+def _wartungsmodus_anzeigen():
+    """Zeige normalen Besuchern während Umstellungen eine Wartungsseite."""
+    if request.method != "GET":
+        return None
+    if not _wartungsmodus_aktiv():
+        return None
+    if _wartungsmodus_bypass_pfad(request.path):
+        return None
+    response = make_response(
+        render_template("wartung.html", version=__version__, year=CURRENT_YEAR),
+        503,
+    )
+    response.headers["Cache-Control"] = "no-store, no-cache, must-revalidate, max-age=0"
+    response.headers["Retry-After"] = "300"
+    response.headers["X-Robots-Tag"] = "noindex, nofollow"
+    return response
 
 
 def _vehicle_key(vehicle_id):
@@ -1146,6 +1217,47 @@ CONFIG_ITEMS = [
     {"id": "media-player", "desc": "Medienwiedergabe"},
     {"id": "park-since", "desc": "Parkdauer"},
 ]
+FLEET_TELEMETRIE_UNTERSTÜTZTE_CONFIG_AUSNAHMEN = {"supercharger-list"}
+OWNER_API_TOPLEVEL_FELDER = {
+    "access_type",
+    "api_version",
+    "ble_autopair_enrolled",
+    "cached_data",
+    "calendar_enabled",
+    "color",
+    "command_signing",
+    "device_type",
+    "granular_access",
+    "in_service",
+    "mobile_access_disabled",
+    "nearby_superchargers",
+    "option_codes",
+    "release_notes_supported",
+    "supercharger_payment_needed",
+    "supercharging_enabled",
+}
+
+
+def _config_mit_telemetrie_only_regeln(cfg):
+    """Entferne Optionen, die im reinen Fleet-Telemetry-Modus nicht gelten."""
+
+    cfg = dict(cfg or {})
+    cfg.pop("tessie_api_token", None)
+    if _nur_fleet_telemetrie_datenquelle():
+        for item_id in FLEET_TELEMETRIE_UNTERSTÜTZTE_CONFIG_AUSNAHMEN:
+            cfg[item_id] = False
+    return cfg
+
+
+def _config_items_fuer_anzeige():
+    """Gib die sichtbaren Konfigurationspunkte passend zur Datenquelle zurück."""
+
+    if not _nur_fleet_telemetrie_datenquelle():
+        return CONFIG_ITEMS
+    return [
+        item for item in CONFIG_ITEMS
+        if item.get("id") not in FLEET_TELEMETRIE_UNTERSTÜTZTE_CONFIG_AUSNAHMEN
+    ]
 
 
 _config_cache = {}
@@ -1389,6 +1501,9 @@ def get_news_events_info():
 
     global _news_events_unavailable
 
+    if _nur_fleet_telemetrie_datenquelle():
+        return ""
+
     tesla = get_tesla()
     if tesla is None or _news_events_unavailable:
         return ""
@@ -1489,6 +1604,9 @@ _trip_segment_cache = {}
 _aggregation_lock = threading.Lock()
 _aggregation_initialized = False
 _aggregation_thread = None
+_fleet_telemetry_thread = None
+_fleet_telemetry_lock = threading.Lock()
+_fleet_telemetry_vehicle_cache = {"mtime": None, "vehicles": []}
 
 
 def _force_statistics_rebuild_on_start():
@@ -3166,6 +3284,1235 @@ def _save_cached(vehicle_id, data):
             json.dump(data, f)
     except Exception:
         pass
+
+
+def _fleet_telemetrie_wahr(value):
+    """Wandle Telemetry-Werte in Boolesche Werte um."""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return abs(value) > 0.001
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "on", "yes"}
+    return bool(value)
+
+
+def _fleet_telemetrie_norm_text(value):
+    """Normalisiere Enum-Texte aus Fleet Telemetry."""
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _fleet_telemetrie_enum_suffix(value, prefix):
+    """Entferne einen bekannten Enum-Präfix aus einem Telemetry-Wert."""
+    text = _fleet_telemetrie_norm_text(value)
+    if text is None:
+        return None
+    if text.startswith(prefix):
+        text = text[len(prefix):]
+    return text or None
+
+
+def _fleet_telemetrie_shift(value):
+    """Wandle Fleet-Telemetry-Gangwerte in Dashboard-Werte um."""
+    text = _fleet_telemetrie_enum_suffix(value, "ShiftState")
+    if text in {"P", "R", "N", "D"}:
+        return text
+    return None
+
+
+def _fleet_telemetrie_ladestatus(value):
+    """Wandle Fleet-Telemetry-Ladestatus in vehicle_data-kompatible Werte um."""
+    text = _fleet_telemetrie_norm_text(value)
+    if text is None:
+        return None
+    for prefix in ("DetailedChargeState", "ChargeState"):
+        if text.startswith(prefix):
+            text = text[len(prefix):]
+            break
+    mapping = {
+        "Disconnected": "Disconnected",
+        "Standby": "Disconnected",
+        "NoPower": "NoPower",
+        "Starting": "Starting",
+        "Charging": "Charging",
+        "Complete": "Complete",
+        "Stopped": "Stopped",
+    }
+    return mapping.get(text)
+
+
+def _fleet_telemetrie_fensterwert(value):
+    """Wandle Fleet-Telemetry-Fensterstatus in Owner-API-nahe Werte um."""
+    text = _fleet_telemetrie_norm_text(value)
+    if text is None:
+        return 0
+    text = text.removeprefix("WindowState").lower()
+    if text in {"opened", "partiallyopen"}:
+        return 1
+    return 0
+
+
+def _fleet_telemetrie_hvac_aktiv(value):
+    """Gib zurück, ob ein HvacPower-Wert aktive Klimatisierung bedeutet."""
+    text = _fleet_telemetrie_norm_text(value)
+    if text is None:
+        return False
+    text = text.removeprefix("HvacPowerState")
+    return text in {"On", "Precondition", "OverheatProtect"}
+
+
+def _fleet_telemetrie_hvac_vorklimatisiert(value):
+    text = _fleet_telemetrie_norm_text(value)
+    if text is None:
+        return False
+    text = text.removeprefix("HvacPowerState")
+    return text == "Precondition"
+
+
+def _fleet_telemetrie_klimawächtermodus(value):
+    """Wandle Fleet-Klimawächtermodi in Owner-API-kompatible Werte um."""
+    mode = _fleet_telemetrie_enum_suffix(value, "ClimateKeeperModeState")
+    if not isinstance(mode, str):
+        return mode
+    mode = mode.lower()
+    if mode == "party":
+        return "camp"
+    return mode
+
+
+def _fleet_telemetrie_ungueltig(value):
+    """Erkenne Fleet-Telemetry-Werte ohne verwertbaren Inhalt."""
+    if isinstance(value, dict):
+        return value.get("invalid") is True
+    if isinstance(value, str):
+        return value.strip().lower() in {
+            "",
+            "invalid",
+            "<invalid>",
+            "nan",
+            "none",
+            "null",
+        }
+    return False
+
+
+def _fleet_telemetrie_wert(value):
+    """Gib den nutzbaren Telemetry-Wert oder None zurück."""
+    if _fleet_telemetrie_ungueltig(value):
+        return None
+    if isinstance(value, dict) and "value" in value:
+        return _fleet_telemetrie_wert(value.get("value"))
+    return value
+
+
+def _fleet_telemetrie_vergleichswert(value):
+    """Normalisiere Telemetry-Werte für stabile Änderungsvergleiche."""
+    value = _fleet_telemetrie_wert(value)
+    if isinstance(value, float):
+        return round(value, 6)
+    if isinstance(value, dict):
+        return {
+            key: _fleet_telemetrie_vergleichswert(value[key])
+            for key in sorted(value)
+        }
+    if isinstance(value, list):
+        return [_fleet_telemetrie_vergleichswert(item) for item in value]
+    return value
+
+
+def _fleet_telemetrie_wert_unveraendert(data, field, value):
+    """Prüfe, ob ein Telemetry-Feld bereits mit gleichem Wert im Cache liegt."""
+    rohwerte = data.get("fleet_telemetry_raw") if isinstance(data, dict) else None
+    if not isinstance(rohwerte, dict) or field not in rohwerte:
+        return False
+    alter_wert = _fleet_telemetrie_vergleichswert(rohwerte.get(field))
+    neuer_wert = _fleet_telemetrie_vergleichswert(value)
+    return alter_wert == neuer_wert
+
+
+def _fleet_telemetrie_entferne_fremddaten(data):
+    """Entferne aktive Anzeigen, die nur aus alten Owner-API-Abrufen stammen."""
+
+    if not isinstance(data, dict):
+        return data
+    for field in OWNER_API_TOPLEVEL_FELDER:
+        data.pop(field, None)
+    return data
+
+
+def _fleet_telemetrie_setze_media(media, key, value):
+    """Schreibe ein Media-Feld und entferne ungültige Werte."""
+    if value is None:
+        media.pop(key, None)
+    else:
+        media[key] = value
+
+
+def _fleet_telemetrie_setze_software_update(vehicle_state):
+    """Erzeuge die Owner-API-Struktur für Software-Updates."""
+    info = vehicle_state.get("software_update")
+    if not isinstance(info, dict):
+        info = {}
+        vehicle_state["software_update"] = info
+    return info
+
+
+def _fleet_telemetrie_tpms_warnungen(value):
+    """Normalisiere TPMS-Warnungen auf Owner-API-Reifenfelder."""
+    textteile = []
+    if value is None:
+        return {}
+    if isinstance(value, (list, tuple, set)):
+        textteile = [str(v).lower() for v in value]
+    elif isinstance(value, dict):
+        for key, aktiv in value.items():
+            if _fleet_telemetrie_wahr(aktiv):
+                textteile.append(str(key).lower())
+    else:
+        textteile = [str(value).lower()]
+    text = " ".join(textteile)
+    if not text.strip() or "none" in text:
+        return {"fl": False, "fr": False, "rl": False, "rr": False}
+    return {
+        "fl": "frontleft" in text or "fl" in text or "front_left" in text,
+        "fr": "frontright" in text or "fr" in text or "front_right" in text,
+        "rl": "rearleft" in text or "rl" in text or "rear_left" in text,
+        "rr": "rearright" in text or "rr" in text or "rear_right" in text,
+    }
+
+
+def _fleet_telemetrie_zeitstempel_ms(value):
+    """Konvertiere Telemetry-Zeitstempel für die UI in Millisekunden."""
+    if value is None:
+        return None
+    try:
+        numeric = float(value)
+    except Exception:
+        return value
+    if numeric and numeric < 1e12:
+        numeric *= 1000
+    return int(numeric)
+
+
+def _fleet_telemetrie_packleistung_aktualisieren(data):
+    """Berechne die Owner-API-nahe Leistungsanzeige aus Packwerten."""
+    charge = data.setdefault("charge_state", {})
+    drive = data.setdefault("drive_state", {})
+    spannung = _as_float(charge.get("pack_voltage"))
+    strom = _as_float(charge.get("pack_current"))
+    if spannung is None or strom is None:
+        return
+    packleistung = round(spannung * strom / 1000.0, 2)
+    charge["pack_power"] = packleistung
+    drive["power"] = -packleistung
+
+
+def _fleet_telemetrie_runtime_config():
+    """Lade die lokale Fleet-Telemetry-Laufzeitkonfiguration."""
+    cfg = {}
+    try:
+        with open(TESLA_FLEET_TELEMETRY_RUNTIME_FILE, "r", encoding="utf-8") as f:
+            loaded = json.load(f)
+            if isinstance(loaded, dict):
+                cfg.update(loaded)
+    except Exception:
+        pass
+    env_enabled = os.getenv("TESLA_FLEET_TELEMETRY_ENABLED")
+    if env_enabled is not None:
+        cfg["enabled"] = env_enabled.strip().lower() not in {
+            "",
+            "0",
+            "false",
+            "no",
+            "off",
+        }
+    cfg.setdefault("enabled", False)
+    cfg.setdefault("mqtt_host", os.getenv("TESLA_FLEET_TELEMETRY_MQTT_HOST", "127.0.0.1"))
+    cfg.setdefault(
+        "mqtt_port",
+        int(os.getenv("TESLA_FLEET_TELEMETRY_MQTT_PORT", "1884")),
+    )
+    cfg.setdefault("topic_base", os.getenv("TESLA_FLEET_TELEMETRY_TOPIC_BASE", "tesla"))
+    cfg.setdefault("client_id", "tesla-dashboard-telemetry")
+    return cfg
+
+
+def _fleet_telemetrie_aktiv():
+    """Prüfe, ob der Fleet-Telemetry-Empfang aktiviert ist."""
+    if os.getenv("PYTEST_CURRENT_TEST"):
+        return False
+    cfg = _fleet_telemetrie_runtime_config()
+    return bool(cfg.get("enabled"))
+
+
+def _fleet_telemetrie_fahrzeuge():
+    """Lade VIN-zu-Dashboard-ID-Zuordnungen für Telemetry-Themen."""
+    try:
+        mtime = os.path.getmtime(TESLA_FLEET_VEHICLES_FILE)
+    except OSError:
+        mtime = None
+    if _fleet_telemetry_vehicle_cache.get("mtime") == mtime:
+        return list(_fleet_telemetry_vehicle_cache.get("vehicles") or [])
+    vehicles = []
+    if mtime is not None:
+        try:
+            with open(TESLA_FLEET_VEHICLES_FILE, "r", encoding="utf-8") as f:
+                payload = json.load(f)
+            if isinstance(payload, dict):
+                raw_vehicles = payload.get("vehicles")
+            else:
+                raw_vehicles = payload
+            if isinstance(raw_vehicles, list):
+                vehicles = [v for v in raw_vehicles if isinstance(v, dict)]
+        except Exception:
+            vehicles = []
+    _fleet_telemetry_vehicle_cache["mtime"] = mtime
+    _fleet_telemetry_vehicle_cache["vehicles"] = vehicles
+    return list(vehicles)
+
+
+def _fleet_telemetrie_cache_ids(vin):
+    """Ermittle alle Dashboard-Cache-IDs für eine Telemetry-VIN."""
+    cache_ids = ["default"]
+    for vehicle in _fleet_telemetrie_fahrzeuge():
+        if str(vehicle.get("vin") or "") == str(vin):
+            for key in ("id_s", "id", "vehicle_id"):
+                value = vehicle.get(key)
+                if value is not None:
+                    cache_ids.append(str(value))
+            break
+    if _default_vehicle_id is not None:
+        cache_ids.append(str(_default_vehicle_id))
+    result = []
+    for cache_id in cache_ids:
+        if cache_id and cache_id not in result:
+            result.append(cache_id)
+    return result
+
+
+def _fleet_telemetrie_basisdaten(data, vin, cache_id, timestamp_ms):
+    """Erzeuge fehlende Dashboard-Unterstrukturen für Telemetry-Daten."""
+    if not isinstance(data, dict):
+        data = {}
+    _fleet_telemetrie_entferne_fremddaten(data)
+    data.setdefault("state", "online")
+    data["state"] = "online"
+    data.setdefault("id_s", cache_id if cache_id != "default" else _default_vehicle_id)
+    if vin:
+        data.setdefault("vin", vin)
+    for vehicle in _fleet_telemetrie_fahrzeuge():
+        if str(vehicle.get("vin") or "") == str(vin):
+            data.setdefault("id_s", str(vehicle.get("id_s") or vehicle.get("id") or data.get("id_s")))
+            data.setdefault("display_name", vehicle.get("display_name"))
+            break
+    data.setdefault("drive_state", {})
+    data.setdefault("charge_state", {})
+    data.setdefault("vehicle_state", {})
+    data.setdefault("climate_state", {})
+    data.setdefault("vehicle_config", {})
+    data["timestamp"] = timestamp_ms
+    data["fleet_telemetry_updated_at"] = timestamp_ms
+    return data
+
+
+def _fleet_telemetrie_setze_feld(data, field, value, timestamp_ms):
+    """Schreibe ein einzelnes Fleet-Telemetry-Feld in die Dashboard-Struktur."""
+    value = _fleet_telemetrie_wert(value)
+    data.setdefault("fleet_telemetry_raw", {})[field] = value
+    drive = data.setdefault("drive_state", {})
+    charge = data.setdefault("charge_state", {})
+    vehicle_state = data.setdefault("vehicle_state", {})
+    climate = data.setdefault("climate_state", {})
+    config = data.setdefault("vehicle_config", {})
+    gui = data.setdefault("gui_settings", {})
+
+    if field == "Location":
+        if isinstance(value, dict):
+            lat = value.get("latitude")
+            lon = value.get("longitude")
+            if lat is not None and lon is not None:
+                drive["latitude"] = lat
+                drive["longitude"] = lon
+                drive["native_latitude"] = lat
+                drive["native_longitude"] = lon
+                drive["native_location_supported"] = True
+                drive["native_type"] = "wgs"
+                drive["gps_as_of"] = timestamp_ms
+                drive["timestamp"] = timestamp_ms
+        return True
+    if field == "DestinationLocation":
+        if isinstance(value, dict):
+            lat = value.get("latitude")
+            lon = value.get("longitude")
+            if lat is not None and lon is not None:
+                drive["active_route_latitude"] = lat
+                drive["active_route_longitude"] = lon
+            else:
+                drive.pop("active_route_latitude", None)
+                drive.pop("active_route_longitude", None)
+        elif value is None:
+            drive.pop("active_route_latitude", None)
+            drive.pop("active_route_longitude", None)
+        drive["timestamp"] = timestamp_ms
+        return True
+    if field == "DestinationName":
+        if value is None:
+            drive.pop("active_route_destination", None)
+        else:
+            drive["active_route_destination"] = value
+        drive["timestamp"] = timestamp_ms
+        return True
+    if field == "ExpectedEnergyPercentAtTripArrival":
+        drive["active_route_energy_at_arrival"] = value
+        drive["timestamp"] = timestamp_ms
+        return True
+    if field == "MilesToArrival":
+        drive["active_route_miles_to_arrival"] = value
+        drive["timestamp"] = timestamp_ms
+        return True
+    if field == "MinutesToArrival":
+        drive["active_route_minutes_to_arrival"] = value
+        drive["timestamp"] = timestamp_ms
+        return True
+    if field == "RouteTrafficMinutesDelay":
+        drive["active_route_traffic_minutes_delay"] = value
+        drive["timestamp"] = timestamp_ms
+        return True
+    if field == "GpsHeading":
+        drive["heading"] = value
+        drive["timestamp"] = timestamp_ms
+        return True
+    if field == "GpsState":
+        drive["gps_state"] = value
+        drive["timestamp"] = timestamp_ms
+        return True
+    if field == "VehicleSpeed":
+        drive["speed"] = value
+        drive["timestamp"] = timestamp_ms
+        return True
+    if field == "Gear":
+        drive["shift_state"] = _fleet_telemetrie_shift(value)
+        drive["timestamp"] = timestamp_ms
+        return True
+
+    if field in {"BatteryLevel", "Soc"}:
+        charge["battery_level"] = value
+        charge["usable_battery_level"] = value
+        charge["timestamp"] = timestamp_ms
+        return True
+    if field in {"DetailedChargeState", "ChargeState"}:
+        ladestatus = _fleet_telemetrie_ladestatus(value)
+        if ladestatus is not None:
+            charge["charging_state"] = ladestatus
+        charge["timestamp"] = timestamp_ms
+        return True
+    if field == "ChargeLimitSoc":
+        charge["charge_limit_soc"] = value
+        charge["timestamp"] = timestamp_ms
+        return True
+    if field == "EstBatteryRange":
+        charge["est_battery_range"] = value
+        charge["battery_range"] = value
+        charge["timestamp"] = timestamp_ms
+        return True
+    if field == "IdealBatteryRange":
+        charge["ideal_battery_range"] = value
+        charge["timestamp"] = timestamp_ms
+        return True
+    if field == "RatedRange":
+        charge["battery_range"] = value
+        charge["timestamp"] = timestamp_ms
+        return True
+    if field == "TimeToFullCharge":
+        charge["time_to_full_charge"] = value
+        try:
+            charge["minutes_to_full_charge"] = int(round(float(value) * 60))
+        except Exception:
+            charge.pop("minutes_to_full_charge", None)
+        charge["timestamp"] = timestamp_ms
+        return True
+    if field == "EstimatedHoursToChargeTermination":
+        charge["time_to_full_charge"] = value
+        try:
+            charge["minutes_to_full_charge"] = int(round(float(value) * 60))
+        except Exception:
+            charge.pop("minutes_to_full_charge", None)
+        charge["timestamp"] = timestamp_ms
+        return True
+    if field == "ChargeAmps":
+        charge["charge_amps"] = value
+        charge["charger_actual_current"] = value
+        charge["timestamp"] = timestamp_ms
+        return True
+    if field == "ChargeRateMilePerHour":
+        charge["charge_rate"] = value
+        charge["timestamp"] = timestamp_ms
+        return True
+    if field in {"ACChargingPower", "DCChargingPower"}:
+        charge["charger_power"] = value
+        charge["timestamp"] = timestamp_ms
+        return True
+    if field in {"ACChargingEnergyIn", "DCChargingEnergyIn"}:
+        if field == "ACChargingEnergyIn":
+            charge["ac_charge_energy_added"] = value
+        else:
+            charge["dc_charge_energy_added"] = value
+        if value is not None:
+            charge["charge_energy_added"] = value
+            data["last_charge_energy_added"] = value
+        charge["timestamp"] = timestamp_ms
+        return True
+    if field in {"ModuleTempMin", "ModuleTempMax"}:
+        target = "module_temp_min" if field == "ModuleTempMin" else "module_temp_max"
+        charge[target] = value
+        temp_min = _as_float(charge.get("module_temp_min"))
+        temp_max = _as_float(charge.get("module_temp_max"))
+        if temp_min is not None and temp_max is not None:
+            charge["battery_temp"] = (temp_min + temp_max) / 2
+        elif temp_min is not None:
+            charge["battery_temp"] = temp_min
+        elif temp_max is not None:
+            charge["battery_temp"] = temp_max
+        charge["timestamp"] = timestamp_ms
+        return True
+    if field in {"PackVoltage", "PackCurrent"}:
+        target = "pack_voltage" if field == "PackVoltage" else "pack_current"
+        charge[target] = value
+        _fleet_telemetrie_packleistung_aktualisieren(data)
+        charge["timestamp"] = timestamp_ms
+        drive["timestamp"] = timestamp_ms
+        return True
+    if field == "ChargeCurrentRequest":
+        charge["charge_current_request"] = value
+        charge["timestamp"] = timestamp_ms
+        return True
+    if field == "ChargeCurrentRequestMax":
+        charge["charge_current_request_max"] = value
+        charge["timestamp"] = timestamp_ms
+        return True
+    if field == "ChargeEnableRequest":
+        charge["charge_enable_request"] = value
+        charge["user_charge_enable_request"] = value
+        charge["timestamp"] = timestamp_ms
+        return True
+    if field == "ChargerPhases":
+        charge["charger_phases"] = value
+        charge["timestamp"] = timestamp_ms
+        return True
+    if field == "ChargerVoltage":
+        charge["charger_voltage"] = value
+        charge["timestamp"] = timestamp_ms
+        return True
+    if field == "ChargePortDoorOpen":
+        charge["charge_port_door_open"] = _fleet_telemetrie_wahr(value)
+        charge["timestamp"] = timestamp_ms
+        return True
+    if field == "ChargePortColdWeatherMode":
+        charge["charge_port_cold_weather_mode"] = _fleet_telemetrie_wahr(value)
+        charge["timestamp"] = timestamp_ms
+        return True
+    if field == "ChargePortLatch":
+        charge["charge_port_latch"] = _fleet_telemetrie_enum_suffix(
+            value,
+            "ChargePortLatch",
+        )
+        charge["timestamp"] = timestamp_ms
+        return True
+    if field == "ChargePort":
+        charge_port_type = _fleet_telemetrie_enum_suffix(value, "ChargePort")
+        charge["charge_port_type"] = charge_port_type
+        config["charge_port_type"] = charge_port_type
+        charge["timestamp"] = timestamp_ms
+        config["timestamp"] = timestamp_ms
+        return True
+    if field == "FastChargerPresent":
+        charge["fast_charger_present"] = _fleet_telemetrie_wahr(value)
+        charge["timestamp"] = timestamp_ms
+        return True
+    if field == "FastChargerType":
+        charge["fast_charger_type"] = _fleet_telemetrie_enum_suffix(value, "FastCharger")
+        charge["timestamp"] = timestamp_ms
+        return True
+    if field == "ChargingCableType":
+        charge["conn_charge_cable"] = _fleet_telemetrie_enum_suffix(
+            value,
+            "ChargingCableType",
+        )
+        charge["timestamp"] = timestamp_ms
+        return True
+    if field == "PreconditioningEnabled":
+        charge["preconditioning_enabled"] = _fleet_telemetrie_wahr(value)
+        charge["timestamp"] = timestamp_ms
+        return True
+    if field == "NotEnoughPowerToHeat":
+        charge["not_enough_power_to_heat"] = _fleet_telemetrie_wahr(value)
+        climate["battery_heater_no_power"] = charge["not_enough_power_to_heat"]
+        charge["timestamp"] = timestamp_ms
+        climate["timestamp"] = timestamp_ms
+        return True
+    if field == "ScheduledChargingMode":
+        charge["scheduled_charging_mode"] = _fleet_telemetrie_enum_suffix(
+            value,
+            "ScheduledChargingMode",
+        )
+        charge["timestamp"] = timestamp_ms
+        return True
+    if field == "ScheduledChargingPending":
+        charge["scheduled_charging_pending"] = _fleet_telemetrie_wahr(value)
+        charge["timestamp"] = timestamp_ms
+        return True
+    if field == "ScheduledChargingStartTime":
+        charge["scheduled_charging_start_time"] = _fleet_telemetrie_zeitstempel_ms(value)
+        charge["timestamp"] = timestamp_ms
+        return True
+    if field == "SuperchargerSessionTripPlanner":
+        charge["supercharger_session_trip_planner"] = _fleet_telemetrie_wahr(value)
+        charge["timestamp"] = timestamp_ms
+        return True
+    if field == "BatteryHeaterOn":
+        charge["battery_heater_on"] = _fleet_telemetrie_wahr(value)
+        climate["battery_heater_on"] = charge["battery_heater_on"]
+        climate["battery_heater"] = charge["battery_heater_on"]
+        charge["timestamp"] = timestamp_ms
+        climate["timestamp"] = timestamp_ms
+        return True
+
+    if field == "Locked":
+        vehicle_state["locked"] = _fleet_telemetrie_wahr(value)
+        vehicle_state["timestamp"] = timestamp_ms
+        return True
+    if field == "DoorState" and isinstance(value, dict):
+        mapping = {
+            "DriverFront": "df",
+            "PassengerFront": "pf",
+            "DriverRear": "dr",
+            "PassengerRear": "pr",
+            "TrunkFront": "ft",
+            "TrunkRear": "rt",
+        }
+        for source, target in mapping.items():
+            if source in value:
+                vehicle_state[target] = 1 if _fleet_telemetrie_wahr(value.get(source)) else 0
+        vehicle_state["timestamp"] = timestamp_ms
+        return True
+    if field in {"FdWindow", "FpWindow", "RdWindow", "RpWindow"}:
+        owner_key = {
+            "FdWindow": "fd_window",
+            "FpWindow": "fp_window",
+            "RdWindow": "rd_window",
+            "RpWindow": "rp_window",
+        }[field]
+        vehicle_state[owner_key] = _fleet_telemetrie_fensterwert(value)
+        vehicle_state["timestamp"] = timestamp_ms
+        return True
+    if field == "Odometer":
+        vehicle_state["odometer"] = value
+        vehicle_state["timestamp"] = timestamp_ms
+        return True
+    if field == "VehicleName":
+        vehicle_state["vehicle_name"] = value
+        data["display_name"] = value
+        vehicle_state["timestamp"] = timestamp_ms
+        return True
+    if field == "Version":
+        vehicle_state["car_version"] = value
+        vehicle_state["timestamp"] = timestamp_ms
+        return True
+    if field == "ServiceMode":
+        vehicle_state["service_mode"] = _fleet_telemetrie_wahr(value)
+        vehicle_state["timestamp"] = timestamp_ms
+        return True
+    if field == "ValetModeEnabled":
+        vehicle_state["valet_mode"] = _fleet_telemetrie_wahr(value)
+        vehicle_state["timestamp"] = timestamp_ms
+        return True
+    if field == "DriverSeatOccupied":
+        vehicle_state["is_user_present"] = _fleet_telemetrie_wahr(value)
+        vehicle_state["driver_present"] = vehicle_state["is_user_present"]
+        vehicle_state["timestamp"] = timestamp_ms
+        return True
+    if field == "BrakePedal":
+        vehicle_state["brake_pedal"] = _fleet_telemetrie_wahr(value)
+        vehicle_state["timestamp"] = timestamp_ms
+        return True
+    if field == "BrakePedalPos":
+        vehicle_state["brake_pedal_pos"] = value
+        vehicle_state["timestamp"] = timestamp_ms
+        return True
+    if field == "CenterDisplay":
+        vehicle_state["center_display_state"] = _fleet_telemetrie_enum_suffix(
+            value,
+            "DisplayState",
+        )
+        vehicle_state["timestamp"] = timestamp_ms
+        return True
+    if field == "HomelinkDeviceCount":
+        vehicle_state["homelink_device_count"] = value
+        vehicle_state["homelink_nearby"] = bool(value)
+        vehicle_state["timestamp"] = timestamp_ms
+        return True
+    if field == "HomelinkNearby":
+        vehicle_state["homelink_nearby"] = _fleet_telemetrie_wahr(value)
+        vehicle_state["timestamp"] = timestamp_ms
+        return True
+    if field == "SentryMode":
+        vehicle_state["sentry_mode"] = _fleet_telemetrie_enum_suffix(
+            value,
+            "SentryModeState",
+        )
+        vehicle_state["timestamp"] = timestamp_ms
+        return True
+    if field == "RemoteStartEnabled":
+        vehicle_state["remote_start_enabled"] = _fleet_telemetrie_wahr(value)
+        vehicle_state["timestamp"] = timestamp_ms
+        return True
+    if field == "SpeedLimitMode":
+        speed_limit = vehicle_state.setdefault("speed_limit_mode", {})
+        speed_limit["active"] = _fleet_telemetrie_wahr(value)
+        vehicle_state["timestamp"] = timestamp_ms
+        return True
+    if field == "CurrentLimitMph":
+        speed_limit = vehicle_state.setdefault("speed_limit_mode", {})
+        speed_limit["current_limit_mph"] = value
+        vehicle_state["timestamp"] = timestamp_ms
+        return True
+    if field == "LightsHazardsActive":
+        vehicle_state["lights_hazards_active"] = _fleet_telemetrie_wahr(value)
+        vehicle_state["timestamp"] = timestamp_ms
+        return True
+    if field == "LightsTurnSignal":
+        vehicle_state["lights_turn_signal"] = _fleet_telemetrie_enum_suffix(
+            value,
+            "TurnSignalState",
+        )
+        vehicle_state["timestamp"] = timestamp_ms
+        return True
+    if field == "LightsHighBeams":
+        vehicle_state["lights_high_beams"] = _fleet_telemetrie_wahr(value)
+        vehicle_state["timestamp"] = timestamp_ms
+        return True
+    if field.startswith("SoftwareUpdate"):
+        software = _fleet_telemetrie_setze_software_update(vehicle_state)
+        if field == "SoftwareUpdateDownloadPercentComplete":
+            software["download_perc"] = value
+        elif field == "SoftwareUpdateInstallationPercentComplete":
+            software["install_perc"] = value
+        elif field == "SoftwareUpdateExpectedDurationMinutes":
+            try:
+                software["expected_duration_sec"] = int(float(value) * 60)
+            except Exception:
+                software.pop("expected_duration_sec", None)
+        elif field == "SoftwareUpdateScheduledStartTime":
+            software["scheduled_time_ms"] = _fleet_telemetrie_zeitstempel_ms(value)
+        elif field == "SoftwareUpdateVersion":
+            software["version"] = "" if value is None else str(value)
+        vehicle_state["timestamp"] = timestamp_ms
+        return True
+    tpms_pressure_map = {
+        "TpmsPressureFl": "tpms_pressure_fl",
+        "TpmsPressureFr": "tpms_pressure_fr",
+        "TpmsPressureRl": "tpms_pressure_rl",
+        "TpmsPressureRr": "tpms_pressure_rr",
+    }
+    if field in tpms_pressure_map:
+        vehicle_state[tpms_pressure_map[field]] = value
+        vehicle_state["timestamp"] = timestamp_ms
+        return True
+    tpms_time_map = {
+        "TpmsLastSeenPressureTimeFl": "tpms_last_seen_pressure_time_fl",
+        "TpmsLastSeenPressureTimeFr": "tpms_last_seen_pressure_time_fr",
+        "TpmsLastSeenPressureTimeRl": "tpms_last_seen_pressure_time_rl",
+        "TpmsLastSeenPressureTimeRr": "tpms_last_seen_pressure_time_rr",
+    }
+    if field in tpms_time_map:
+        vehicle_state[tpms_time_map[field]] = _fleet_telemetrie_zeitstempel_ms(value)
+        vehicle_state["timestamp"] = timestamp_ms
+        return True
+    if field in {"TpmsHardWarnings", "TpmsSoftWarnings"}:
+        prefix = "tpms_hard_warning" if field == "TpmsHardWarnings" else "tpms_soft_warning"
+        for reifen, aktiv in _fleet_telemetrie_tpms_warnungen(value).items():
+            vehicle_state[f"{prefix}_{reifen}"] = aktiv
+        vehicle_state["timestamp"] = timestamp_ms
+        return True
+    if field.startswith("Media"):
+        media = vehicle_state.setdefault("media_info", {})
+        media_map = {
+            "MediaAudioVolume": "audio_volume",
+            "MediaAudioVolumeIncrement": "audio_volume_increment",
+            "MediaAudioVolumeMax": "audio_volume_max",
+            "MediaNowPlayingAlbum": "now_playing_album",
+            "MediaNowPlayingArtist": "now_playing_artist",
+            "MediaNowPlayingDuration": "now_playing_duration",
+            "MediaNowPlayingElapsed": "now_playing_elapsed",
+            "MediaNowPlayingStation": "now_playing_station",
+            "MediaNowPlayingTitle": "now_playing_title",
+            "MediaPlaybackSource": "now_playing_source",
+            "MediaPlaybackStatus": "media_playback_status",
+        }
+        target = media_map.get(field)
+        if target:
+            if field == "MediaPlaybackStatus":
+                value = _fleet_telemetrie_enum_suffix(value, "MediaStatus")
+            _fleet_telemetrie_setze_media(media, target, value)
+        vehicle_state["timestamp"] = timestamp_ms
+        return True
+
+    if field == "InsideTemp":
+        climate["inside_temp"] = value
+        climate["timestamp"] = timestamp_ms
+        return True
+    if field == "OutsideTemp":
+        climate["outside_temp"] = value
+        climate["timestamp"] = timestamp_ms
+        return True
+    if field == "HvacPower":
+        climate["is_climate_on"] = _fleet_telemetrie_hvac_aktiv(value)
+        climate["is_auto_conditioning_on"] = climate["is_climate_on"]
+        climate["is_preconditioning"] = _fleet_telemetrie_hvac_vorklimatisiert(value)
+        climate["timestamp"] = timestamp_ms
+        return True
+    if field in {"HvacFanSpeed", "HvacFanStatus"}:
+        climate["fan_status"] = value
+        climate["timestamp"] = timestamp_ms
+        return True
+    if field == "HvacAutoMode":
+        climate["hvac_auto_request"] = _fleet_telemetrie_enum_suffix(
+            value,
+            "HvacAutoModeState",
+        )
+        climate["timestamp"] = timestamp_ms
+        return True
+    if field == "HvacLeftTemperatureRequest":
+        climate["driver_temp_setting"] = value
+        climate["timestamp"] = timestamp_ms
+        return True
+    if field == "HvacRightTemperatureRequest":
+        climate["passenger_temp_setting"] = value
+        climate["timestamp"] = timestamp_ms
+        return True
+    if field == "ClimateKeeperMode":
+        climate["climate_keeper_mode"] = _fleet_telemetrie_klimawächtermodus(value)
+        climate["timestamp"] = timestamp_ms
+        return True
+    if field == "CabinOverheatProtectionMode":
+        climate["cabin_overheat_protection"] = _fleet_telemetrie_enum_suffix(
+            value,
+            "CabinOverheatProtectionModeState",
+        )
+        climate["timestamp"] = timestamp_ms
+        return True
+    if field == "CabinOverheatProtectionTemperatureLimit":
+        limit = _fleet_telemetrie_enum_suffix(
+            value,
+            "CabinOverheatProtectionTempLimit",
+        )
+        limit = _fleet_telemetrie_enum_suffix(
+            limit,
+            "ClimateOverheatProtectionTempLimit",
+        )
+        climate["cop_activation_temperature"] = limit
+        climate["timestamp"] = timestamp_ms
+        return True
+    if field == "DefrostMode":
+        defrost = _fleet_telemetrie_enum_suffix(value, "DefrostModeState")
+        climate["defrost_mode"] = defrost
+        climate["is_front_defroster_on"] = bool(defrost and str(defrost).lower() != "off")
+        climate["timestamp"] = timestamp_ms
+        return True
+    if field == "DefrostForPreconditioning":
+        climate["is_front_defroster_on"] = _fleet_telemetrie_wahr(value)
+        climate["timestamp"] = timestamp_ms
+        return True
+    if field == "RearDefrostEnabled":
+        climate["is_rear_defroster_on"] = _fleet_telemetrie_wahr(value)
+        climate["timestamp"] = timestamp_ms
+        return True
+    if field == "WiperHeatEnabled":
+        climate["wiper_blade_heater"] = _fleet_telemetrie_wahr(value)
+        climate["timestamp"] = timestamp_ms
+        return True
+    if field == "HvacSteeringWheelHeatLevel":
+        climate["steering_wheel_heat_level"] = value
+        try:
+            climate["steering_wheel_heater"] = float(value) > 0
+        except Exception:
+            climate["steering_wheel_heater"] = _fleet_telemetrie_wahr(value)
+        climate["timestamp"] = timestamp_ms
+        return True
+    if field == "HvacSteeringWheelHeatAuto":
+        climate["auto_steering_wheel_heat"] = _fleet_telemetrie_wahr(value)
+        climate["timestamp"] = timestamp_ms
+        return True
+    seat_heater_map = {
+        "SeatHeaterLeft": "seat_heater_left",
+        "SeatHeaterRight": "seat_heater_right",
+        "SeatHeaterRearLeft": "seat_heater_rear_left",
+        "SeatHeaterRearCenter": "seat_heater_rear_center",
+        "SeatHeaterRearRight": "seat_heater_rear_right",
+    }
+    if field in seat_heater_map:
+        climate[seat_heater_map[field]] = value
+        climate["timestamp"] = timestamp_ms
+        return True
+    seat_cooling_map = {
+        "ClimateSeatCoolingFrontLeft": "seat_fan_front_left",
+        "ClimateSeatCoolingFrontRight": "seat_fan_front_right",
+    }
+    if field in seat_cooling_map:
+        climate[seat_cooling_map[field]] = value
+        climate["timestamp"] = timestamp_ms
+        return True
+
+    if field == "CarType":
+        config["car_type"] = _fleet_telemetrie_enum_suffix(value, "CarType")
+        config["timestamp"] = timestamp_ms
+        return True
+    if field == "EfficiencyPackage":
+        config["efficiency_package"] = value
+        config["timestamp"] = timestamp_ms
+        return True
+    if field == "Trim":
+        config["trim_badging"] = value
+        config["timestamp"] = timestamp_ms
+        return True
+    if field == "ExteriorColor":
+        config["exterior_color"] = value
+        config["timestamp"] = timestamp_ms
+        return True
+    if field == "WheelType":
+        config["wheel_type"] = value
+        config["timestamp"] = timestamp_ms
+        return True
+    if field == "EuropeVehicle":
+        config["eu_vehicle"] = _fleet_telemetrie_wahr(value)
+        config["timestamp"] = timestamp_ms
+        return True
+    if field == "RearSeatHeaters":
+        config["rear_seat_heaters"] = value
+        config["timestamp"] = timestamp_ms
+        return True
+    if field == "RightHandDrive":
+        config["rhd"] = _fleet_telemetrie_wahr(value)
+        config["timestamp"] = timestamp_ms
+        return True
+    if field == "RoofColor":
+        config["roof_color"] = value
+        config["timestamp"] = timestamp_ms
+        return True
+    if field == "SunroofInstalled":
+        config["sun_roof_installed"] = _fleet_telemetrie_enum_suffix(
+            value,
+            "SunroofInstalledState",
+        )
+        config["timestamp"] = timestamp_ms
+        return True
+
+    if field == "Setting24HourTime":
+        gui["gui_24_hour_time"] = _fleet_telemetrie_wahr(value)
+        gui["timestamp"] = timestamp_ms
+        return True
+    if field == "SettingChargeUnit":
+        gui["gui_charge_rate_units"] = _fleet_telemetrie_enum_suffix(
+            value,
+            "ChargeUnitPreference",
+        )
+        gui["timestamp"] = timestamp_ms
+        return True
+    if field == "SettingDistanceUnit":
+        gui["gui_distance_units"] = _fleet_telemetrie_enum_suffix(
+            value,
+            "DistanceUnit",
+        )
+        gui["timestamp"] = timestamp_ms
+        return True
+    if field == "SettingTemperatureUnit":
+        gui["gui_temperature_units"] = _fleet_telemetrie_enum_suffix(
+            value,
+            "TemperatureUnit",
+        )
+        gui["timestamp"] = timestamp_ms
+        return True
+    if field == "SettingTirePressureUnit":
+        gui["gui_tirepressure_units"] = _fleet_telemetrie_enum_suffix(
+            value,
+            "PressureUnit",
+        )
+        gui["timestamp"] = timestamp_ms
+        return True
+
+    return True
+
+
+def _fleet_telemetrie_dashboard_daten_anreichern(cache_id, data):
+    """Aktualisiere abgeleitete Dashboard-Daten für Telemetry-Ereignisse."""
+    if not isinstance(data, dict):
+        return data
+
+    try:
+        track_park_time(data)
+        data["park_start"] = park_start_ms
+        data["park_duration"] = park_duration_string(park_start_ms)
+    except Exception:
+        pass
+
+    try:
+        track_drive_path(data)
+        data["path"] = trip_path
+    except Exception:
+        pass
+
+    drive = data.get("drive_state")
+    if not isinstance(drive, dict):
+        return data
+    lat = drive.get("latitude")
+    lon = drive.get("longitude")
+    if lat is not None and lon is not None:
+        try:
+            entry = address_cache.get(cache_id)
+            now = time.time()
+            needs_update = (
+                entry is None
+                or now - entry.get("ts", 0) >= 5
+                or abs(entry.get("lat") - lat) > 1e-4
+                or abs(entry.get("lon") - lon) > 1e-4
+            )
+            if needs_update:
+                result = reverse_geocode(lat, lon, cache_id)
+                addr = result.get("address")
+                if addr:
+                    address_cache[cache_id] = {
+                        "lat": lat,
+                        "lon": lon,
+                        "address": addr,
+                        "ts": now,
+                    }
+            entry = address_cache.get(cache_id)
+            if entry and entry.get("address"):
+                data["location_address"] = entry["address"]
+            else:
+                data.pop("location_address", None)
+        except Exception:
+            pass
+    return data
+
+
+def _fleet_telemetrie_cache_aktualisieren(vin, field, value, timestamp_ms=None):
+    """Übernehme ein MQTT-Telemetry-Feld in Cache, Live-Daten und Streams."""
+    if timestamp_ms is None:
+        timestamp_ms = int(time.time() * 1000)
+    value = _fleet_telemetrie_wert(value)
+    aktualisierte_daten = []
+    with _fleet_telemetry_lock:
+        for cache_id in _fleet_telemetrie_cache_ids(vin):
+            data = latest_data.get(cache_id)
+            if not isinstance(data, dict):
+                data = _load_cached(cache_id) or {}
+            if _fleet_telemetrie_wert_unveraendert(data, field, value):
+                continue
+            data = _fleet_telemetrie_basisdaten(data, vin, cache_id, timestamp_ms)
+            if not _fleet_telemetrie_setze_feld(data, field, value, timestamp_ms):
+                continue
+            data["state_checked_at"] = timestamp_ms
+            data["fleet_telemetry_last_field"] = field
+            data["preconditioning_display_allowed"] = (
+                _vorklimatisierung_im_stand_erlaubt(data)
+            )
+            data = _fleet_telemetrie_dashboard_daten_anreichern(cache_id, data)
+            data["_live"] = True
+            data.pop("api_error", None)
+            latest_data[cache_id] = data
+            try:
+                cached_copy = dict(data)
+                cached_copy.pop("_live", None)
+                cached_copy.pop("state_checked_at", None)
+                _save_cached(cache_id, cached_copy)
+            except Exception:
+                pass
+            aktualisierte_daten.append((cache_id, data))
+    for cache_id, data in aktualisierte_daten:
+        for q in subscribers.get(cache_id, []):
+            q.put(data)
+    return bool(aktualisierte_daten)
+
+
+def _fleet_telemetrie_verbindungsstatus_state(status):
+    """Wandle Fleet-Telemetry-Connectivity-Status in Dashboard-State um."""
+    if status is None:
+        return None
+    status_text = str(status).strip().lower()
+    if status_text == "connected":
+        return "online"
+    if status_text == "disconnected":
+        return "disconnected"
+    return None
+
+
+def _fleet_telemetrie_verbindung_aktualisieren(vin, payload, timestamp_ms=None):
+    """Übernehme Fleet-Telemetry-Verbindungsereignisse in den Cache."""
+    if timestamp_ms is None:
+        timestamp_ms = int(time.time() * 1000)
+    status = None
+    if isinstance(payload, dict):
+        status = payload.get("Status") or payload.get("status")
+    state = _fleet_telemetrie_verbindungsstatus_state(status)
+    if state is None:
+        return False
+    aktualisierte_daten = []
+    with _fleet_telemetry_lock:
+        for cache_id in _fleet_telemetrie_cache_ids(vin):
+            data = latest_data.get(cache_id)
+            if not isinstance(data, dict):
+                data = _load_cached(cache_id) or {}
+            data = _fleet_telemetrie_basisdaten(data, vin, cache_id, timestamp_ms)
+            data["state"] = state
+            data["state_checked_at"] = timestamp_ms
+            data["fleet_telemetry_connectivity"] = payload
+            data["_live"] = True
+            latest_data[cache_id] = data
+            try:
+                cached_copy = dict(data)
+                cached_copy.pop("_live", None)
+                cached_copy.pop("state_checked_at", None)
+                _save_cached(cache_id, cached_copy)
+            except Exception:
+                pass
+            aktualisierte_daten.append((cache_id, data))
+    for cache_id, data in aktualisierte_daten:
+        for q in subscribers.get(cache_id, []):
+            q.put(data)
+    return bool(aktualisierte_daten)
+
+
+def _fleet_telemetrie_decode_payload(payload):
+    """Dekodiere MQTT-Nutzdaten aus Fleet Telemetry."""
+    if isinstance(payload, bytes):
+        payload = payload.decode("utf-8", errors="replace")
+    try:
+        return json.loads(payload)
+    except Exception:
+        return payload
+
+
+def _fleet_telemetrie_mqtt_message(topic, payload, cfg=None):
+    """Verarbeite eine einzelne MQTT-Nachricht aus Fleet Telemetry."""
+    if cfg is None:
+        cfg = _fleet_telemetrie_runtime_config()
+    topic_base = str(cfg.get("topic_base") or "tesla").strip("/")
+    parts = topic.split("/")
+    if len(parts) < 3 or parts[0] != topic_base:
+        return False
+    vin = parts[1]
+    typ = parts[2]
+    value = _fleet_telemetrie_decode_payload(payload)
+    if typ == "v" and len(parts) >= 4:
+        field = "/".join(parts[3:])
+        return _fleet_telemetrie_cache_aktualisieren(vin, field, value)
+    if typ == "connectivity":
+        return _fleet_telemetrie_verbindung_aktualisieren(vin, value)
+    return False
+
+
+def _fleet_telemetrie_listener_loop():
+    """Höre auf MQTT-Daten des Fleet-Telemetry-Servers."""
+    cfg = _fleet_telemetrie_runtime_config()
+    if not cfg.get("enabled"):
+        return
+    if paho_mqtt is None:
+        logging.warning("paho-mqtt fehlt; Fleet-Telemetry-Empfang ist deaktiviert")
+        return
+
+    topic_base = str(cfg.get("topic_base") or "tesla").strip("/")
+    mqtt_host = str(cfg.get("mqtt_host") or "127.0.0.1")
+    mqtt_port = int(cfg.get("mqtt_port") or 1884)
+    client_id_basis = str(cfg.get("client_id") or "tesla-dashboard-telemetry")
+    client_id = f"{client_id_basis}-{os.getpid()}"
+
+    def _on_connect(client, _userdata, _flags, reason_code, _properties=None):
+        try:
+            rc = int(reason_code)
+        except Exception:
+            rc = getattr(reason_code, "value", 0)
+        if str(reason_code).lower() == "success":
+            rc = 0
+        if rc == 0:
+            client.subscribe(f"{topic_base}/#", qos=0)
+            logging.info("Fleet-Telemetry-MQTT verbunden: %s:%s", mqtt_host, mqtt_port)
+        else:
+            logging.warning("Fleet-Telemetry-MQTT-Verbindung fehlgeschlagen: rc=%s", rc)
+
+    def _on_message(_client, _userdata, message):
+        try:
+            _fleet_telemetrie_mqtt_message(message.topic, message.payload, cfg)
+        except Exception:
+            logging.exception("Fleet-Telemetry-MQTT-Nachricht konnte nicht verarbeitet werden")
+
+    while _fleet_telemetrie_aktiv():
+        if hasattr(paho_mqtt, "CallbackAPIVersion"):
+            client = paho_mqtt.Client(
+                callback_api_version=paho_mqtt.CallbackAPIVersion.VERSION2,
+                client_id=client_id,
+            )
+        else:
+            client = paho_mqtt.Client(client_id=client_id)
+        client.on_connect = _on_connect
+        client.on_message = _on_message
+        try:
+            client.connect(mqtt_host, mqtt_port, keepalive=30)
+            client.loop_forever(retry_first_connection=True)
+        except Exception as exc:
+            logging.warning("Fleet-Telemetry-MQTT getrennt: %s", exc)
+            time.sleep(10)
+        finally:
+            try:
+                client.disconnect()
+            except Exception:
+                pass
+
+
+def _start_fleet_telemetry_listener():
+    """Starte den lokalen Fleet-Telemetry-MQTT-Listener."""
+    global _fleet_telemetry_thread
+    if not _fleet_telemetrie_aktiv():
+        return
+    if _fleet_telemetry_thread is not None and _fleet_telemetry_thread.is_alive():
+        return
+    _fleet_telemetry_thread = threading.Thread(
+        target=_fleet_telemetrie_listener_loop,
+        daemon=True,
+    )
+    _fleet_telemetry_thread.start()
+
+
+def _fleet_telemetrie_cache_fuer_dashboard(cache_id, cached=None):
+    """Gib Telemetry-Cache zurück, wenn er im Telemetry-Modus nutzbar ist."""
+    if not _fleet_telemetrie_aktiv():
+        return None
+    data = latest_data.get(cache_id)
+    if not isinstance(data, dict):
+        data = cached if isinstance(cached, dict) else _load_cached(cache_id)
+    if not isinstance(data, dict):
+        return None
+    updated_at = data.get("fleet_telemetry_updated_at")
+    if updated_at is not None:
+        try:
+            age = time.time() - (float(updated_at) / 1000.0)
+        except Exception:
+            age = None
+        if age is not None and age <= TESLA_FLEET_TELEMETRY_STALE_SECONDS:
+            data = dict(data)
+            _fleet_telemetrie_entferne_fremddaten(data)
+            data["_live"] = True
+            return data
+    if data:
+        data = dict(data)
+        _fleet_telemetrie_entferne_fremddaten(data)
+        data["_live"] = False
+        data.setdefault("api_error", "Noch keine aktuellen Fleet-Telemetry-Daten empfangen")
+        return data
+    return None
 
 
 def _last_energy_file(vehicle_id):
@@ -5263,6 +6610,24 @@ def default_vehicle_id():
     if vid:
         _default_vehicle_id = str(vid)
         return _default_vehicle_id
+    if _nur_fleet_telemetrie_datenquelle():
+        for vehicle in _fleet_telemetrie_fahrzeuge():
+            for key in ("id_s", "id", "vehicle_id"):
+                value = vehicle.get(key)
+                if value not in (None, ""):
+                    _default_vehicle_id = str(value)
+                    return _default_vehicle_id
+        cached = _load_cached("default")
+        if isinstance(cached, dict):
+            cached_id = (
+                cached.get("id_s")
+                or cached.get("vehicle_id")
+                or cached.get("id")
+            )
+            if cached_id not in (None, ""):
+                _default_vehicle_id = str(cached_id)
+                return _default_vehicle_id
+        return None
     tesla = get_tesla()
     if tesla is None:
         return None
@@ -5299,10 +6664,27 @@ def _refresh_state(vehicle, times=1):
     return state
 
 
+def _zustand_aus_cache(cached):
+    """Liefere einen plausiblen Fahrzeugzustand aus gecachten Daten."""
+    if not isinstance(cached, dict):
+        return None
+    state = cached.get("state")
+    if isinstance(state, str) and state.strip():
+        return state
+    return None
+
+
+def _setze_zustand_wenn_bekannt(data, state):
+    """Überschreibe einen Cachezustand nur mit bekannten API-Werten."""
+    if isinstance(data, dict) and state is not None:
+        data["state"] = state
+
+
 def get_vehicle_state(vehicle_id=None):
     """Return the current vehicle state without waking the car."""
     vid = str(vehicle_id or _default_vehicle_id or "default")
     state = last_vehicle_state.get(vid)
+    vorheriger_state = state
     now = time.time()
     cfg = load_config(vehicle_id)
     try:
@@ -5317,6 +6699,41 @@ def get_vehicle_state(vehicle_id=None):
         vs = cached.get("vehicle_state", {})
         service_mode = vs.get("service_mode")
         service_mode_plus = vs.get("service_mode_plus")
+    if _fleet_telemetrie_aktiv():
+        telemetry_data = _fleet_telemetrie_cache_fuer_dashboard(vid, cached)
+        telemetry_state = None
+        if isinstance(telemetry_data, dict):
+            telemetry_state = telemetry_data.get("state")
+            checked_at = telemetry_data.get(
+                "fleet_telemetry_updated_at",
+                telemetry_data.get("state_checked_at", int(now * 1000)),
+            )
+            if telemetry_state is not None:
+                log_vehicle_state(vid, telemetry_state)
+                return {
+                    "state": telemetry_state,
+                    "state_checked_at": checked_at,
+                    "service_mode": service_mode,
+                    "service_mode_plus": service_mode_plus,
+                }
+        cached_state = vorheriger_state or _zustand_aus_cache(cached)
+        return {
+            "error": "Noch keine Fleet-Telemetry-Daten empfangen",
+            "state": cached_state,
+            "state_checked_at": int(now * 1000),
+            "service_mode": service_mode,
+            "service_mode_plus": service_mode_plus,
+        }
+
+    if _nur_fleet_telemetrie_datenquelle():
+        cached_state = vorheriger_state or _zustand_aus_cache(cached)
+        return {
+            "error": "Fahrzeugstatus kommt ausschließlich aus Fleet Telemetry",
+            "state": cached_state,
+            "state_checked_at": int(now * 1000),
+            "service_mode": service_mode,
+            "service_mode_plus": service_mode_plus,
+        }
 
     last_refresh = _last_state_refresh_ts.get(vid)
     refresh_interval = max(1, api_interval)
@@ -5337,7 +6754,14 @@ def get_vehicle_state(vehicle_id=None):
     allow_refresh = state not in {"offline", "asleep"}
     vehicles = _cached_vehicle_list(tesla, allow_refresh=allow_refresh)
     if not vehicles:
-        return {"error": "No vehicles found"}
+        state = vorheriger_state or _zustand_aus_cache(cached)
+        return {
+            "error": "No vehicles found",
+            "state": state,
+            "state_checked_at": int(now * 1000),
+            "service_mode": service_mode,
+            "service_mode_plus": service_mode_plus,
+        }
 
     vehicle = None
     if vehicle_id is not None:
@@ -5357,209 +6781,22 @@ def get_vehicle_state(vehicle_id=None):
             "state_checked_at": int(now * 1000),
         }
 
+    if state is None:
+        state = vorheriger_state or _zustand_aus_cache(cached)
+        return {
+            "error": "Vehicle state unavailable",
+            "state": state,
+            "state_checked_at": int(now * 1000),
+            "service_mode": service_mode,
+            "service_mode_plus": service_mode_plus,
+        }
+
     return {
         "state": state,
         "state_checked_at": int(now * 1000),
         "service_mode": service_mode,
         "service_mode_plus": service_mode_plus,
     }
-
-
-def _extract_battery_temp(payload):
-    """Gibt die erste gefundene Batterietemperatur aus einem Payload zurück."""
-
-    schluessel = ("battery_temp", "battery_temperature", "module_temp_min", "module_temp_max")
-
-    if isinstance(payload, dict):
-        if "module_temp_min" in payload or "module_temp_max" in payload:
-            temp_min = payload.get("module_temp_min")
-            temp_max = payload.get("module_temp_max")
-            if temp_min is not None and temp_max is not None:
-                return (temp_min + temp_max) / 2
-            if temp_min is not None:
-                return temp_min
-            if temp_max is not None:
-                return temp_max
-        for key in schluessel:
-            if key in payload:
-                return payload.get(key)
-        for value in payload.values():
-            found = _extract_battery_temp(value)
-            if found is not None:
-                return found
-    elif isinstance(payload, list):
-        for item in payload:
-            found = _extract_battery_temp(item)
-            if found is not None:
-                return found
-    return None
-
-
-def _fleet_access_token(tesla):
-    """Return a bearer token preferring Fleet credentials when available."""
-
-    fleet_token = os.getenv("TESLA_FLEET_ACCESS_TOKEN")
-    if fleet_token:
-        return fleet_token
-
-    if teslapy is not None and tesla is not None:
-        fleet_token_data = getattr(tesla, "fleet_token", None)
-        if isinstance(fleet_token_data, dict):
-            access_token = fleet_token_data.get("access_token")
-            if access_token:
-                return access_token
-
-        for attr in ("token", "sso_token"):
-            token_data = getattr(tesla, attr, None)
-            if isinstance(token_data, dict):
-                access_token = token_data.get("access_token")
-                if access_token:
-                    return access_token
-
-    owner_token = os.getenv("TESLA_ACCESS_TOKEN")
-    if owner_token:
-        return owner_token
-
-    logging.info(
-        "No Fleet access token available; set TESLA_FLEET_ACCESS_TOKEN for Fleet API calls",
-    )
-    return None
-
-
-def _tessie_battery_temp(vin):
-    """Hole die Batterietemperatur über die Tessie-API."""
-
-    cfg = load_config()
-    token = cfg.get("tessie_api_token")
-    if not token:
-        return None
-    if vin is None:
-        return None
-
-    url = f"https://api.tessie.com/{vin}/battery"
-    headers = {"Authorization": f"Bearer {token}"}
-    with tessie_anfrage_lock:
-        jetzt = time.monotonic()
-        letzte_anfrage = letzte_anfrage_pro_vin.get(vin)
-        if letzte_anfrage is not None:
-            verbleibend = TESLA_TESSIE_MIN_INTERVAL - (jetzt - letzte_anfrage)
-            if verbleibend > 0:
-                logging.info(
-                    (
-                        "Tessie-Abfrage für VIN %s zu früh angefordert "
-                        "(noch %.1f Sekunden); nutze Cachewert."
-                    ),
-                    vin,
-                    verbleibend,
-                )
-                return letzte_batterie_temp_pro_vin.get(vin)
-        try:
-            resp = requests.get(url, headers=headers, timeout=TESLA_REQUEST_TIMEOUT)
-        finally:
-            letzte_anfrage_pro_vin[vin] = time.monotonic()
-    resp.raise_for_status()
-    payload = resp.json()
-    try:
-        log_api_data("tessie_battery", sanitize(payload), vehicle_id=vin)
-    except Exception:
-        pass
-    battery_temp = _extract_battery_temp(payload)
-    if battery_temp is None:
-        with tessie_anfrage_lock:
-            letzte_bekannte_temp = letzte_batterie_temp_pro_vin.get(vin)
-        if letzte_bekannte_temp is not None:
-            logging.info(
-                "Keine aktuelle Batterietemperatur im Tessie-Status; nutze letzten Wert."
-            )
-            return letzte_bekannte_temp
-        logging.info("Keine Batterietemperatur im Tessie-Status gefunden.")
-        return None
-    with tessie_anfrage_lock:
-        letzte_batterie_temp_pro_vin[vin] = battery_temp
-    return battery_temp
-
-
-def _fleet_battery_temp(tesla, vehicle, vid):
-    """Fetch battery temperature via Fleet API when configured."""
-
-    endpoint = os.getenv("TESLA_FLEET_CHARGE_STATE_URL")
-    if not endpoint:
-        return None
-
-    token = _fleet_access_token(tesla)
-    if not token:
-        logging.info("Skipping Fleet battery temperature lookup: no bearer token available")
-        return None
-
-    vehicle_identifier = os.getenv("TESLA_FLEET_VEHICLE_ID") or vid
-    if vehicle_identifier is None:
-        return None
-
-    headers = {"Authorization": f"Bearer {token}"}
-
-    url = endpoint.format(vehicle_id=vehicle_identifier)
-    resp = requests.get(url, headers=headers, timeout=TESLA_REQUEST_TIMEOUT)
-    resp.raise_for_status()
-    payload = resp.json()
-    try:
-        log_api_data("fleet_charge_state", sanitize(payload), vehicle_id=vehicle_identifier)
-    except Exception:
-        pass
-    return _extract_battery_temp(payload)
-
-
-def _owner_battery_temp(vehicle, vid):
-    """Fetch battery temperature via an additional Owner API call."""
-
-    charge_state = None
-    api_call = getattr(vehicle, "api", None)
-    if callable(api_call):
-        try:
-            charge_state = api_call("CHARGE_STATE")
-            log_api_data("charge_state", sanitize(charge_state), vehicle_id=vid)
-        except Exception:
-            charge_state = None
-
-    if charge_state is None:
-        data_request = getattr(vehicle, "data_request", None)
-        if callable(data_request):
-            try:
-                charge_state = data_request("charge_state")
-                log_api_data("charge_state", sanitize(charge_state), vehicle_id=vid)
-            except Exception:
-                charge_state = None
-
-    if isinstance(charge_state, dict):
-        return _extract_battery_temp(charge_state)
-    return None
-
-
-def _fetch_battery_temp(tesla, vehicle, vin):
-    """Ergänze charge_state nur über die Tessie-API um die Batterietemperatur."""
-
-    cfg = load_config()
-    token = cfg.get("tessie_api_token")
-    if not token:
-        logging.info(
-            "Kein Tessie-Token vorhanden; es wird keine alternative API für battery_temp genutzt."
-        )
-        return None
-    if vin is None:
-        logging.info("Keine VIN vorhanden; Tessie-Abfrage für battery_temp wird übersprungen.")
-        return None
-
-    try:
-        return _tessie_battery_temp(vin)
-    except Exception as exc:
-        _log_api_error(exc)
-        with tessie_anfrage_lock:
-            letzte_bekannte_temp = letzte_batterie_temp_pro_vin.get(vin)
-        if letzte_bekannte_temp is not None:
-            logging.info(
-                "Tessie-Abfrage fehlgeschlagen; nutze zuletzt bekannte Batterietemperatur."
-            )
-            return letzte_bekannte_temp
-    return None
 
 
 def _normalize_supercharger_sites(payload, drive_state):
@@ -5830,6 +7067,20 @@ def _formatierter_fahrzeugname(name, car_type, trim_badging):
 def get_vehicle_data(vehicle_id=None, state=None):
     """Fetch vehicle data for a given vehicle id."""
     vid = vehicle_id if vehicle_id is not None else _default_vehicle_id
+    cache_id = str(vid or "default")
+
+    if _nur_fleet_telemetrie_datenquelle():
+        telemetry_data = _fleet_telemetrie_cache_fuer_dashboard(cache_id)
+        if telemetry_data is not None:
+            return telemetry_data
+        payload = {
+            "error": "Fahrzeugdaten kommen ausschließlich aus Fleet Telemetry",
+            "state": state,
+            "_live": False,
+        }
+        if vid is not None:
+            payload["id_s"] = str(vid)
+        return payload
 
     if state is not None and state != "online":
         payload = {"state": state}
@@ -5910,8 +7161,6 @@ def get_vehicle_data(vehicle_id=None, state=None):
         if battery_temp is not None:
             _cache_battery_temp(vin, battery_temp)
         if battery_temp is None:
-            battery_temp = _fetch_battery_temp(tesla, vehicle, vin)
-        if battery_temp is None:
             battery_temp = _cached_battery_temp(vin)
             if battery_temp is not None:
                 logging.info(
@@ -5957,6 +7206,12 @@ def get_vehicle_data(vehicle_id=None, state=None):
 
 def get_vehicle_list():
     """Return a list of available vehicles without exposing VIN."""
+    fleet_vehicles = _fleet_telemetrie_fahrzeugliste(
+        telemetrie_aktiv_erforderlich=not _nur_fleet_telemetrie_datenquelle(),
+    )
+    if fleet_vehicles or _nur_fleet_telemetrie_datenquelle():
+        return fleet_vehicles
+
     tesla = get_tesla()
     if tesla is None:
         return []
@@ -5968,6 +7223,91 @@ def get_vehicle_list():
             name = f"Fahrzeug {idx}"
         sanitized.append({"id": v["id_s"], "display_name": name})
     return sanitized
+
+
+def _fleet_telemetrie_fahrzeugliste(telemetrie_aktiv_erforderlich=True):
+    """Erzeuge die Fahrzeugauswahl aus Fleet-Telemetry-Daten."""
+    global _default_vehicle_id
+
+    if telemetrie_aktiv_erforderlich and not _fleet_telemetrie_aktiv():
+        return []
+
+    vehicles = []
+    bekannte_ids = set()
+
+    def add_vehicle(vehicle_id, display_name=None, aliases=None):
+        vehicle_id = str(vehicle_id or "").strip()
+        alias_ids = []
+        for alias in aliases or []:
+            alias_id = str(alias or "").strip()
+            if alias_id:
+                alias_ids.append(alias_id)
+        if not vehicle_id or vehicle_id in bekannte_ids:
+            bekannte_ids.update(alias_ids)
+            return
+        if any(alias_id in bekannte_ids for alias_id in alias_ids):
+            bekannte_ids.add(vehicle_id)
+            bekannte_ids.update(alias_ids)
+            return
+        bekannte_ids.add(vehicle_id)
+        bekannte_ids.update(alias_ids)
+        name = str(display_name or "").strip() or f"Fahrzeug {len(vehicles) + 1}"
+        vehicles.append({"id": vehicle_id, "display_name": name})
+
+    for vehicle in _fleet_telemetrie_fahrzeuge():
+        vehicle_id = None
+        aliases = []
+        for key in ("id_s", "id", "vehicle_id"):
+            value = vehicle.get(key)
+            if value not in (None, ""):
+                aliases.append(value)
+                vehicle_id = value
+                break
+        for key in ("id_s", "id", "vehicle_id"):
+            value = vehicle.get(key)
+            if value not in (None, "") and value not in aliases:
+                aliases.append(value)
+        add_vehicle(vehicle_id, vehicle.get("display_name"), aliases)
+
+    for cache_id, data in list(latest_data.items()):
+        if not isinstance(data, dict):
+            continue
+        vehicle_state = data.get("vehicle_state")
+        if not isinstance(vehicle_state, dict):
+            vehicle_state = {}
+        vehicle_id = data.get("id_s")
+        if vehicle_id in (None, "") and cache_id != "default":
+            vehicle_id = cache_id
+        display_name = data.get("display_name") or vehicle_state.get("vehicle_name")
+        add_vehicle(
+            vehicle_id,
+            display_name,
+            [cache_id, data.get("id"), data.get("id_s"), data.get("vehicle_id")],
+        )
+
+    cached_default = _load_cached("default")
+    if isinstance(cached_default, dict):
+        vehicle_state = cached_default.get("vehicle_state")
+        if not isinstance(vehicle_state, dict):
+            vehicle_state = {}
+        display_name = (
+            cached_default.get("display_name")
+            or vehicle_state.get("vehicle_name")
+        )
+        add_vehicle(
+            cached_default.get("id_s"),
+            display_name,
+            [
+                cached_default.get("id"),
+                cached_default.get("id_s"),
+                cached_default.get("vehicle_id"),
+            ],
+        )
+
+    if vehicles and _default_vehicle_id is None:
+        _default_vehicle_id = vehicles[0]["id"]
+
+    return vehicles
 
 
 def reverse_geocode(lat, lon, vehicle_id=None):
@@ -6064,6 +7404,24 @@ def _fetch_data_once(vehicle_id="default"):
         cache_id = vehicle_id
 
     cached = _load_cached(cache_id)
+    telemetry_data = _fleet_telemetrie_cache_fuer_dashboard(cache_id, cached)
+    if telemetry_data is not None:
+        latest_data[cache_id] = telemetry_data
+        return telemetry_data
+    if _nur_fleet_telemetrie_datenquelle():
+        data = cached if isinstance(cached, dict) else {}
+        data = dict(data)
+        data.setdefault("state", _zustand_aus_cache(cached))
+        data["api_error"] = "Noch keine Fleet-Telemetry-Daten empfangen"
+        data["state_checked_at"] = int(time.time() * 1000)
+        data["preconditioning_display_allowed"] = (
+            _vorklimatisierung_im_stand_erlaubt(data)
+        )
+        data["_live"] = False
+        latest_data[cache_id] = data
+        for q in subscribers.get(cache_id, []):
+            q.put(data)
+        return data
 
     vehicle_key = str(vid or cache_id)
     vorheriger_state = last_vehicle_state.get(vehicle_key)
@@ -6081,6 +7439,9 @@ def _fetch_data_once(vehicle_id="default"):
     state_checked_at = (
         state_info.get("state_checked_at") if isinstance(state_info, dict) else None
     )
+    api_error = state_info.get("error") if isinstance(state_info, dict) else None
+    if state is None:
+        state = vorheriger_state or _zustand_aus_cache(cached)
 
     data = None
     live = False
@@ -6109,6 +7470,8 @@ def _fetch_data_once(vehicle_id="default"):
         )
         if darf_live_abrufen:
             data = get_vehicle_data(vid, state=state)
+            if isinstance(data, dict) and data.get("error"):
+                api_error = data.get("error") or api_error
             if (
                 isinstance(data, dict)
                 and not data.get("error")
@@ -6119,24 +7482,21 @@ def _fetch_data_once(vehicle_id="default"):
                 cached = _load_cached(cache_id)
                 if cached is not None:
                     data = cached
-                    if isinstance(data, dict):
-                        data["state"] = state
+                    _setze_zustand_wenn_bekannt(data, state)
                 else:
                     data = {"state": state}
         else:
             cached = _load_cached(cache_id)
             if cached is not None:
                 data = cached
-                if isinstance(data, dict):
-                    data["state"] = state
+                _setze_zustand_wenn_bekannt(data, state)
             else:
                 data = {"state": state}
     else:
         cached = _load_cached(cache_id)
         if cached is not None:
             data = cached
-            if isinstance(data, dict):
-                data["state"] = state
+            _setze_zustand_wenn_bekannt(data, state)
         else:
             data = {"state": state}
 
@@ -6478,6 +7838,10 @@ def _fetch_data_once(vehicle_id="default"):
             _vorklimatisierung_im_stand_erlaubt(data)
         )
         data["_live"] = live
+        if live:
+            data.pop("api_error", None)
+        elif api_error:
+            data["api_error"] = api_error
     latest_data[cache_id] = data
     if isinstance(data, dict):
         try:
@@ -6532,7 +7896,14 @@ def _fetch_loop(vehicle_id, interval=3):
             idle_interval = max(1, int(cfg.get("api_interval_idle", idle_interval)))
         except Exception:
             pass
-        data = _fetch_data_once(vehicle_id)
+        try:
+            data = _fetch_data_once(vehicle_id)
+        except Exception as exc:
+            _log_api_error(exc)
+            logging.exception(
+                "Fahrzeugdaten-Abruf für %s fehlgeschlagen", vehicle_id
+            )
+            data = {"error": str(exc), "_live": False}
         if isinstance(data, dict) and data.get("_live"):
             try:
                 send_aprs(data)
@@ -6585,7 +7956,10 @@ def _fetch_loop(vehicle_id, interval=3):
 
 def _start_thread(vehicle_id):
     """Start background fetching thread for the given vehicle."""
-    if vehicle_id in threads:
+    if _fleet_telemetrie_aktiv():
+        return
+    vorhandener_thread = threads.get(vehicle_id)
+    if vorhandener_thread is not None and vorhandener_thread.is_alive():
         return
     t = threading.Thread(target=_fetch_loop, args=(vehicle_id,), daemon=True)
     threads[vehicle_id] = t
@@ -6598,7 +7972,7 @@ taximeter = Taximeter(TAXI_DB, _fetch_data_once, get_taximeter_tariff)
 
 @app.route("/")
 def index():
-    cfg = load_config()
+    cfg = _config_mit_telemetrie_only_regeln(load_config())
     return render_template(
         "index.html",
         version=__version__,
@@ -6613,6 +7987,19 @@ def index():
 def robots_txt():
     """Liefere robots.txt aus dem Static-Verzeichnis."""
     return send_from_directory("static", "robots.txt")
+
+
+@app.route("/.well-known/appspecific/com.tesla.3p.public-key.pem")
+def tesla_fleet_public_key():
+    """Liefere den öffentlichen Tesla-Fleet-Schlüssel aus."""
+    public_key_path = Path(TESLA_FLEET_PUBLIC_KEY_PATH)
+    if not public_key_path.is_file():
+        abort(404)
+    return send_from_directory(
+        public_key_path.parent,
+        public_key_path.name,
+        mimetype="application/x-pem-file",
+    )
 
 
 @app.route("/map")
@@ -6986,8 +8373,7 @@ def api_config():
         cfg["phone_number"] = True
     if "infobip_api_key" in cfg:
         cfg["infobip_api_key"] = True
-    if "tessie_api_token" in cfg:
-        cfg["tessie_api_token"] = True
+    cfg = _config_mit_telemetrie_only_regeln(cfg)
     cfg.pop("infobip_base_url", None)
     return jsonify(cfg)
 
@@ -7147,10 +8533,6 @@ def config_page():
         keep_infobip_api_key = infobip_api_key == SECRET_PLACEHOLDER
         if keep_infobip_api_key:
             infobip_api_key = ""
-        tessie_api_token = request.form.get("tessie_api_token", "").strip()
-        keep_tessie_api_token = tessie_api_token == SECRET_PLACEHOLDER
-        if keep_tessie_api_token:
-            tessie_api_token = ""
         infobip_base_url = request.form.get("infobip_base_url", "").strip()
         sms_sender_id = request.form.get("sms_sender_id", "").strip()
         sms_enabled = "sms_enabled" in request.form
@@ -7167,7 +8549,7 @@ def config_page():
         if selected_vehicle:
             selected_vehicle_id = selected_vehicle
         aprs_cfg = load_config(vehicle_id=selected_vehicle_id)
-        if "refresh_vehicle_list" in request.form:
+        if "refresh_vehicle_list" in request.form and not _nur_fleet_telemetrie_datenquelle():
             tesla = get_tesla()
             if tesla is not None:
                 _cached_vehicle_list(tesla, ttl=0)
@@ -7218,10 +8600,7 @@ def config_page():
             cfg["infobip_api_key"] = infobip_api_key
         elif not keep_infobip_api_key and "infobip_api_key" in cfg:
             cfg.pop("infobip_api_key")
-        if tessie_api_token:
-            cfg["tessie_api_token"] = tessie_api_token
-        elif not keep_tessie_api_token and "tessie_api_token" in cfg:
-            cfg.pop("tessie_api_token")
+        cfg.pop("tessie_api_token", None)
         if infobip_base_url:
             cfg["infobip_base_url"] = infobip_base_url
         elif "infobip_base_url" in cfg:
@@ -7284,7 +8663,7 @@ def config_page():
         save_config(aprs_cfg, vehicle_id=selected_vehicle_id)
     else:
         aprs_cfg = load_config(vehicle_id=selected_vehicle_id)
-    display_cfg = dict(cfg)
+    display_cfg = _config_mit_telemetrie_only_regeln(cfg)
     for key in ("aprs_callsign", "aprs_passcode", "aprs_wx_callsign", "aprs_wx_enabled", "aprs_comment"):
         if key in aprs_cfg:
             display_cfg[key] = aprs_cfg[key]
@@ -7292,14 +8671,14 @@ def config_page():
         display_cfg["aprs_passcode"] = SECRET_PLACEHOLDER
     if display_cfg.get("infobip_api_key"):
         display_cfg["infobip_api_key"] = SECRET_PLACEHOLDER
-    if display_cfg.get("tessie_api_token"):
-        display_cfg["tessie_api_token"] = SECRET_PLACEHOLDER
+    display_cfg.pop("tessie_api_token", None)
     return render_template(
         "config.html",
-        items=CONFIG_ITEMS,
+        items=_config_items_fuer_anzeige(),
         config=display_cfg,
         vehicles=vehicles,
         selected_vehicle_id=selected_vehicle_id,
+        fleet_only=_nur_fleet_telemetrie_datenquelle(),
     )
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ aprslib
 phonenumbers==9.0.9
 qrcode
 reportlab
+paho-mqtt

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -746,6 +746,7 @@ select {
 #nav-bar table {
   width: 100%;
   border-collapse: collapse;
+  table-layout: fixed;
 }
 
 #v2l-infos th,
@@ -763,6 +764,7 @@ select {
   border: 1px solid #444;
   padding: 6px 8px;
   text-align: left;
+  overflow-wrap: anywhere;
 }
 
 #v2l-infos th,
@@ -838,6 +840,7 @@ select {
 #media-player table {
   width: 100%;
   border-collapse: collapse;
+  table-layout: fixed;
 }
 
 #media-player th,
@@ -845,6 +848,7 @@ select {
   border: 1px solid #444;
   padding: 6px 8px;
   text-align: left;
+  overflow-wrap: anywhere;
 }
 
 #media-player th {
@@ -1041,6 +1045,89 @@ select {
   font-weight: bold;
 }
 
+.turn-indicator {
+  display: grid;
+  grid-template-columns: 1fr 34px 1fr;
+  gap: 8px;
+  width: 140px;
+  height: 24px;
+  align-items: center;
+  justify-items: center;
+  margin: 0 auto 2px;
+}
+
+.turn-arrow {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 42px;
+  height: 24px;
+  color: #335533;
+  font-size: 24px;
+  line-height: 1;
+  text-shadow: none;
+  opacity: 0.45;
+}
+
+.turn-arrow.is-active {
+  color: #00e676;
+  opacity: 1;
+  text-shadow: 0 0 8px rgba(0, 230, 118, 0.9);
+  animation: blinker-puls 0.9s steps(2, start) infinite;
+}
+
+.high-beam-indicator {
+  position: relative;
+  display: inline-block;
+  width: 34px;
+  height: 24px;
+  color: #294466;
+  opacity: 0.45;
+}
+
+.high-beam-indicator::before {
+  content: '';
+  position: absolute;
+  right: 4px;
+  top: 4px;
+  width: 10px;
+  height: 16px;
+  border: 2px solid currentColor;
+  border-left: 0;
+  border-radius: 0 12px 12px 0;
+  box-sizing: border-box;
+}
+
+.high-beam-indicator::after {
+  content: '';
+  position: absolute;
+  left: 2px;
+  top: 5px;
+  width: 22px;
+  height: 14px;
+  background: repeating-linear-gradient(
+    to bottom,
+    currentColor 0,
+    currentColor 2px,
+    transparent 2px,
+    transparent 5px
+  );
+  clip-path: polygon(0 0, 100% 15%, 100% 85%, 0 100%);
+}
+
+.high-beam-indicator.is-active {
+  color: #42a5ff;
+  opacity: 1;
+  filter: drop-shadow(0 0 6px rgba(66, 165, 255, 0.95));
+}
+
+@keyframes blinker-puls {
+  50% {
+    opacity: 0.25;
+    text-shadow: none;
+  }
+}
+
 #speedometer svg {
   display: block;
 }
@@ -1162,6 +1249,14 @@ select {
   }
   #heater-indicator {
     flex-direction: column;
+  }
+  #v2l-infos th,
+  #charging-info th,
+  #ladeplanung-info th,
+  #preconditioning-info th,
+  #media-player th,
+  #nav-bar th {
+    white-space: normal;
   }
   #map {
     height: 50vh !important;
@@ -1325,6 +1420,24 @@ select {
   fill: #555;
 }
 
+#openings-indicator .brake-lights {
+  pointer-events: none;
+}
+
+#openings-indicator .brake-light {
+  fill: #4b1212;
+  stroke: #260707;
+  stroke-width: 1px;
+  opacity: 0.7;
+}
+
+#openings-indicator .brake-lights.is-active .brake-light {
+  fill: #ff1744;
+  stroke: #ffcdd2;
+  opacity: 1;
+  filter: drop-shadow(0 0 5px rgba(255, 23, 68, 0.95));
+}
+
 #openings-indicator .blue-highlight {
   fill: blue;
 }
@@ -1340,10 +1453,89 @@ select {
   dominant-baseline: central;
 }
 
+.tpms-summary {
+  box-sizing: border-box;
+  min-height: 32px;
+  max-width: 150px;
+  margin: 6px auto 0;
+  padding: 4px 6px;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 4px;
+  background: rgba(0, 0, 0, 0.18);
+  color: #ddd;
+  font-size: 0.78rem;
+  font-weight: bold;
+  line-height: 1.25;
+}
+
+.tpms-summary.tpms-ok {
+  border-color: rgba(76, 175, 80, 0.65);
+  color: #7bdc7f;
+}
+
+.tpms-summary.tpms-warnung {
+  border-color: rgba(255, 152, 0, 0.8);
+  color: #ffb74d;
+}
+
+.tpms-summary.tpms-kritisch {
+  border-color: rgba(211, 47, 47, 0.9);
+  color: #ff6b6b;
+}
+
+.tpms-summary.tpms-unbekannt {
+  color: #aaa;
+}
+
 #openings-indicator .car-body {
   fill: #333;
   stroke: #777;
   stroke-width: 2px;
+}
+
+.tpms-tire.tpms-ok circle {
+  fill: rgba(76, 175, 80, 0.18);
+}
+
+.tpms-tire.tpms-warnung circle {
+  fill: rgba(255, 152, 0, 0.28);
+}
+
+.tpms-tire.tpms-kritisch circle {
+  fill: rgba(211, 47, 47, 0.35);
+}
+
+.tpms-tire.tpms-unbekannt circle {
+  fill: rgba(85, 85, 85, 0.3);
+}
+
+.tpms-status {
+  display: inline-block;
+  min-width: 5.5em;
+  padding: 2px 6px;
+  border-radius: 4px;
+  text-align: center;
+  font-weight: bold;
+}
+
+.tpms-status-ok {
+  background: rgba(76, 175, 80, 0.2);
+  color: #7bdc7f;
+}
+
+.tpms-status-warnung {
+  background: rgba(255, 152, 0, 0.24);
+  color: #ffb74d;
+}
+
+.tpms-status-kritisch {
+  background: rgba(211, 47, 47, 0.28);
+  color: #ff6b6b;
+}
+
+.tpms-status-unbekannt {
+  background: rgba(117, 117, 117, 0.22);
+  color: #bbb;
 }
 
 /* animated doors */

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -19,6 +19,9 @@ var DEFAULT_ZOOM = 18;
 var superchargerMarkers = [];
 var lastSuperchargerData = null;
 var letzteKartenPosition = null;
+var letzteKartenRichtung = null;
+var letzteZielSignatur = null;
+var letztePfadSignatur = null;
 var privacyCircle = null;
 
 function normalizeShiftState(shift) {
@@ -297,6 +300,7 @@ var CONFIG = {};
 var HIGHLIGHT_BLUE = false;
 var currentPath = [];
 var OFFLINE_TEXT = 'Das Fahrzeug ist offline und schläft - Bitte nicht wecken! - Die Daten sind die zuletzt bekannten und somit nicht aktuell!';
+var DISCONNECTED_TEXT = 'Die Fleet-Telemetry-Verbindung zum Fahrzeug ist getrennt. Es werden die zuletzt bekannten Daten angezeigt.';
 var SERVICE_MODE_TEXT = 'Fahrzeug befindet sich im Service Mode.';
 var SERVICE_MODE_PLUS_TEXT = 'Fahrzeug befindet sich im Service Mode Plus.';
 var smsForm = $('#sms-form');
@@ -394,6 +398,21 @@ function positionIstNeu(lat, lng) {
     var diffLat = Math.abs(lat - letzteKartenPosition[0]);
     var diffLng = Math.abs(lng - letzteKartenPosition[1]);
     return diffLat > 1e-6 || diffLng > 1e-6;
+}
+
+function kartenPunkteSignatur(points) {
+    if (!Array.isArray(points) || !points.length) {
+        return 'leer';
+    }
+    var erstes = points[0] || [];
+    var letztes = points[points.length - 1] || [];
+    return [
+        points.length,
+        erstes[0],
+        erstes[1],
+        letztes[0],
+        letztes[1]
+    ].join('|');
 }
 
 function planeNaechsteStatusabfrage() {
@@ -769,14 +788,21 @@ function handleData(data) {
     updateOfflineInfo(data.state, vehicle.service_mode, vehicle.service_mode_plus);
     updateSoftwareUpdate(vehicle.software_update);
     var drive = data.drive_state || {};
-    updateDataAge(vehicle.timestamp);
+    var charge = data.charge_state || {};
+    var climate = data.climate_state || {};
+    updateDataAge(neuesterDatenZeitstempel(data, vehicle, drive, charge, climate));
     updateLockStatus(vehicle.locked);
     updateUserPresence(vehicle.is_user_present);
+    updateTurnSignalIndicator(vehicle.lights_turn_signal, vehicle.lights_hazards_active);
+    updateHighBeamIndicator(vehicle.lights_high_beams);
     updateGearShift(drive.shift_state);
     updateParkTime(data.park_start);
     updateNavBar(drive);
-    var charge = data.charge_state || {};
-    updateSpeedometer(drive.speed, drive.power, charge.charging_state);
+    var displayPower = drive.power;
+    if (charge.charging_state === 'Charging' && charge.charger_power != null) {
+        displayPower = charge.charger_power;
+    }
+    updateSpeedometer(drive.speed, displayPower, charge.charging_state);
     updateOdometer(vehicle.odometer);
     var rangeMiles = charge.ideal_battery_range;
     if (rangeMiles == null) {
@@ -786,7 +812,6 @@ function handleData(data) {
     updateV2LInfos(charge, drive);
     updateChargingInfo(charge, data);
     updateLadeplanungInfo(charge, drive, data);
-    var climate = data.climate_state || {};
     updateThermometers(climate.inside_temp, climate.outside_temp, charge.battery_temp);
     updateClimateStatus(climate.is_climate_on);
     updateClimateMode(climate.climate_keeper_mode);
@@ -832,13 +857,15 @@ function handleData(data) {
     var offline = istOfflineOderSchlaeft(data.state);
     if (isFinite(mapLat) && isFinite(mapLng)) {
         var coordsNeu = positionIstNeu(mapLat, mapLng);
-        if (offline) {
-            marker.setLatLng([mapLat, mapLng]);
-        } else if (typeof marker.slideTo === 'function') {
-            marker.slideTo([mapLat, mapLng], {duration: 1000});
-            slide = true;
-        } else {
-            marker.setLatLng([mapLat, mapLng]);
+        if (coordsNeu) {
+            if (offline) {
+                marker.setLatLng([mapLat, mapLng]);
+            } else if (typeof marker.slideTo === 'function') {
+                marker.slideTo([mapLat, mapLng], {duration: 1000});
+                slide = true;
+            } else {
+                marker.setLatLng([mapLat, mapLng]);
+            }
         }
         var speedVal = parseFloat(drive.speed);
         var units = data.gui_settings && data.gui_settings.gui_distance_units;
@@ -851,7 +878,7 @@ function handleData(data) {
         if (Date.now() - lastUserZoom < USER_ZOOM_PRIORITY_MS) {
             zoom = map.getZoom();
         }
-        if (!offline || coordsNeu || !letzteKartenPosition) {
+        if (coordsNeu || !letzteKartenPosition) {
             zoomSetByApp = true;
             if (offline) {
                 map.setView([mapLat, mapLng], zoom, {animate: false});
@@ -862,7 +889,13 @@ function handleData(data) {
         }
         if (typeof drive.heading === 'number') {
             var displayHeading = adjustHeadingForReverse(drive.heading, drive.shift_state);
-            marker.setRotationAngle(displayHeading);
+            if (
+                letzteKartenRichtung == null ||
+                Math.abs(Number(displayHeading) - Number(letzteKartenRichtung)) > 0.1
+            ) {
+                marker.setRotationAngle(displayHeading);
+                letzteKartenRichtung = displayHeading;
+            }
         }
         letzteKartenPosition = [mapLat, mapLng];
     } else if (!letzteKartenPosition && !offline) {
@@ -907,15 +940,25 @@ function handleData(data) {
         isFinite(dLat) &&
         isFinite(dLng)
     ) {
-        if (!destMarker) {
-            destMarker = L.marker([dLat, dLng], { icon: flagIcon }).addTo(map);
-        } else {
-            destMarker.setLatLng([dLat, dLng]);
-        }
-        if (!destLine) {
-            destLine = L.polyline([[mapLat, mapLng], [dLat, dLng]], { color: 'red', dashArray: '5, 5', weight: 2 }).addTo(map);
-        } else {
-            destLine.setLatLngs([[mapLat, mapLng], [dLat, dLng]]);
+        var zielSignatur = [
+            drive.active_route_destination,
+            mapLat,
+            mapLng,
+            dLat,
+            dLng
+        ].join('|');
+        if (zielSignatur !== letzteZielSignatur) {
+            if (!destMarker) {
+                destMarker = L.marker([dLat, dLng], { icon: flagIcon }).addTo(map);
+            } else {
+                destMarker.setLatLng([dLat, dLng]);
+            }
+            if (!destLine) {
+                destLine = L.polyline([[mapLat, mapLng], [dLat, dLng]], { color: 'red', dashArray: '5, 5', weight: 2 }).addTo(map);
+            } else {
+                destLine.setLatLngs([[mapLat, mapLng], [dLat, dLng]]);
+            }
+            letzteZielSignatur = zielSignatur;
         }
     } else {
         if (destMarker) {
@@ -926,20 +969,28 @@ function handleData(data) {
             map.removeLayer(destLine);
             destLine = null;
         }
+        letzteZielSignatur = null;
     }
     var pathPoints = updatePathPoints(data);
     var sichtbarePathPoints = privatisiereKartenPunkte(pathPoints);
+    var pfadSignatur = kartenPunkteSignatur(sichtbarePathPoints);
     if (sichtbarePathPoints.length > 1) {
-        if (!polyline) {
-            polyline = L.polyline(sichtbarePathPoints, { color: 'blue' }).addTo(map);
-        } else if (slide) {
-            pendingPath = sichtbarePathPoints.slice();
-        } else {
-            polyline.setLatLngs(sichtbarePathPoints);
+        if (pfadSignatur !== letztePfadSignatur) {
+            if (!polyline) {
+                polyline = L.polyline(sichtbarePathPoints, { color: 'blue' }).addTo(map);
+            } else if (slide) {
+                pendingPath = sichtbarePathPoints.slice();
+            } else {
+                polyline.setLatLngs(sichtbarePathPoints);
+            }
+            letztePfadSignatur = pfadSignatur;
         }
     } else if (polyline) {
         map.removeLayer(polyline);
         polyline = null;
+        letztePfadSignatur = pfadSignatur;
+    } else {
+        letztePfadSignatur = pfadSignatur;
     }
 }
 
@@ -1009,6 +1060,51 @@ function updateUserPresence(present) {
     }
 }
 
+function updateTurnSignalIndicator(turnSignal, hazardsActive) {
+    var $indicator = $('#turn-indicator');
+    var $left = $('#turn-left');
+    var $right = $('#turn-right');
+    var signal = typeof turnSignal === 'string' ? turnSignal.toLowerCase() : '';
+    if (signal.indexOf('turnsignalstate') === 0) {
+        signal = signal.substring('turnsignalstate'.length).toLowerCase();
+    }
+    var hazards = false;
+    if (typeof hazardsActive === 'string') {
+        var hazardsText = hazardsActive.toLowerCase();
+        hazards = hazardsText === 'true' || hazardsText === '1' || hazardsText === 'on';
+    } else {
+        hazards = !!hazardsActive;
+    }
+    var leftActive = hazards || signal === 'left' || signal === 'both';
+    var rightActive = hazards || signal === 'right' || signal === 'both';
+    $left.toggleClass('is-active', leftActive);
+    $right.toggleClass('is-active', rightActive);
+    var title = 'Blinker aus';
+    if (hazards || signal === 'both') {
+        title = 'Warnblinker an';
+    } else if (signal === 'left') {
+        title = 'Blinker links';
+    } else if (signal === 'right') {
+        title = 'Blinker rechts';
+    }
+    $indicator.attr('title', title).attr('aria-label', title);
+}
+
+function updateHighBeamIndicator(highBeamsActive) {
+    var $el = $('#high-beam-indicator');
+    var active = false;
+    if (typeof highBeamsActive === 'string') {
+        var text = highBeamsActive.toLowerCase();
+        active = text === 'true' || text === '1' || text === 'on';
+    } else {
+        active = !!highBeamsActive;
+    }
+    var title = active ? 'Fernlicht an' : 'Fernlicht aus';
+    $el.toggleClass('is-active', active)
+        .attr('title', title)
+        .attr('aria-label', title);
+}
+
 function updateClimateStatus(on) {
     if (on == null) {
         $('#climate-status').text('').attr('title', '').attr('aria-label', '');
@@ -1048,6 +1144,9 @@ function updateFanStatus(speed) {
 
 function updateClimateMode(mode) {
     var $el = $('#climate-mode');
+    if (typeof mode === 'string') {
+        mode = mode.toLowerCase();
+    }
     if (!mode || mode === 'off') {
         $el.text('').attr('title', '').attr('aria-label', '').hide();
         return;
@@ -1057,9 +1156,12 @@ function updateClimateMode(mode) {
     if (mode === 'dog') {
         icon = '\uD83D\uDC36';
         title = 'Hundemodus';
-    } else if (mode === 'camp') {
+    } else if (mode === 'camp' || mode === 'party') {
         icon = '\u26FA';
         title = 'Camp-Modus';
+    } else if (mode === 'on') {
+        icon = '\u267B';
+        title = 'Klimaanlage halten';
     } else {
         $el.text('').attr('title', '').hide();
         return;
@@ -1291,6 +1393,22 @@ function reifendruckStatus(ist, soll, weichWarnung, hartWarnung) {
     return {klasse: 'ok', text: 'OK'};
 }
 
+function reifendruckHinweis(eintrag, status) {
+    var hinweise = [];
+    if (istAktiv(eintrag.hart)) {
+        hinweise.push('harte Warnung');
+    }
+    if (istAktiv(eintrag.weich)) {
+        hinweise.push('weiche Warnung');
+    }
+    if (status.klasse === 'kritisch' && hinweise.length === 0) {
+        hinweise.push('kritische Abweichung');
+    } else if (status.klasse === 'warnung' && hinweise.length === 0) {
+        hinweise.push('prüfen');
+    }
+    return hinweise.join(', ') || status.text;
+}
+
 function reifendruckReifen(vehicle) {
     vehicle = vehicle || {};
     var vorneSoll = vehicle.tpms_rcp_front_value;
@@ -1338,13 +1456,18 @@ function reifendruckReifen(vehicle) {
 function updateTPMS(vehicle) {
     function set(reifen) {
         var $group = $('#tpms-' + reifen.id);
+        var $title = $group.find('title');
         var $text = $group.find('text');
         var $circle = $group.find('circle');
         var val = reifen.wert;
         if (val == null || isNaN(val)) {
             $text.text('--');
             $circle.css('stroke', '#555');
-            $group.attr('aria-label', reifen.name + ': kein Reifendruckwert');
+            $group
+                .removeClass('tpms-ok tpms-warnung tpms-kritisch')
+                .addClass('tpms-unbekannt')
+                .attr('aria-label', reifen.name + ': kein Reifendruckwert');
+            $title.text(reifen.name + ': kein Reifendruckwert');
             return;
         }
         var num = Number(val);
@@ -1358,15 +1481,86 @@ function updateTPMS(vehicle) {
             color = '#d00';
         }
         $circle.css('stroke', color);
+        $group
+            .removeClass('tpms-ok tpms-warnung tpms-kritisch tpms-unbekannt')
+            .addClass('tpms-' + status.klasse);
         var ziel = parseNumber(reifen.soll);
         var text = reifen.name + ': ' + num.toFixed(2) + ' bar';
         if (ziel != null) {
             text += ', Soll ' + ziel.toFixed(2) + ' bar';
         }
-        text += ', Status ' + status.text;
+        var alter = formatiereAlter(reifen.zeit);
+        if (alter) {
+            text += ', Messung ' + alter;
+        }
+        text += ', Status ' + reifendruckHinweis(reifen, status);
         $group.attr('aria-label', text);
+        $title.text(text);
     }
-    reifendruckReifen(vehicle).forEach(set);
+    var reifen = reifendruckReifen(vehicle);
+    reifen.forEach(set);
+    updateReifendruckKurzstatus(reifen);
+}
+
+function updateReifendruckKurzstatus(reifen) {
+    var $summary = $('#tpms-summary');
+    if (!$summary.length) {
+        return;
+    }
+    var mitDaten = reifen.filter(function(eintrag) {
+        return parseNumber(eintrag.wert) != null;
+    });
+    if (!mitDaten.length) {
+        $summary
+            .removeClass('tpms-ok tpms-warnung tpms-kritisch')
+            .addClass('tpms-unbekannt')
+            .text('Reifendruck: --')
+            .attr('title', 'Keine Reifendruckwerte')
+            .attr('aria-label', 'Keine Reifendruckwerte');
+        return;
+    }
+    var statusKlasse = 'ok';
+    var kritische = 0;
+    var warnungen = 0;
+    var niedrigster = null;
+    var juengsteMessung = null;
+    mitDaten.forEach(function(eintrag) {
+        var status = reifendruckStatus(eintrag.wert, eintrag.soll, eintrag.weich, eintrag.hart);
+        if (status.klasse === 'kritisch') {
+            kritische += 1;
+        } else if (status.klasse === 'warnung') {
+            warnungen += 1;
+        }
+        var wert = parseNumber(eintrag.wert);
+        if (wert != null && (niedrigster == null || wert < niedrigster)) {
+            niedrigster = wert;
+        }
+        var zeit = leseZeitstempelMillis(eintrag.zeit);
+        if (zeit != null && (juengsteMessung == null || zeit > juengsteMessung)) {
+            juengsteMessung = zeit;
+        }
+    });
+    var text = 'Reifendruck OK';
+    if (kritische > 0) {
+        statusKlasse = 'kritisch';
+        text = kritische + ' kritisch';
+    } else if (warnungen > 0) {
+        statusKlasse = 'warnung';
+        text = warnungen === 1 ? '1 Reifen prüfen' : warnungen + ' Reifen prüfen';
+    }
+    if (niedrigster != null) {
+        text += ' · min ' + niedrigster.toFixed(1) + ' bar';
+    }
+    var alter = formatiereAlter(juengsteMessung);
+    if (alter) {
+        text += ' · ' + alter;
+    }
+    $summary
+        .removeClass('tpms-ok tpms-warnung tpms-kritisch tpms-unbekannt')
+        .addClass('tpms-' + statusKlasse)
+        .text(text)
+        .attr('title', text)
+        .attr('aria-label', text);
 }
 
 function updateReifendruckDetails(vehicle) {
@@ -1406,7 +1600,8 @@ function updateReifendruckDetails(vehicle) {
                '<td>' + formatiereBar(soll) + '</td>' +
                '<td>' + escapeHtml(abweichung) + '</td>' +
                '<td>' + escapeHtml(alter) + '</td>' +
-               '<td>' + escapeHtml(status.text) + '</td>' +
+               '<td><span class="tpms-status tpms-status-' + status.klasse + '">' +
+               escapeHtml(reifendruckHinweis(eintrag, status)) + '</span></td>' +
                '</tr>';
     });
     var zusammenfassung = 'Reifendruck im Zielbereich';
@@ -1422,6 +1617,26 @@ function updateReifendruckDetails(vehicle) {
                '<th>Reifen</th><th>Ist</th><th>Soll</th><th>Abweichung</th><th>Messung</th><th>Status</th>' +
                '</tr></thead><tbody>' + rows.join('') + '</tbody></table>';
     $details.html(html).show();
+}
+
+function updateBrakeLights(vehicle) {
+    var $lights = $('#brake-lights');
+    if (!$lights.length) {
+        return;
+    }
+    vehicle = vehicle || {};
+    var pedalAktiv = istAktiv(vehicle.brake_pedal);
+    var bremsdruck = parseNumber(vehicle.brake_pedal_pos);
+    var aktiv = pedalAktiv || (bremsdruck != null && bremsdruck > 0.1);
+    var titel = aktiv ? 'Bremslicht an' : 'Bremslicht aus';
+    if (bremsdruck != null) {
+        titel += ' · Bremsdruck ' + bremsdruck.toFixed(1);
+    }
+    $lights
+        .toggleClass('is-active', aktiv)
+        .attr('aria-label', titel)
+        .attr('title', titel);
+    $lights.find('title').text(titel);
 }
 
 function updateOpenings(vehicle, charge) {
@@ -1473,6 +1688,7 @@ function updateOpenings(vehicle, charge) {
 
     var charging = charge && charge.charging_state === 'Charging';
     $('#charge-cable').toggleClass('charging', charging);
+    updateBrakeLights(vehicle);
 }
 
 var MAX_SPEED = 250;
@@ -1566,7 +1782,8 @@ function updateThermometers(inside, outside, battery) {
 }
 
 function updateBatteryIndicator(level, rangeMiles, chargingState, heaterOn) {
-    var pct = level != null ? level : 0;
+    var pct = level != null && !isNaN(level) ? Math.max(0, Math.min(100, Number(level))) : 0;
+    var pctText = Math.round(pct);
     var range = rangeMiles != null ? Math.round(rangeMiles * MILES_TO_KM) : '?';
     var charging = chargingState === 'Charging';
     var heating = !!heaterOn;
@@ -1580,15 +1797,16 @@ function updateBatteryIndicator(level, rangeMiles, chargingState, heaterOn) {
         html += '<div class="heater">\uD83D\uDD25</div>';
     }
     html += '</div>';
-    html += '<div class="battery-value">' + pct + '%</div>';
+    html += '<div class="battery-value">' + pctText + '%</div>';
     html += '<div class="range">' + range + ' km</div>';
     $('#battery-indicator').html(html);
 }
 
 function batteryBar(level) {
-    var pct = level != null ? level : 0;
+    var pct = level != null && !isNaN(level) ? Math.max(0, Math.min(100, Number(level))) : 0;
+    var pctText = Math.round(pct);
     var clip = 'clip-path: inset(' + (100 - pct) + '% 0 0 0)';
-    return '<div class="battery-block"><div class="battery"><div class="level" style="' + clip + '"></div></div><div class="battery-value">' + pct + '%</div></div>';
+    return '<div class="battery-block"><div class="battery"><div class="level" style="' + clip + '"></div></div><div class="battery-value">' + pctText + '%</div></div>';
 }
 
 var lastChargeInfo = null;
@@ -1598,6 +1816,7 @@ var letzteLadedauerMs = null;
 var letzterLadezuwachsProzent = null;
 var lastChargeSessionStartMs = null;
 var lastChargingState = null;
+var lastChargingInfoHtml = null;
 var letzteBatterieTemperatur = null;
 
 function parseNumber(value) {
@@ -2078,7 +2297,12 @@ function updateLadeplanungInfo(charge, drive, data) {
 function updateChargingInfo(charge, wurzelDaten) {
     var $info = $('#charging-info');
     if (!charge) {
-        $info.empty().hide();
+        if (lastChargingInfoHtml !== '') {
+            $info.empty().hide();
+            lastChargingInfoHtml = '';
+        } else {
+            $info.hide();
+        }
         return;
     }
 
@@ -2299,10 +2523,19 @@ function updateChargingInfo(charge, wurzelDaten) {
         rows.push('<tr><th>Zuletzt hinzugefügte %:</th><td>' + lastChargeAddedPercentText + '</td></tr>');
     }
 
-    if (rows.length) {
-        $info.html('<table>' + rows.join('') + '</table>').show();
+    var chargingInfoHtml = rows.length ? '<table>' + rows.join('') + '</table>' : '';
+    if (chargingInfoHtml === lastChargingInfoHtml) {
+        if (rows.length) {
+            $info.show();
+        } else {
+            $info.hide();
+        }
+    } else if (rows.length) {
+        $info.html(chargingInfoHtml).show();
+        lastChargingInfoHtml = chargingInfoHtml;
     } else {
         $info.empty().hide();
+        lastChargingInfoHtml = chargingInfoHtml;
     }
 
     if (sessionStartMsAktuell != null) {
@@ -2432,6 +2665,25 @@ function describe(key) {
         return w.charAt(0).toUpperCase() + w.slice(1);
     }).join(" ");
     return result;
+}
+
+function neuesterDatenZeitstempel(data, vehicle, drive, charge, climate) {
+    var kandidaten = [
+        data && data.fleet_telemetry_updated_at,
+        data && data.timestamp,
+        vehicle && vehicle.timestamp,
+        drive && drive.timestamp,
+        charge && charge.timestamp,
+        climate && climate.timestamp
+    ];
+    var neuester = null;
+    kandidaten.forEach(function(wert) {
+        var millis = leseZeitstempelMillis(wert);
+        if (millis != null && (neuester == null || millis > neuester)) {
+            neuester = millis;
+        }
+    });
+    return neuester;
 }
 
 function updateDataAge(ts) {
@@ -2713,6 +2965,11 @@ function updateOfflineInfo(state, serviceMode, serviceModePlus) {
             $msg.text(OFFLINE_TEXT).show();
             return;
         }
+        if (st === 'disconnected') {
+            hideLoading();
+            $msg.text(DISCONNECTED_TEXT).show();
+            return;
+        }
     }
     hideLoading();
     $msg.hide().text('');
@@ -2826,14 +3083,6 @@ function startStream() {
                 }
             });
         });
-        // Ensure the map shows Essen if no cached data was found
-        var zoom = DEFAULT_ZOOM;
-        if (Date.now() - lastUserZoom < USER_ZOOM_PRIORITY_MS) {
-            zoom = map.getZoom();
-        }
-        zoomSetByApp = true;
-        map.setView(DEFAULT_POS, zoom);
-        updateZoomDisplay();
         // Attempt to reconnect after a short delay in case the browser has
         // suspended the connection while running in the background.
         if (!statusAbfrageTimer) {

--- a/templates/config.html
+++ b/templates/config.html
@@ -67,21 +67,19 @@
             </label>
         </section>
 
+        {% if not fleet_only %}
         <section class="config-section">
-            <h2>API</h2>
+            <h2>Aktualisierung</h2>
             <label>
-                API Intervall (Sekunden)
+                Intervall (Sekunden)
                 <input type="number" name="api_interval" min="1" step="1" value="{{ config.get('api_interval', 3) }}">
             </label>
             <label>
-                API Intervall ohne Client (Sekunden)
+                Intervall ohne Client (Sekunden)
                 <input type="number" name="api_interval_idle" min="1" step="1" value="{{ config.get('api_interval_idle', 30) }}">
             </label>
-            <label>
-                Tessie API-Token
-                <input type="password" name="tessie_api_token" value="{{ config.get('tessie_api_token','') }}" autocomplete="new-password" placeholder="Neuen API-Token eingeben">
-            </label>
         </section>
+        {% endif %}
 
         <section class="config-section">
             <h2>Anzeige</h2>
@@ -167,7 +165,9 @@
 
         <div class="config-actions">
             <button type="submit">Speichern</button>
+            {% if not fleet_only %}
             <button type="submit" name="refresh_vehicle_list" value="1">Fahrzeugliste aktualisieren</button>
+            {% endif %}
         </div>
     </form>
 </body>

--- a/templates/index.html
+++ b/templates/index.html
@@ -131,6 +131,11 @@
         </div>
         <div id="battery-indicator"></div>
             <div id="speedometer">
+                <div id="turn-indicator" class="turn-indicator" role="img" aria-label="Blinker aus">
+                    <span id="turn-left" class="turn-arrow" aria-hidden="true">◀</span>
+                    <span id="high-beam-indicator" class="high-beam-indicator" role="img" aria-label="Fernlicht aus" title="Fernlicht aus"></span>
+                    <span id="turn-right" class="turn-arrow" aria-hidden="true">▶</span>
+                </div>
                 <svg width="140" height="70" viewBox="0 -5 120 60">
                     <path d="M10,50 A50,50 0 0,1 110,50" stroke="#ccc" stroke-width="12" fill="none"/>
                     <g id="speedometer-ticks" stroke="#000" stroke-width="2">
@@ -199,6 +204,11 @@
                 <path id="trunk" class="part-closed" d="M30 165 H70 V175 L50 185 L30 175 Z">
                     <title>Kofferraum</title>
                 </path>
+                <g id="brake-lights" class="brake-lights" role="img" aria-label="Bremslicht aus">
+                    <title>Bremslicht aus</title>
+                    <rect class="brake-light brake-light-left" x="25" y="176" width="14" height="5" rx="2" ry="2" />
+                    <rect class="brake-light brake-light-right" x="61" y="176" width="14" height="5" rx="2" ry="2" />
+                </g>
                 <rect id="door-fl" class="part-closed" x="20" y="40" width="10" height="45">
                     <title>T&#252;r vorne links</title>
                 </rect>

--- a/templates/wartung.html
+++ b/templates/wartung.html
@@ -1,0 +1,95 @@
+<!doctype html>
+<html lang="de">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Tesla-Dashboard - Wartung</title>
+    <style>
+        :root {
+            color-scheme: dark;
+            --hintergrund: #101418;
+            --fläche: #182027;
+            --akzent: #3fb984;
+            --text: #eef4f0;
+            --sekundär: #a8b4ad;
+            --linie: #2b363f;
+        }
+
+        * {
+            box-sizing: border-box;
+        }
+
+        body {
+            min-height: 100vh;
+            margin: 0;
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            background: var(--hintergrund);
+            color: var(--text);
+            font-family: Arial, Helvetica, sans-serif;
+        }
+
+        main {
+            width: min(680px, calc(100% - 32px));
+            margin: auto;
+            padding: 32px;
+            border: 1px solid var(--linie);
+            border-radius: 8px;
+            background: var(--fläche);
+        }
+
+        h1 {
+            margin: 0 0 16px;
+            font-size: clamp(1.8rem, 4vw, 2.6rem);
+            line-height: 1.1;
+        }
+
+        p {
+            margin: 0 0 14px;
+            color: var(--sekundär);
+            font-size: 1.05rem;
+            line-height: 1.55;
+        }
+
+        .status {
+            display: inline-flex;
+            align-items: center;
+            gap: 10px;
+            margin-bottom: 20px;
+            color: var(--akzent);
+            font-weight: 700;
+        }
+
+        .punkt {
+            width: 10px;
+            height: 10px;
+            border-radius: 50%;
+            background: var(--akzent);
+            box-shadow: 0 0 18px rgba(63, 185, 132, 0.8);
+        }
+
+        footer {
+            padding: 20px;
+            color: var(--sekundär);
+            text-align: center;
+            font-size: 0.9rem;
+        }
+    </style>
+</head>
+<body>
+    <main>
+        <div class="status"><span class="punkt" aria-hidden="true"></span>Umstellung läuft</div>
+        <h1>Dashboard wird gerade auf Fleet Telemetry umgestellt</h1>
+        <p>
+            Die Fahrzeugdaten werden aktuell auf den neuen Tesla-Fleet-Telemetry-Stream
+            umgestellt. Währenddessen ist die öffentliche Ansicht vorübergehend gesperrt.
+        </p>
+        <p>
+            Die Seite wird wieder freigegeben, sobald Standort, Ladezustand, Klima und
+            Fahrzeugstatus vollständig im Dashboard angezeigt werden.
+        </p>
+    </main>
+    <footer>Tesla-Dashboard V{{ version }} - © 2025{% if year > 2025 %}-{{ year }}{% endif %} Erik Schauer, do1ffe@darc.de</footer>
+</body>
+</html>

--- a/tests/test_dashboard_feature_pack.py
+++ b/tests/test_dashboard_feature_pack.py
@@ -50,6 +50,15 @@ def test_api_daten_bleiben_trotz_privatmodus_real(monkeypatch):
     assert "privacy_radius_m" not in payload
 
 
+def test_stream_fehlerpfad_setzt_karte_nicht_auf_default():
+    js = pathlib.Path("static/js/main.js").read_text(encoding="utf-8")
+    start = js.index("eventSource.onerror = function()")
+    ende = js.index("function startStreamIfOnline()", start)
+    fehlerpfad = js[start:ende]
+
+    assert "map.setView(DEFAULT_POS" not in fehlerpfad
+
+
 def test_history_nutzt_trotz_privatmodus_reale_punkte(monkeypatch):
     trip_path = str(pathlib.Path(app_module.DATA_DIR) / "fahrzeug" / "trips" / "trip_20260521.csv")
     monkeypatch.setattr(

--- a/tests/test_state_gating.py
+++ b/tests/test_state_gating.py
@@ -254,6 +254,40 @@ def test_get_vehicle_state_asleep_prueft_state_erst_nach_10_sekunden(monkeypatch
     assert aufrufe_fahrzeugliste == [False]
 
 
+def test_get_vehicle_state_fahrzeuglistenfehler_nutzt_cache_state(monkeypatch):
+    monkeypatch.setattr(app, "last_vehicle_state", {"veh-list-error": "online"})
+    monkeypatch.setattr(app, "_last_state_refresh_ts", {})
+    monkeypatch.setattr(
+        app,
+        "load_config",
+        lambda vehicle_id=None: {"api_interval": 1, "api_interval_idle": 30},
+    )
+    monkeypatch.setattr(
+        app,
+        "_load_cached",
+        lambda vehicle_id: {
+            "state": "online",
+            "vehicle_state": {
+                "locked": True,
+                "is_user_present": False,
+                "service_mode": False,
+                "service_mode_plus": False,
+            },
+        },
+    )
+    monkeypatch.setattr(app.time, "time", lambda: 123.0)
+    monkeypatch.setattr(app, "get_tesla", lambda: object())
+    monkeypatch.setattr(app, "_cached_vehicle_list", lambda *args, **kwargs: [])
+
+    daten = app.get_vehicle_state("veh-list-error")
+
+    assert daten["state"] == "online"
+    assert daten["error"] == "No vehicles found"
+    assert daten["state_checked_at"] == 123000
+    assert daten["service_mode"] is False
+    assert daten["service_mode_plus"] is False
+
+
 def test_fetch_data_once_online_ruft_live_abruf_auf_und_nutzt_fallback(monkeypatch):
     aufrufe_get_vehicle_data = []
 
@@ -283,6 +317,34 @@ def test_fetch_data_once_online_ruft_live_abruf_auf_und_nutzt_fallback(monkeypat
     assert aufrufe_get_vehicle_data == [("veh-online", "online")]
     assert daten["state"] == "online"
     assert daten["source"] == "cache"
+    assert daten["_live"] is False
+
+
+def test_fetch_data_once_statusfehler_erhaelt_cache_state(monkeypatch):
+    _setze_neutrale_ladehilfen(monkeypatch)
+    monkeypatch.setattr(app, "occupant_present", False)
+    monkeypatch.setattr(app, "latest_data", {})
+    monkeypatch.setattr(app, "last_vehicle_state", {"veh-forbidden": "online"})
+    monkeypatch.setattr(
+        app,
+        "get_vehicle_state",
+        lambda vid: {"state": None, "error": "403 forbidden"},
+    )
+    monkeypatch.setattr(
+        app,
+        "_load_cached",
+        lambda vehicle_id: {
+            "state": "online",
+            "charge_state": {"charging_state": "Disconnected"},
+            "drive_state": {"shift_state": None, "speed": 0, "power": 0},
+            "vehicle_state": {"locked": True, "is_user_present": False},
+        },
+    )
+
+    daten = app._fetch_data_once("veh-forbidden")
+
+    assert daten["state"] == "online"
+    assert daten["api_error"] == "403 forbidden"
     assert daten["_live"] is False
 
 
@@ -584,6 +646,36 @@ def test_fetch_loop_locked_ohne_insassen_nutzt_idle_intervall(monkeypatch):
     assert idle_aufrufe == [30]
 
 
+def test_fetch_loop_protokolliert_abruffehler_und_laeuft_weiter(monkeypatch):
+    fehler = []
+
+    monkeypatch.setattr(
+        app,
+        "load_config",
+        lambda: {"api_interval": 5, "api_interval_idle": 30},
+    )
+
+    def _fake_fetch_data_once(vehicle_id):
+        raise RuntimeError("api kaputt")
+
+    monkeypatch.setattr(app, "_fetch_data_once", _fake_fetch_data_once)
+    monkeypatch.setattr(app, "_log_api_error", lambda exc: fehler.append(str(exc)))
+    monkeypatch.setattr(app.logging, "exception", lambda *args, **kwargs: None)
+    monkeypatch.setattr(app.time, "time", lambda: 100.0)
+    monkeypatch.setattr(app.time, "sleep", lambda sekunden: None)
+    monkeypatch.setattr(app, "occupant_present", False)
+
+    def _fake_sleep_idle(sekunden):
+        raise RuntimeError("stop-loop")
+
+    monkeypatch.setattr(app, "_sleep_idle", _fake_sleep_idle)
+
+    with pytest.raises(RuntimeError, match="stop-loop"):
+        app._fetch_loop("veh")
+
+    assert fehler == ["api kaputt"]
+
+
 def test_fetch_loop_offline_nutzt_state_intervall_trotz_aktivitaetsdaten(monkeypatch):
     schlaf_aufrufe = []
 
@@ -662,6 +754,37 @@ def test_fetch_loop_unlocked_nutzt_normales_intervall(monkeypatch):
         app._fetch_loop("veh")
 
     assert schlaf_aufrufe == [5]
+
+
+def test_start_thread_ersetzt_beendeten_thread(monkeypatch):
+    gestartete_threads = []
+
+    class BeendeterThread:
+        def is_alive(self):
+            return False
+
+    class NeuerThread:
+        def __init__(self, target, args, daemon):
+            self.target = target
+            self.args = args
+            self.daemon = daemon
+            self.gestartet = False
+            gestartete_threads.append(self)
+
+        def is_alive(self):
+            return self.gestartet
+
+        def start(self):
+            self.gestartet = True
+
+    monkeypatch.setattr(app, "threads", {"veh": BeendeterThread()})
+    monkeypatch.setattr(app.threading, "Thread", NeuerThread)
+
+    app._start_thread("veh")
+
+    assert len(gestartete_threads) == 1
+    assert app.threads["veh"] is gestartete_threads[0]
+    assert gestartete_threads[0].gestartet is True
 
 
 def test_fetch_loop_schiebedach_offen_nutzt_normales_intervall(monkeypatch):

--- a/tests/test_tesla_fleet_public_key.py
+++ b/tests/test_tesla_fleet_public_key.py
@@ -1,0 +1,39 @@
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+import app
+
+
+def test_tesla_fleet_public_key_wird_ausgeliefert(monkeypatch, tmp_path):
+    public_key = tmp_path / "com.tesla.3p.public-key.pem"
+    public_key.write_text(
+        "-----BEGIN PUBLIC KEY-----\n"
+        "TEST\n"
+        "-----END PUBLIC KEY-----\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(app, "TESLA_FLEET_PUBLIC_KEY_PATH", str(public_key))
+
+    response = app.app.test_client().get(
+        "/.well-known/appspecific/com.tesla.3p.public-key.pem"
+    )
+
+    assert response.status_code == 200
+    assert response.mimetype == "application/x-pem-file"
+    assert response.data == public_key.read_bytes()
+
+
+def test_tesla_fleet_public_key_fehlt(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        app,
+        "TESLA_FLEET_PUBLIC_KEY_PATH",
+        str(tmp_path / "fehlt.pem"),
+    )
+
+    response = app.app.test_client().get(
+        "/.well-known/appspecific/com.tesla.3p.public-key.pem"
+    )
+
+    assert response.status_code == 404

--- a/tests/test_tesla_fleet_telemetry.py
+++ b/tests/test_tesla_fleet_telemetry.py
@@ -1,0 +1,504 @@
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+import app
+
+
+def test_fleet_telemetrie_mqtt_aktualisiert_dashboard_cache(monkeypatch):
+    gespeicherte_daten = {}
+
+    monkeypatch.setattr(app, "_fleet_telemetrie_fahrzeuge", lambda: [{
+        "vin": "TESTVIN",
+        "id_s": "veh-1",
+        "display_name": "Testauto",
+    }])
+    monkeypatch.setattr(app, "_load_cached", lambda vehicle_id: {})
+    monkeypatch.setattr(app, "reverse_geocode", lambda lat, lon, vehicle_id=None: {})
+    monkeypatch.setattr(
+        app,
+        "_save_cached",
+        lambda vehicle_id, data: gespeicherte_daten.setdefault(vehicle_id, data),
+    )
+    monkeypatch.setattr(app, "latest_data", {})
+
+    assert app._fleet_telemetrie_mqtt_message(
+        "tesla/TESTVIN/v/Location",
+        b'{"latitude": 51.0, "longitude": 7.0}',
+        {"topic_base": "tesla"},
+    )
+    assert app._fleet_telemetrie_mqtt_message(
+        "tesla/TESTVIN/v/BatteryLevel",
+        b"88",
+        {"topic_base": "tesla"},
+    )
+    assert app._fleet_telemetrie_mqtt_message(
+        "tesla/TESTVIN/v/DetailedChargeState",
+        b'"DetailedChargeStateCharging"',
+        {"topic_base": "tesla"},
+    )
+
+    daten = app.latest_data["veh-1"]
+    assert daten["display_name"] == "Testauto"
+    assert daten["drive_state"]["latitude"] == 51.0
+    assert daten["drive_state"]["longitude"] == 7.0
+    assert daten["charge_state"]["battery_level"] == 88
+    assert daten["charge_state"]["usable_battery_level"] == 88
+    assert daten["charge_state"]["charging_state"] == "Charging"
+    assert daten["_live"] is True
+    assert gespeicherte_daten["veh-1"]["fleet_telemetry_updated_at"]
+
+
+def test_fleet_telemetrie_mqtt_ignoriert_unveraenderte_rohwerte(monkeypatch):
+    gespeicherte_daten = []
+
+    class Sammler:
+        def __init__(self):
+            self.daten = []
+
+        def put(self, daten):
+            self.daten.append(daten)
+
+    sammler = Sammler()
+    monkeypatch.setattr(app, "_fleet_telemetrie_cache_ids", lambda vin: ["veh-1"])
+    monkeypatch.setattr(app, "_load_cached", lambda vehicle_id: {})
+    monkeypatch.setattr(
+        app,
+        "_save_cached",
+        lambda vehicle_id, data: gespeicherte_daten.append((vehicle_id, data)),
+    )
+    monkeypatch.setattr(app, "latest_data", {})
+    monkeypatch.setattr(app, "subscribers", {"veh-1": [sammler]})
+
+    assert app._fleet_telemetrie_mqtt_message(
+        "tesla/TESTVIN/v/LightsHighBeams",
+        b"false",
+        {"topic_base": "tesla"},
+    )
+    erster_zeitstempel = app.latest_data["veh-1"]["fleet_telemetry_updated_at"]
+
+    assert not app._fleet_telemetrie_mqtt_message(
+        "tesla/TESTVIN/v/LightsHighBeams",
+        b"false",
+        {"topic_base": "tesla"},
+    )
+    assert app.latest_data["veh-1"]["fleet_telemetry_updated_at"] == erster_zeitstempel
+    assert len(gespeicherte_daten) == 1
+    assert len(sammler.daten) == 1
+
+    assert app._fleet_telemetrie_mqtt_message(
+        "tesla/TESTVIN/v/LightsHighBeams",
+        b"true",
+        {"topic_base": "tesla"},
+    )
+    assert app.latest_data["veh-1"]["vehicle_state"]["lights_high_beams"] is True
+    assert len(gespeicherte_daten) == 2
+    assert len(sammler.daten) == 2
+
+
+def test_fleet_telemetrie_connectivity_unterscheidet_connected_und_disconnected(monkeypatch):
+    gespeicherte_daten = []
+
+    class Sammler:
+        def __init__(self):
+            self.daten = []
+
+        def put(self, daten):
+            self.daten.append(daten)
+
+    sammler = Sammler()
+    monkeypatch.setattr(app, "_fleet_telemetrie_cache_ids", lambda vin: ["veh-1"])
+    monkeypatch.setattr(app, "_load_cached", lambda vehicle_id: {})
+    monkeypatch.setattr(
+        app,
+        "_save_cached",
+        lambda vehicle_id, data: gespeicherte_daten.append((vehicle_id, data)),
+    )
+    monkeypatch.setattr(app, "latest_data", {})
+    monkeypatch.setattr(app, "subscribers", {"veh-1": [sammler]})
+
+    assert app._fleet_telemetrie_mqtt_message(
+        "tesla/TESTVIN/connectivity",
+        b'{"Status": "CONNECTED"}',
+        {"topic_base": "tesla"},
+    )
+    assert app.latest_data["veh-1"]["state"] == "online"
+
+    assert app._fleet_telemetrie_mqtt_message(
+        "tesla/TESTVIN/connectivity",
+        b'{"Status": "DISCONNECTED"}',
+        {"topic_base": "tesla"},
+    )
+    assert app.latest_data["veh-1"]["state"] == "disconnected"
+    assert gespeicherte_daten[-1][1]["state"] == "disconnected"
+    assert sammler.daten[-1]["state"] == "disconnected"
+
+
+def test_fleet_telemetrie_mqtt_normalisiert_oeffnungen(monkeypatch):
+    monkeypatch.setattr(app, "_fleet_telemetrie_fahrzeuge", lambda: [{
+        "vin": "TESTVIN",
+        "id_s": "veh-1",
+    }])
+    monkeypatch.setattr(app, "_load_cached", lambda vehicle_id: {})
+    monkeypatch.setattr(app, "_save_cached", lambda vehicle_id, data: None)
+    monkeypatch.setattr(app, "latest_data", {})
+
+    app._fleet_telemetrie_mqtt_message(
+        "tesla/TESTVIN/v/DoorState",
+        (
+            b'{"DriverFront": true, "PassengerFront": false, '
+            b'"DriverRear": false, "PassengerRear": false, '
+            b'"TrunkFront": false, "TrunkRear": true}'
+        ),
+        {"topic_base": "tesla"},
+    )
+    app._fleet_telemetrie_mqtt_message(
+        "tesla/TESTVIN/v/FdWindow",
+        b'"WindowStateClosed"',
+        {"topic_base": "tesla"},
+    )
+    app._fleet_telemetrie_mqtt_message(
+        "tesla/TESTVIN/v/RpWindow",
+        b'"WindowStatePartiallyOpen"',
+        {"topic_base": "tesla"},
+    )
+
+    vehicle_state = app.latest_data["veh-1"]["vehicle_state"]
+    assert vehicle_state["df"] == 1
+    assert vehicle_state["pf"] == 0
+    assert vehicle_state["rt"] == 1
+    assert vehicle_state["fd_window"] == 0
+    assert vehicle_state["rp_window"] == 1
+
+
+def test_fleet_telemetrie_mqtt_mappt_dashboard_zusatzfelder(monkeypatch):
+    monkeypatch.setattr(app, "_fleet_telemetrie_fahrzeuge", lambda: [{
+        "vin": "TESTVIN",
+        "id_s": "veh-1",
+    }])
+    monkeypatch.setattr(app, "_load_cached", lambda vehicle_id: {})
+    monkeypatch.setattr(app, "_save_cached", lambda vehicle_id, data: None)
+    monkeypatch.setattr(app, "latest_data", {})
+    monkeypatch.setattr(app, "reverse_geocode", lambda lat, lon, vehicle_id=None: {})
+
+    nachrichten = {
+        "DestinationName": b'"Ziel"',
+        "DestinationLocation": b'{"latitude": 51.1, "longitude": 7.1}',
+        "ExpectedEnergyPercentAtTripArrival": b"42",
+        "MilesToArrival": b"12.5",
+        "MinutesToArrival": b"18",
+        "RouteTrafficMinutesDelay": b"3",
+        "GpsState": b'"GpsStateActive"',
+        "DCChargingEnergyIn": b"7.5",
+        "DCChargingPower": b"11",
+        "ChargeState": b'"Standby"',
+        "PackVoltage": b"400",
+        "PackCurrent": b"-12.5",
+        "ChargeRateMilePerHour": b"24",
+        "ChargingCableType": b'"ChargingCableTypeIEC"',
+        "TimeToFullCharge": b"1.5",
+        "ClimateKeeperMode": b'"ClimateKeeperModeStateParty"',
+        "CabinOverheatProtectionMode": b'"CabinOverheatProtectionModeStateOn"',
+        "CabinOverheatProtectionTemperatureLimit": b'"ClimateOverheatProtectionTempLimitHigh"',
+        "DefrostMode": b'"DefrostModeStateOn"',
+        "RearDefrostEnabled": b"true",
+        "WiperHeatEnabled": b"true",
+        "HvacSteeringWheelHeatLevel": b"2",
+        "SeatHeaterLeft": b"3",
+        "DriverSeatOccupied": b"true",
+        "BrakePedal": b"true",
+        "BrakePedalPos": b"3.4",
+        "LightsHazardsActive": b"false",
+        "LightsTurnSignal": b'"TurnSignalStateLeft"',
+        "LightsHighBeams": b"true",
+        "SoftwareUpdateVersion": b'"2026.20.1"',
+        "SoftwareUpdateExpectedDurationMinutes": b"45",
+        "TpmsPressureFl": b"2.9",
+        "TpmsSoftWarnings": b'"TireLocationFrontLeft"',
+        "MediaNowPlayingTitle": b'"Song"',
+        "MediaPlaybackStatus": b'"MediaStatusPlaying"',
+    }
+    for feld, payload in nachrichten.items():
+        assert app._fleet_telemetrie_mqtt_message(
+            f"tesla/TESTVIN/v/{feld}",
+            payload,
+            {"topic_base": "tesla"},
+        )
+
+    daten = app.latest_data["veh-1"]
+    assert daten["drive_state"]["active_route_destination"] == "Ziel"
+    assert daten["drive_state"]["active_route_latitude"] == 51.1
+    assert daten["drive_state"]["active_route_energy_at_arrival"] == 42
+    assert daten["drive_state"]["active_route_miles_to_arrival"] == 12.5
+    assert daten["drive_state"]["gps_state"] == "GpsStateActive"
+    assert daten["charge_state"]["charge_energy_added"] == 7.5
+    assert daten["charge_state"]["charger_power"] == 11
+    assert daten["charge_state"]["charging_state"] == "Disconnected"
+    assert daten["charge_state"]["pack_voltage"] == 400
+    assert daten["charge_state"]["pack_current"] == -12.5
+    assert daten["charge_state"]["pack_power"] == -5.0
+    assert daten["drive_state"]["power"] == 5.0
+    assert daten["charge_state"]["charge_rate"] == 24
+    assert daten["charge_state"]["conn_charge_cable"] == "IEC"
+    assert daten["charge_state"]["minutes_to_full_charge"] == 90
+    assert daten["climate_state"]["climate_keeper_mode"] == "camp"
+    assert daten["climate_state"]["cabin_overheat_protection"] == "On"
+    assert daten["climate_state"]["cop_activation_temperature"] == "High"
+    assert daten["climate_state"]["is_front_defroster_on"] is True
+    assert daten["climate_state"]["is_rear_defroster_on"] is True
+    assert daten["climate_state"]["wiper_blade_heater"] is True
+    assert daten["climate_state"]["steering_wheel_heater"] is True
+    assert daten["climate_state"]["seat_heater_left"] == 3
+    assert daten["vehicle_state"]["is_user_present"] is True
+    assert daten["vehicle_state"]["brake_pedal"] is True
+    assert daten["vehicle_state"]["brake_pedal_pos"] == 3.4
+    assert daten["vehicle_state"]["lights_hazards_active"] is False
+    assert daten["vehicle_state"]["lights_turn_signal"] == "Left"
+    assert daten["vehicle_state"]["lights_high_beams"] is True
+    assert daten["vehicle_state"]["software_update"]["version"] == "2026.20.1"
+    assert daten["vehicle_state"]["software_update"]["expected_duration_sec"] == 2700
+    assert daten["vehicle_state"]["tpms_pressure_fl"] == 2.9
+    assert daten["vehicle_state"]["tpms_soft_warning_fl"] is True
+    assert daten["vehicle_state"]["media_info"]["now_playing_title"] == "Song"
+    assert daten["vehicle_state"]["media_info"]["media_playback_status"] == "Playing"
+
+
+def test_fetch_data_once_nutzt_telemetrie_cache_ohne_owner_api(monkeypatch):
+    aufrufe = []
+    cache = {
+        "state": "online",
+        "fleet_telemetry_updated_at": int(app.time.time() * 1000),
+        "charge_state": {"battery_level": 90},
+        "drive_state": {},
+        "vehicle_state": {},
+        "climate_state": {},
+    }
+
+    monkeypatch.setattr(app, "_fleet_telemetrie_aktiv", lambda: True)
+    monkeypatch.setattr(app, "_load_cached", lambda vehicle_id: dict(cache))
+    monkeypatch.setattr(app, "latest_data", {})
+    monkeypatch.setattr(
+        app,
+        "get_vehicle_state",
+        lambda vehicle_id=None: aufrufe.append("state"),
+    )
+    monkeypatch.setattr(
+        app,
+        "get_vehicle_data",
+        lambda vehicle_id=None, state=None: aufrufe.append("data"),
+    )
+
+    daten = app._fetch_data_once("default")
+
+    assert daten["charge_state"]["battery_level"] == 90
+    assert daten["_live"] is True
+    assert aufrufe == []
+
+
+def test_fetch_data_once_telemetrie_only_ohne_cache_ruft_keine_owner_api(monkeypatch):
+    aufrufe = []
+
+    monkeypatch.setattr(app, "_nur_fleet_telemetrie_datenquelle", lambda: True)
+    monkeypatch.setattr(app, "_fleet_telemetrie_aktiv", lambda: False)
+    monkeypatch.setattr(app, "_load_cached", lambda vehicle_id: None)
+    monkeypatch.setattr(app, "latest_data", {})
+    monkeypatch.setattr(app, "subscribers", {})
+    monkeypatch.setattr(
+        app,
+        "get_vehicle_state",
+        lambda vehicle_id=None: aufrufe.append("state"),
+    )
+    monkeypatch.setattr(
+        app,
+        "get_vehicle_data",
+        lambda vehicle_id=None, state=None: aufrufe.append("data"),
+    )
+
+    daten = app._fetch_data_once("veh-1")
+
+    assert daten["_live"] is False
+    assert daten["api_error"] == "Noch keine Fleet-Telemetry-Daten empfangen"
+    assert aufrufe == []
+
+
+def test_get_vehicle_data_telemetrie_only_nutzt_nur_telemetrie_cache(monkeypatch):
+    aufrufe = []
+    telemetry_cache = {
+        "state": "online",
+        "fleet_telemetry_updated_at": int(app.time.time() * 1000),
+        "_live": True,
+    }
+
+    monkeypatch.setattr(app, "_nur_fleet_telemetrie_datenquelle", lambda: True)
+    monkeypatch.setattr(
+        app,
+        "_fleet_telemetrie_cache_fuer_dashboard",
+        lambda cache_id: dict(telemetry_cache),
+    )
+    monkeypatch.setattr(app, "get_tesla", lambda: aufrufe.append("tesla"))
+
+    daten = app.get_vehicle_data("veh-1", state="online")
+
+    assert daten["_live"] is True
+    assert aufrufe == []
+
+
+def test_get_vehicle_list_telemetrie_only_ohne_fallback(monkeypatch):
+    aufrufe = []
+
+    monkeypatch.setattr(app, "_nur_fleet_telemetrie_datenquelle", lambda: True)
+    monkeypatch.setattr(app, "_fleet_telemetrie_fahrzeuge", lambda: [])
+    monkeypatch.setattr(app, "_load_cached", lambda vehicle_id: None)
+    monkeypatch.setattr(app, "latest_data", {})
+    monkeypatch.setattr(app, "get_tesla", lambda: aufrufe.append("tesla"))
+
+    assert app.get_vehicle_list() == []
+    assert aufrufe == []
+
+
+def test_telemetrie_cache_entfernt_owner_api_supercharger(monkeypatch):
+    cache = {
+        "state": "online",
+        "fleet_telemetry_updated_at": int(app.time.time() * 1000),
+        "nearby_superchargers": [{"name": "Alt"}],
+        "access_type": "OWNER",
+    }
+
+    monkeypatch.setattr(app, "_fleet_telemetrie_aktiv", lambda: True)
+
+    daten = app._fleet_telemetrie_cache_fuer_dashboard("veh-1", cache)
+
+    assert "nearby_superchargers" not in daten
+    assert "access_type" not in daten
+
+
+def test_api_config_deaktiviert_owner_api_supercharger_im_telemetrie_only(monkeypatch):
+    monkeypatch.setattr(app, "_nur_fleet_telemetrie_datenquelle", lambda: True)
+    monkeypatch.setattr(
+        app,
+        "load_config",
+        lambda vehicle_id=None: {
+            "supercharger-list": True,
+            "tessie_api_token": "alt",
+        },
+    )
+
+    response = app.app.test_client().get("/api/config")
+    daten = response.get_json()
+
+    assert response.status_code == 200
+    assert daten["supercharger-list"] is False
+    assert "tessie_api_token" not in daten
+
+
+def test_news_events_telemetrie_only_ohne_tesla_api(monkeypatch):
+    aufrufe = []
+
+    monkeypatch.setattr(app, "_nur_fleet_telemetrie_datenquelle", lambda: True)
+    monkeypatch.setattr(app, "get_tesla", lambda: aufrufe.append("tesla"))
+
+    assert app.get_news_events_info() == ""
+    assert aufrufe == []
+
+
+def test_fetch_data_once_sendet_telemetrie_cache_nicht_an_stream(monkeypatch):
+    class Sammler:
+        def __init__(self):
+            self.daten = []
+
+        def put(self, daten):
+            self.daten.append(daten)
+
+    sammler = Sammler()
+    cache = {
+        "state": "online",
+        "fleet_telemetry_updated_at": int(app.time.time() * 1000),
+        "charge_state": {"battery_level": 90},
+        "drive_state": {},
+        "vehicle_state": {},
+        "climate_state": {},
+    }
+
+    monkeypatch.setattr(app, "_fleet_telemetrie_aktiv", lambda: True)
+    monkeypatch.setattr(app, "_load_cached", lambda vehicle_id: dict(cache))
+    monkeypatch.setattr(app, "latest_data", {})
+    monkeypatch.setattr(app, "subscribers", {"default": [sammler]})
+
+    daten = app._fetch_data_once("default")
+
+    assert daten["charge_state"]["battery_level"] == 90
+    assert sammler.daten == []
+
+
+def test_start_thread_startet_bei_fleet_telemetrie_keinen_polling_thread(monkeypatch):
+    monkeypatch.setattr(app, "_fleet_telemetrie_aktiv", lambda: True)
+    monkeypatch.setattr(app, "threads", {})
+
+    app._start_thread("veh-1")
+
+    assert app.threads == {}
+
+
+def test_fahrzeugliste_nutzt_fleet_telemetrie_ohne_owner_api(monkeypatch):
+    monkeypatch.setattr(app, "_fleet_telemetrie_aktiv", lambda: True)
+    monkeypatch.setattr(app, "_default_vehicle_id", None)
+    monkeypatch.setattr(app, "get_tesla", lambda: None)
+    monkeypatch.setattr(app, "_load_cached", lambda vehicle_id: None)
+    monkeypatch.setattr(app, "latest_data", {})
+    monkeypatch.setattr(app, "_fleet_telemetrie_fahrzeuge", lambda: [{
+        "vin": "TESTVIN",
+        "id_s": "veh-1",
+        "vehicle_id": "legacy-veh-1",
+        "display_name": "Testauto",
+    }])
+
+    fahrzeuge = app.get_vehicle_list()
+
+    assert fahrzeuge == [{"id": "veh-1", "display_name": "Testauto"}]
+    assert app._default_vehicle_id == "veh-1"
+
+
+def test_fahrzeugliste_nutzt_telemetrie_cache_als_fallback(monkeypatch):
+    monkeypatch.setattr(app, "_fleet_telemetrie_aktiv", lambda: True)
+    monkeypatch.setattr(app, "_default_vehicle_id", None)
+    monkeypatch.setattr(app, "_fleet_telemetrie_fahrzeuge", lambda: [])
+    monkeypatch.setattr(
+        app,
+        "_load_cached",
+        lambda vehicle_id: {
+            "id_s": "veh-cache",
+            "display_name": "Cacheauto",
+        } if vehicle_id == "default" else None,
+    )
+    monkeypatch.setattr(app, "latest_data", {})
+
+    fahrzeuge = app.get_vehicle_list()
+
+    assert fahrzeuge == [{"id": "veh-cache", "display_name": "Cacheauto"}]
+
+
+def test_fahrzeugliste_dedupliziert_fleet_alias_ids(monkeypatch):
+    monkeypatch.setattr(app, "_fleet_telemetrie_aktiv", lambda: True)
+    monkeypatch.setattr(app, "_default_vehicle_id", None)
+    monkeypatch.setattr(app, "_load_cached", lambda vehicle_id: None)
+    monkeypatch.setattr(app, "_fleet_telemetrie_fahrzeuge", lambda: [{
+        "vin": "TESTVIN",
+        "id_s": "fleet-id",
+        "vehicle_id": "legacy-id",
+        "display_name": "Testauto",
+    }])
+    monkeypatch.setattr(
+        app,
+        "latest_data",
+        {
+            "legacy-id": {
+                "id_s": "legacy-id",
+                "display_name": "Testauto",
+            }
+        },
+    )
+
+    fahrzeuge = app.get_vehicle_list()
+
+    assert fahrzeuge == [{"id": "fleet-id", "display_name": "Testauto"}]

--- a/tests/test_wartungsmodus.py
+++ b/tests/test_wartungsmodus.py
@@ -1,0 +1,35 @@
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+import app
+
+
+def test_wartungsmodus_zeigt_wartungsseite(monkeypatch, tmp_path):
+    wartungsdatei = tmp_path / "wartung"
+    wartungsdatei.write_text("aktiv\n", encoding="utf-8")
+    monkeypatch.setenv("TESLA_DASHBOARD_WARTUNG", "1")
+    monkeypatch.setattr(app, "WARTUNGSMODUS_DATEI", str(wartungsdatei))
+
+    response = app.app.test_client().get("/")
+
+    assert response.status_code == 503
+    assert b"Dashboard wird gerade auf Fleet Telemetry umgestellt" in response.data
+    assert response.headers["X-Robots-Tag"] == "noindex, nofollow"
+    assert response.headers["Retry-After"] == "300"
+
+
+def test_wartungsmodus_laesst_api_und_public_key_durch(monkeypatch, tmp_path):
+    wartungsdatei = tmp_path / "wartung"
+    wartungsdatei.write_text("aktiv\n", encoding="utf-8")
+    public_key = tmp_path / "com.tesla.3p.public-key.pem"
+    public_key.write_text("PUBLIC KEY\n", encoding="utf-8")
+    monkeypatch.setenv("TESLA_DASHBOARD_WARTUNG", "1")
+    monkeypatch.setattr(app, "WARTUNGSMODUS_DATEI", str(wartungsdatei))
+    monkeypatch.setattr(app, "TESLA_FLEET_PUBLIC_KEY_PATH", str(public_key))
+
+    client = app.app.test_client()
+
+    assert client.get("/api/version").status_code == 200
+    assert client.get("/.well-known/appspecific/com.tesla.3p.public-key.pem").status_code == 200


### PR DESCRIPTION
## Summary
- migrate vehicle data flow to Tesla Fleet Telemetry only
- add Fleet Telemetry public key, maintenance page, telemetry mapping, connectivity handling, and UI indicators
- remove Tessie/Owner API fallbacks from the productive dashboard path
- add regression tests for telemetry-only behavior, map fallback handling, and connectivity states

## Validation
- python3 -m py_compile app.py
- node --check static/js/main.js
- pytest -q

## Notes
- Fleet Telemetry does not expose a reliable asleep state; disconnected is now represented separately from online.